### PR TITLE
feat(budget): production hardening + native budget feature parity

### DIFF
--- a/backend/app/api/routes/budget/accounts.py
+++ b/backend/app/api/routes/budget/accounts.py
@@ -41,9 +41,10 @@ async def list_accounts(
             db, family_id, account_type, include_closed=include_closed, limit=limit, offset=offset
         )
     else:
-        accounts = await AccountService.list_by_family(db, family_id, limit=limit, offset=offset)
-        if not include_closed:
-            accounts = [a for a in accounts if not a.closed]
+        accounts = await AccountService.list_for_family(
+            db, family_id,
+            include_closed=include_closed, limit=limit, offset=offset,
+        )
 
     return accounts
 

--- a/backend/app/api/routes/budget/accounts.py
+++ b/backend/app/api/routes/budget/accounts.py
@@ -26,23 +26,25 @@ async def list_accounts(
     account_type: str = Query(None, description="Filter by account type"),
     include_closed: bool = Query(False, description="Include closed accounts"),
     budget_only: bool = Query(False, description="Only on-budget accounts"),
+    limit: int = Query(200, ge=1, le=500, description="Max results"),
+    offset: int = Query(0, ge=0, description="Pagination offset"),
 ):
     """List all accounts"""
     family_id = to_uuid_required(current_user.family_id)
-    
+
     if budget_only:
         accounts = await AccountService.list_budget_accounts(
-            db, family_id, include_closed=include_closed
+            db, family_id, include_closed=include_closed, limit=limit, offset=offset
         )
     elif account_type:
         accounts = await AccountService.list_by_type(
-            db, family_id, account_type, include_closed=include_closed
+            db, family_id, account_type, include_closed=include_closed, limit=limit, offset=offset
         )
     else:
-        accounts = await AccountService.list_by_family(db, family_id)
+        accounts = await AccountService.list_by_family(db, family_id, limit=limit, offset=offset)
         if not include_closed:
             accounts = [a for a in accounts if not a.closed]
-    
+
     return accounts
 
 

--- a/backend/app/api/routes/budget/categories.py
+++ b/backend/app/api/routes/budget/categories.py
@@ -117,6 +117,8 @@ async def list_categories(
     db: AsyncSession = Depends(get_db),
     group_id: UUID = Query(None, description="Filter by group ID"),
     include_hidden: bool = Query(False, description="Include hidden categories"),
+    limit: int = Query(500, ge=1, le=1000, description="Max results"),
+    offset: int = Query(0, ge=0, description="Pagination offset"),
 ):
     """List all categories, optionally filtered by group"""
     if group_id:
@@ -125,15 +127,19 @@ async def list_categories(
             group_id,
             to_uuid_required(current_user.family_id),
             include_hidden=include_hidden,
+            limit=limit,
+            offset=offset,
         )
     else:
         categories = await CategoryService.list_by_family(
             db,
             to_uuid_required(current_user.family_id),
+            limit=limit,
+            offset=offset,
         )
         if not include_hidden:
             categories = [c for c in categories if not c.hidden]
-    
+
     return categories
 
 

--- a/backend/app/api/routes/budget/categories.py
+++ b/backend/app/api/routes/budget/categories.py
@@ -131,14 +131,13 @@ async def list_categories(
             offset=offset,
         )
     else:
-        categories = await CategoryService.list_by_family(
+        categories = await CategoryService.list_for_family(
             db,
             to_uuid_required(current_user.family_id),
+            include_hidden=include_hidden,
             limit=limit,
             offset=offset,
         )
-        if not include_hidden:
-            categories = [c for c in categories if not c.hidden]
 
     return categories
 

--- a/backend/app/api/routes/budget/goals.py
+++ b/backend/app/api/routes/budget/goals.py
@@ -40,13 +40,11 @@ async def list_goals(
 
     if category_id:
         goals = await GoalService.list_by_category(
-            db, category_id, family_id, active_only=active_only
+            db, category_id, family_id,
+            active_only=active_only, limit=limit, offset=offset,
         )
-        # In-memory slice for sub-list; small set per category
-        goals = goals[offset:offset + limit]
     elif active_only:
-        goals = await GoalService.list_active(db, family_id)
-        goals = goals[offset:offset + limit]
+        goals = await GoalService.list_active(db, family_id, limit=limit, offset=offset)
     else:
         goals = await GoalService.list_by_family(db, family_id, limit=limit, offset=offset)
 

--- a/backend/app/api/routes/budget/goals.py
+++ b/backend/app/api/routes/budget/goals.py
@@ -32,19 +32,24 @@ async def list_goals(
     db: AsyncSession = Depends(get_db),
     category_id: Optional[UUID] = Query(None, description="Filter by category ID"),
     active_only: bool = Query(True, description="Only return active goals"),
+    limit: int = Query(200, ge=1, le=500, description="Max results"),
+    offset: int = Query(0, ge=0, description="Pagination offset"),
 ):
     """List budget goals for the family"""
     family_id = to_uuid_required(current_user.family_id)
-    
+
     if category_id:
         goals = await GoalService.list_by_category(
             db, category_id, family_id, active_only=active_only
         )
+        # In-memory slice for sub-list; small set per category
+        goals = goals[offset:offset + limit]
+    elif active_only:
+        goals = await GoalService.list_active(db, family_id)
+        goals = goals[offset:offset + limit]
     else:
-        goals = await GoalService.list_active(
-            db, family_id
-        ) if active_only else await GoalService.list_by_family(db, family_id)
-    
+        goals = await GoalService.list_by_family(db, family_id, limit=limit, offset=offset)
+
     return goals
 
 

--- a/backend/app/api/routes/budget/month.py
+++ b/backend/app/api/routes/budget/month.py
@@ -101,12 +101,14 @@ async def get_month_budget(
                 BudgetTransaction.amount > 0,
                 BudgetTransaction.date >= month_date,
                 BudgetTransaction.date <= end_of_month,
+                BudgetTransaction.deleted_at.is_(None),
                 BudgetTransaction.account_id.in_(
                     select(BudgetAccount.id).where(
                         and_(
                             BudgetAccount.family_id == family_id,
                             BudgetAccount.offbudget == False,
                             BudgetAccount.closed == False,
+                            BudgetAccount.deleted_at.is_(None),
                         )
                     )
                 ),

--- a/backend/app/api/routes/budget/payees.py
+++ b/backend/app/api/routes/budget/payees.py
@@ -22,6 +22,8 @@ router = APIRouter()
 @router.get("/", response_model=List[PayeeResponse])
 async def list_payees(
     favorites_only: bool = Query(False, description="Only return favorite payees"),
+    limit: int = Query(500, ge=1, le=2000, description="Max results"),
+    offset: int = Query(0, ge=0, description="Pagination offset"),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
@@ -30,6 +32,8 @@ async def list_payees(
         db,
         to_uuid_required(current_user.family_id),
         favorites_only=favorites_only,
+        limit=limit,
+        offset=offset,
     )
     return payees
 

--- a/backend/app/api/routes/budget/recurring_transactions.py
+++ b/backend/app/api/routes/budget/recurring_transactions.py
@@ -41,13 +41,14 @@ async def list_recurring_transactions(
 
     if account_id:
         templates = await RecurringTransactionService.list_by_account(
-            db, account_id, family_id, active_only=active_only
+            db, account_id, family_id,
+            active_only=active_only, limit=limit, offset=offset,
         )
-        templates = templates[offset:offset + limit]
     else:
-        templates = await RecurringTransactionService.list_by_family(db, family_id, limit=limit, offset=offset)
-        if active_only:
-            templates = [t for t in templates if t.is_active]
+        templates = await RecurringTransactionService.list_by_family_filtered(
+            db, family_id,
+            active_only=active_only, limit=limit, offset=offset,
+        )
 
     return templates
 

--- a/backend/app/api/routes/budget/recurring_transactions.py
+++ b/backend/app/api/routes/budget/recurring_transactions.py
@@ -33,19 +33,22 @@ async def list_recurring_transactions(
     db: AsyncSession = Depends(get_db),
     account_id: Optional[UUID] = Query(None, description="Filter by account ID"),
     active_only: bool = Query(True, description="Only return active templates"),
+    limit: int = Query(200, ge=1, le=500, description="Max results"),
+    offset: int = Query(0, ge=0, description="Pagination offset"),
 ):
     """List recurring transaction templates for the family"""
     family_id = to_uuid_required(current_user.family_id)
-    
+
     if account_id:
         templates = await RecurringTransactionService.list_by_account(
             db, account_id, family_id, active_only=active_only
         )
+        templates = templates[offset:offset + limit]
     else:
-        templates = await RecurringTransactionService.list_by_family(
-            db, family_id
-        ) if not active_only else [t for t in await RecurringTransactionService.list_by_family(db, family_id) if t.is_active]
-    
+        templates = await RecurringTransactionService.list_by_family(db, family_id, limit=limit, offset=offset)
+        if active_only:
+            templates = [t for t in templates if t.is_active]
+
     return templates
 
 

--- a/backend/app/api/routes/budget/saved_filters.py
+++ b/backend/app/api/routes/budget/saved_filters.py
@@ -4,7 +4,7 @@ Saved Filter routes
 CRUD endpoints for saved transaction filter presets.
 """
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, Query, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing import List
 from uuid import UUID
@@ -27,10 +27,12 @@ router = APIRouter()
 async def list_saved_filters(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
+    limit: int = Query(200, ge=1, le=500, description="Max results"),
+    offset: int = Query(0, ge=0, description="Pagination offset"),
 ):
     """List all saved filters for the family"""
     family_id = to_uuid_required(current_user.family_id)
-    return await SavedFilterService.list_by_family(db, family_id)
+    return await SavedFilterService.list_by_family(db, family_id, limit=limit, offset=offset)
 
 
 @router.post("/", response_model=SavedFilterResponse, status_code=status.HTTP_201_CREATED)

--- a/backend/app/api/routes/budget/tags.py
+++ b/backend/app/api/routes/budget/tags.py
@@ -4,7 +4,7 @@ Tag routes
 CRUD endpoints for budget tags and transaction-tag associations.
 """
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, Query, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing import List
 from uuid import UUID
@@ -28,10 +28,12 @@ router = APIRouter()
 async def list_tags(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
+    limit: int = Query(500, ge=1, le=2000, description="Max results"),
+    offset: int = Query(0, ge=0, description="Pagination offset"),
 ):
     """List all tags for the family"""
     family_id = to_uuid_required(current_user.family_id)
-    return await TagService.list_by_family(db, family_id)
+    return await TagService.list_by_family(db, family_id, limit=limit, offset=offset)
 
 
 @router.post("/", response_model=TagResponse, status_code=status.HTTP_201_CREATED)

--- a/backend/app/api/routes/budget/transactions.py
+++ b/backend/app/api/routes/budget/transactions.py
@@ -33,6 +33,12 @@ from app.models import User
 router = APIRouter()
 
 
+def _build_split_response(parent, children) -> SplitTransactionResponse:
+    """Construct response with sum-of-children total; surfaces drift if data corrupt."""
+    total = sum(c.amount for c in children)
+    return SplitTransactionResponse(parent=parent, children=children, total=total)
+
+
 @router.get("/", response_model=List[TransactionResponse])
 async def list_transactions(
     current_user: User = Depends(get_current_user),
@@ -241,7 +247,7 @@ async def create_split_transaction(
     )
     await UsageService.increment(db, current_user.family_id, "budget_transaction")
     children = await TransactionService.get_split_children(db, parent.id, family_id)
-    return SplitTransactionResponse(parent=parent, children=children, total=parent.amount)
+    return _build_split_response(parent, children)
 
 
 @router.get("/{transaction_id}/splits", response_model=SplitTransactionResponse)
@@ -254,7 +260,7 @@ async def get_split_transaction(
     family_id = to_uuid_required(current_user.family_id)
     parent = await TransactionService.get_by_id(db, transaction_id, family_id)
     children = await TransactionService.get_split_children(db, transaction_id, family_id)
-    return SplitTransactionResponse(parent=parent, children=children, total=parent.amount)
+    return _build_split_response(parent, children)
 
 
 @router.put("/{transaction_id}/splits", response_model=SplitTransactionResponse)
@@ -270,7 +276,7 @@ async def update_split_transaction(
         db, transaction_id, family_id, data.splits
     )
     children = await TransactionService.get_split_children(db, parent.id, family_id)
-    return SplitTransactionResponse(parent=parent, children=children, total=parent.amount)
+    return _build_split_response(parent, children)
 
 
 @router.put("/{transaction_id}/reconcile", response_model=TransactionResponse)

--- a/backend/app/api/routes/budget/transactions.py
+++ b/backend/app/api/routes/budget/transactions.py
@@ -4,7 +4,8 @@ Transaction routes
 CRUD endpoints for budget transactions.
 """
 
-from fastapi import APIRouter, Depends, status, Query, File, UploadFile, Form
+from fastapi import APIRouter, Body, Depends, status, Query, File, UploadFile, Form
+from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing import List, Optional, Dict
 from datetime import date
@@ -126,6 +127,94 @@ async def delete_transaction(
         db,
         transaction_id,
         to_uuid_required(current_user.family_id),
+    )
+
+
+class BulkUpdateRequest(BaseModel):
+    transaction_ids: List[UUID]
+    updates: Dict[str, object] = Field(..., description="Whitelist: cleared, reconciled, category_id, payee_id")
+
+
+class BulkDeleteRequest(BaseModel):
+    transaction_ids: List[UUID]
+
+
+class FinishReconciliationRequest(BaseModel):
+    account_id: UUID
+    statement_balance: int
+    transaction_ids: List[UUID]
+
+
+@router.get("/search", response_model=List[TransactionResponse])
+async def search_transactions(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    account_id: Optional[UUID] = Query(None),
+    category_id: Optional[UUID] = Query(None),
+    payee_id: Optional[UUID] = Query(None),
+    cleared: Optional[bool] = Query(None),
+    reconciled: Optional[bool] = Query(None),
+    start_date: Optional[date] = Query(None),
+    end_date: Optional[date] = Query(None),
+    amount_min: Optional[int] = Query(None, description="Min amount in cents (inclusive)"),
+    amount_max: Optional[int] = Query(None, description="Max amount in cents (inclusive)"),
+    search: Optional[str] = Query(None, description="Substring match against notes (case-insensitive)"),
+    limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+):
+    """Filter transactions by any combination of criteria."""
+    family_id = to_uuid_required(current_user.family_id)
+    return await TransactionService.search_transactions(
+        db, family_id,
+        account_id=account_id, category_id=category_id, payee_id=payee_id,
+        cleared=cleared, reconciled=reconciled,
+        start_date=start_date, end_date=end_date,
+        amount_min=amount_min, amount_max=amount_max,
+        search=search, limit=limit, offset=offset,
+    )
+
+
+@router.post("/bulk-update")
+async def bulk_update_transactions(
+    data: BulkUpdateRequest,
+    current_user: User = Depends(require_parent_role),
+    db: AsyncSession = Depends(get_db),
+):
+    """Bulk modify N transactions (parent only). Whitelist: cleared, reconciled, category_id, payee_id."""
+    family_id = to_uuid_required(current_user.family_id)
+    count = await TransactionService.bulk_update_transactions(
+        db, family_id, data.transaction_ids, data.updates,
+    )
+    return {"updated_count": count}
+
+
+@router.post("/bulk-delete")
+async def bulk_delete_transactions(
+    data: BulkDeleteRequest,
+    current_user: User = Depends(require_parent_role),
+    db: AsyncSession = Depends(get_db),
+):
+    """Bulk delete N transactions (parent only)."""
+    family_id = to_uuid_required(current_user.family_id)
+    count = await TransactionService.bulk_delete_transactions(
+        db, family_id, data.transaction_ids,
+    )
+    return {"deleted_count": count}
+
+
+@router.post("/finish-reconciliation")
+async def finish_reconciliation(
+    data: FinishReconciliationRequest,
+    current_user: User = Depends(require_parent_role),
+    db: AsyncSession = Depends(get_db),
+):
+    """Mark transactions as cleared+reconciled and create adjustment if balance differs (parent only)."""
+    family_id = to_uuid_required(current_user.family_id)
+    return await TransactionService.finish_reconciliation(
+        db, family_id,
+        account_id=data.account_id,
+        statement_balance=data.statement_balance,
+        transaction_ids=data.transaction_ids,
     )
 
 

--- a/backend/app/api/routes/budget/transactions.py
+++ b/backend/app/api/routes/budget/transactions.py
@@ -235,7 +235,9 @@ async def create_split_transaction(
     db: AsyncSession = Depends(get_db),
 ):
     """Create a parent + N child split transaction (parent only)."""
-    await require_feature("budget_transaction", db, current_user)
+    await require_feature(
+        "budget_transaction", db, current_user, units=len(data.splits)
+    )
     family_id = to_uuid_required(current_user.family_id)
     parent = await TransactionService.create_split(
         db,
@@ -249,7 +251,11 @@ async def create_split_transaction(
         cleared=data.cleared,
         reconciled=data.reconciled,
     )
-    await UsageService.increment(db, current_user.family_id, "budget_transaction")
+    # Charge usage per child leg; the parent row is a virtual aggregator and
+    # is not user-visible as an independent transaction.
+    await UsageService.increment(
+        db, current_user.family_id, "budget_transaction", amount=len(data.splits)
+    )
     children = await TransactionService.get_split_children(db, parent.id, family_id)
     return _build_split_response(parent, children)
 

--- a/backend/app/api/routes/budget/transactions.py
+++ b/backend/app/api/routes/budget/transactions.py
@@ -19,7 +19,14 @@ from app.services.usage_service import UsageService
 from app.services.budget.csv_import_service import CSVImportService
 from app.services.budget.file_import_service import import_file_transactions
 from app.services.budget.receipt_scanner_service import scan_and_create_transaction
-from app.schemas.budget import TransactionCreate, TransactionUpdate, TransactionResponse
+from app.schemas.budget import (
+    TransactionCreate,
+    TransactionUpdate,
+    TransactionResponse,
+    SplitTransactionCreate,
+    SplitTransactionUpdate,
+    SplitTransactionResponse,
+)
 from app.models import User
 
 router = APIRouter()
@@ -35,10 +42,11 @@ async def list_transactions(
     end_date: Optional[date] = Query(None, description="End date filter"),
     limit: int = Query(100, le=500, description="Limit results"),
     offset: int = Query(0, ge=0, description="Offset for pagination"),
+    include_split_children: bool = Query(False, description="Include child legs of split parents"),
 ):
     """List transactions with optional filters"""
     family_id = to_uuid_required(current_user.family_id)
-    
+
     if account_id:
         transactions = await TransactionService.list_by_account(
             db, account_id, family_id, start_date, end_date, limit, offset
@@ -51,7 +59,10 @@ async def list_transactions(
         transactions = await TransactionService.list_by_family(
             db, family_id, limit=limit, offset=offset
         )
-    
+
+    if not include_split_children:
+        transactions = [t for t in transactions if t.parent_id is None]
+
     return transactions
 
 
@@ -116,6 +127,61 @@ async def delete_transaction(
         transaction_id,
         to_uuid_required(current_user.family_id),
     )
+
+
+@router.post("/split", response_model=SplitTransactionResponse, status_code=status.HTTP_201_CREATED)
+async def create_split_transaction(
+    data: SplitTransactionCreate,
+    current_user: User = Depends(require_parent_role),
+    db: AsyncSession = Depends(get_db),
+):
+    """Create a parent + N child split transaction (parent only)."""
+    await require_feature("budget_transaction", db, current_user)
+    family_id = to_uuid_required(current_user.family_id)
+    parent = await TransactionService.create_split(
+        db,
+        family_id,
+        account_id=data.account_id,
+        txn_date=data.date,
+        splits=data.splits,
+        payee_id=data.payee_id,
+        payee_name=data.payee_name,
+        notes=data.notes,
+        cleared=data.cleared,
+        reconciled=data.reconciled,
+    )
+    await UsageService.increment(db, current_user.family_id, "budget_transaction")
+    children = await TransactionService.get_split_children(db, parent.id, family_id)
+    return SplitTransactionResponse(parent=parent, children=children, total=parent.amount)
+
+
+@router.get("/{transaction_id}/splits", response_model=SplitTransactionResponse)
+async def get_split_transaction(
+    transaction_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Return parent split transaction with its child legs."""
+    family_id = to_uuid_required(current_user.family_id)
+    parent = await TransactionService.get_by_id(db, transaction_id, family_id)
+    children = await TransactionService.get_split_children(db, transaction_id, family_id)
+    return SplitTransactionResponse(parent=parent, children=children, total=parent.amount)
+
+
+@router.put("/{transaction_id}/splits", response_model=SplitTransactionResponse)
+async def update_split_transaction(
+    transaction_id: UUID,
+    data: SplitTransactionUpdate,
+    current_user: User = Depends(require_parent_role),
+    db: AsyncSession = Depends(get_db),
+):
+    """Replace child legs of a split parent (parent only)."""
+    family_id = to_uuid_required(current_user.family_id)
+    parent = await TransactionService.replace_split_children(
+        db, transaction_id, family_id, data.splits
+    )
+    children = await TransactionService.get_split_children(db, parent.id, family_id)
+    return SplitTransactionResponse(parent=parent, children=children, total=parent.amount)
 
 
 @router.put("/{transaction_id}/reconcile", response_model=TransactionResponse)

--- a/backend/app/api/routes/budget/transactions.py
+++ b/backend/app/api/routes/budget/transactions.py
@@ -90,6 +90,39 @@ async def create_transaction(
     return transaction
 
 
+@router.get("/search", response_model=List[TransactionResponse])
+async def search_transactions(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    account_id: Optional[UUID] = Query(None),
+    category_id: Optional[UUID] = Query(None),
+    payee_id: Optional[UUID] = Query(None),
+    cleared: Optional[bool] = Query(None),
+    reconciled: Optional[bool] = Query(None),
+    start_date: Optional[date] = Query(None),
+    end_date: Optional[date] = Query(None),
+    amount_min: Optional[int] = Query(None, description="Min amount in cents (inclusive)"),
+    amount_max: Optional[int] = Query(None, description="Max amount in cents (inclusive)"),
+    search: Optional[str] = Query(None, description="Substring match against notes (case-insensitive)"),
+    limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+):
+    """Filter transactions by any combination of criteria.
+
+    Declared before /{transaction_id} routes so the literal path is matched
+    before the UUID-typed path parameter.
+    """
+    family_id = to_uuid_required(current_user.family_id)
+    return await TransactionService.search_transactions(
+        db, family_id,
+        account_id=account_id, category_id=category_id, payee_id=payee_id,
+        cleared=cleared, reconciled=reconciled,
+        start_date=start_date, end_date=end_date,
+        amount_min=amount_min, amount_max=amount_max,
+        search=search, limit=limit, offset=offset,
+    )
+
+
 @router.get("/{transaction_id}", response_model=TransactionResponse)
 async def get_transaction(
     transaction_id: UUID,
@@ -149,35 +182,6 @@ class FinishReconciliationRequest(BaseModel):
     account_id: UUID
     statement_balance: int
     transaction_ids: List[UUID]
-
-
-@router.get("/search", response_model=List[TransactionResponse])
-async def search_transactions(
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
-    account_id: Optional[UUID] = Query(None),
-    category_id: Optional[UUID] = Query(None),
-    payee_id: Optional[UUID] = Query(None),
-    cleared: Optional[bool] = Query(None),
-    reconciled: Optional[bool] = Query(None),
-    start_date: Optional[date] = Query(None),
-    end_date: Optional[date] = Query(None),
-    amount_min: Optional[int] = Query(None, description="Min amount in cents (inclusive)"),
-    amount_max: Optional[int] = Query(None, description="Max amount in cents (inclusive)"),
-    search: Optional[str] = Query(None, description="Substring match against notes (case-insensitive)"),
-    limit: int = Query(100, ge=1, le=500),
-    offset: int = Query(0, ge=0),
-):
-    """Filter transactions by any combination of criteria."""
-    family_id = to_uuid_required(current_user.family_id)
-    return await TransactionService.search_transactions(
-        db, family_id,
-        account_id=account_id, category_id=category_id, payee_id=payee_id,
-        cleared=cleared, reconciled=reconciled,
-        start_date=start_date, end_date=end_date,
-        amount_min=amount_min, amount_max=amount_max,
-        search=search, limit=limit, offset=offset,
-    )
 
 
 @router.post("/bulk-update")

--- a/backend/app/core/premium.py
+++ b/backend/app/core/premium.py
@@ -136,13 +136,18 @@ async def get_family_plan(db: AsyncSession, user: User) -> FamilyPlan:
 # ---------------------------------------------------------------------------
 
 async def require_feature(
-    feature: str, db: AsyncSession, user: User
+    feature: str, db: AsyncSession, user: User, units: int = 1
 ) -> FamilyPlan:
     """
-    Ensure the family's plan allows *feature*.
+    Ensure the family's plan allows *feature* for *units* additional usages.
 
-    Returns the FamilyPlan on success, raises HTTP 403 on failure.
+    Returns the FamilyPlan on success, raises HTTP 403 on failure. Pass
+    units > 1 when a single API call would consume multiple chargeable
+    increments (e.g. a split transaction with N child legs).
     """
+    if units < 1:
+        raise ValueError("units must be >= 1")
+
     plan = await get_family_plan(db, user)
     limit_key = FEATURE_LIMIT_MAP.get(feature)
 
@@ -194,7 +199,7 @@ async def require_feature(
     # Check metered usage
     family_id = user.family_id
     current_usage = await UsageService.get_usage(db, family_id, feature)
-    allowed = current_usage < numeric_limit
+    allowed = current_usage + units <= numeric_limit
 
     if allowed:
         return plan

--- a/backend/app/models/budget.py
+++ b/backend/app/models/budget.py
@@ -22,15 +22,17 @@ from app.core.database import Base
 
 class BudgetCategoryGroup(Base):
     """Category groups organize budget categories (e.g., 'Mandado', 'Servicios', 'Entretenimiento')."""
-    
+
     __tablename__ = "budget_category_groups"
-    
+
     id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), primary_key=True, default=uuid4)
     family_id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), ForeignKey("families.id", ondelete="CASCADE"), nullable=False, index=True)
     name: Mapped[str] = mapped_column(String(100), nullable=False)
     sort_order: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
     is_income: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     hidden: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    deleted_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True, index=True, comment="Soft delete timestamp")
+    deleted_by_id: Mapped[Optional[UUID]] = mapped_column(PGUUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True, comment="User who deleted this group")
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
     
@@ -51,9 +53,11 @@ class BudgetCategory(Base):
     hidden: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     rollover_enabled: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
     goal_amount: Mapped[int] = mapped_column(BigInteger, default=0, nullable=False, comment="Monthly goal in cents")
+    deleted_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True, index=True, comment="Soft delete timestamp")
+    deleted_by_id: Mapped[Optional[UUID]] = mapped_column(PGUUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True, comment="User who deleted this category")
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
-    
+
     # Relationships
     group: Mapped["BudgetCategoryGroup"] = relationship("BudgetCategoryGroup", back_populates="categories")
     family: Mapped["Family"] = relationship("Family", back_populates="budget_categories")
@@ -98,9 +102,12 @@ class BudgetAccount(Base):
     notes: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     sort_order: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
     starting_balance: Mapped[int] = mapped_column(BigInteger, default=0, nullable=False, comment="Initial account balance in cents at creation time")
+    currency: Mapped[str] = mapped_column(String(3), nullable=False, server_default="MXN", comment="ISO 4217 currency code (e.g. MXN, USD, EUR)")
+    deleted_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True, index=True, comment="Soft delete timestamp")
+    deleted_by_id: Mapped[Optional[UUID]] = mapped_column(PGUUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True, comment="User who deleted this account")
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
-    
+
     # Relationships
     family: Mapped["Family"] = relationship("Family", back_populates="budget_accounts")
     transactions: Mapped[list["BudgetTransaction"]] = relationship(
@@ -159,6 +166,8 @@ class BudgetTransaction(Base):
     parent_id: Mapped[Optional[UUID]] = mapped_column(PGUUID(as_uuid=True), ForeignKey("budget_transactions.id", ondelete="CASCADE"), nullable=True, comment="For split transactions")
     is_parent: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False, comment="Is this a split parent transaction?")
     transfer_account_id: Mapped[Optional[UUID]] = mapped_column(PGUUID(as_uuid=True), ForeignKey("budget_accounts.id", ondelete="SET NULL"), nullable=True, comment="Target account for transfers")
+    deleted_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True, index=True, comment="Soft delete timestamp")
+    deleted_by_id: Mapped[Optional[UUID]] = mapped_column(PGUUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True, comment="User who deleted this transaction")
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
     

--- a/backend/app/schemas/budget.py
+++ b/backend/app/schemas/budget.py
@@ -238,6 +238,38 @@ class TransactionResponse(TransactionBase):
         from_attributes = True
 
 
+class SplitChild(BaseModel):
+    """One leg of a split transaction."""
+    amount: int = Field(..., description="Amount in cents (sign matches parent)")
+    category_id: Optional[UUID] = Field(None, description="Category for this leg")
+    payee_id: Optional[UUID] = Field(None, description="Override payee for this leg")
+    notes: Optional[str] = Field(None, description="Per-leg notes")
+
+
+class SplitTransactionCreate(BaseModel):
+    """Create a parent transaction with N child legs."""
+    account_id: UUID
+    date: DateType
+    payee_id: Optional[UUID] = None
+    payee_name: Optional[str] = Field(None, max_length=255)
+    notes: Optional[str] = None
+    cleared: bool = False
+    reconciled: bool = False
+    splits: List[SplitChild] = Field(..., min_length=2, description="At least 2 child legs required")
+
+
+class SplitTransactionUpdate(BaseModel):
+    """Replace the child legs of an existing split parent."""
+    splits: List[SplitChild] = Field(..., min_length=2)
+
+
+class SplitTransactionResponse(BaseModel):
+    """Parent transaction plus its children."""
+    parent: TransactionResponse
+    children: List[TransactionResponse]
+    total: int = Field(..., description="Sum of children amounts (must equal parent.amount)")
+
+
 # ============================================================================
 # ALLOCATION SCHEMAS
 # ============================================================================

--- a/backend/app/schemas/budget.py
+++ b/backend/app/schemas/budget.py
@@ -99,6 +99,11 @@ class AccountBase(BaseModel):
     notes: Optional[str] = Field(None, description="Optional notes")
     sort_order: int = Field(0, ge=0, description="Display order")
     starting_balance: int = Field(0, description="Initial account balance in cents at creation time")
+    currency: str = Field(
+        "MXN",
+        min_length=3, max_length=3,
+        description="ISO 4217 currency code. All accounts in a family must share the same currency — reports/balances do not convert.",
+    )
 
     @field_validator('type')
     @classmethod
@@ -106,6 +111,13 @@ class AccountBase(BaseModel):
         allowed_types = ['checking', 'savings', 'credit', 'investment', 'loan', 'other']
         if v not in allowed_types:
             raise ValueError(f'type must be one of: {", ".join(allowed_types)}')
+        return v
+
+    @field_validator('currency')
+    @classmethod
+    def validate_currency(cls, v):
+        if not v.isalpha() or v != v.upper():
+            raise ValueError("currency must be a 3-letter uppercase ISO 4217 code")
         return v
 
 
@@ -123,6 +135,7 @@ class AccountUpdate(BaseModel):
     notes: Optional[str] = None
     sort_order: Optional[int] = Field(None, ge=0)
     starting_balance: Optional[int] = Field(None, description="Initial account balance in cents")
+    currency: Optional[str] = Field(None, min_length=3, max_length=3)
 
     @field_validator('type')
     @classmethod
@@ -131,6 +144,13 @@ class AccountUpdate(BaseModel):
             allowed_types = ['checking', 'savings', 'credit', 'investment', 'loan', 'other']
             if v not in allowed_types:
                 raise ValueError(f'type must be one of: {", ".join(allowed_types)}')
+        return v
+
+    @field_validator('currency')
+    @classmethod
+    def validate_currency(cls, v):
+        if v is not None and (not v.isalpha() or v != v.upper()):
+            raise ValueError("currency must be a 3-letter uppercase ISO 4217 code")
         return v
 
 

--- a/backend/app/schemas/budget.py
+++ b/backend/app/schemas/budget.py
@@ -266,6 +266,9 @@ class SplitChild(BaseModel):
     notes: Optional[str] = Field(None, description="Per-leg notes")
 
 
+SPLIT_MAX_LEGS = 50
+
+
 class SplitTransactionCreate(BaseModel):
     """Create a parent transaction with N child legs."""
     account_id: UUID
@@ -275,12 +278,19 @@ class SplitTransactionCreate(BaseModel):
     notes: Optional[str] = None
     cleared: bool = False
     reconciled: bool = False
-    splits: List[SplitChild] = Field(..., min_length=2, description="At least 2 child legs required")
+    splits: List[SplitChild] = Field(
+        ...,
+        min_length=2,
+        max_length=SPLIT_MAX_LEGS,
+        description=f"Between 2 and {SPLIT_MAX_LEGS} child legs.",
+    )
 
 
 class SplitTransactionUpdate(BaseModel):
     """Replace the child legs of an existing split parent."""
-    splits: List[SplitChild] = Field(..., min_length=2)
+    splits: List[SplitChild] = Field(
+        ..., min_length=2, max_length=SPLIT_MAX_LEGS
+    )
 
 
 class SplitTransactionResponse(BaseModel):

--- a/backend/app/services/base_service.py
+++ b/backend/app/services/base_service.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, and_, delete as sql_delete
 from typing import TypeVar, Generic, Type, List, Optional
 from uuid import UUID
-from datetime import datetime
+from datetime import datetime, timezone
 
 from app.core.exceptions import NotFoundException
 
@@ -64,6 +64,8 @@ class BaseFamilyService(Generic[ModelType]):
         query = select(cls.model).where(
             and_(cls.model.id == entity_id, cls.model.family_id == family_id)
         )
+        if hasattr(cls.model, "deleted_at"):
+            query = query.where(cls.model.deleted_at.is_(None))
         result = await db.execute(query)
         entity = result.scalar_one_or_none()
 
@@ -97,6 +99,8 @@ class BaseFamilyService(Generic[ModelType]):
             raise NotImplementedError("Subclass must set 'model' class attribute")
 
         query = select(cls.model).where(cls.model.family_id == family_id)
+        if hasattr(cls.model, "deleted_at"):
+            query = query.where(cls.model.deleted_at.is_(None))
 
         # Apply ordering if created_at exists
         if hasattr(cls.model, "created_at"):
@@ -168,7 +172,7 @@ class BaseFamilyService(Generic[ModelType]):
 
         # Update timestamp if exists
         if hasattr(entity, "updated_at"):
-            entity.updated_at = datetime.utcnow()
+            entity.updated_at = datetime.now(timezone.utc)
 
         await db.commit()
         await db.refresh(entity)
@@ -200,6 +204,8 @@ class BaseFamilyService(Generic[ModelType]):
             .select_from(cls.model)
             .where(cls.model.family_id == family_id)
         )
+        if hasattr(cls.model, "deleted_at"):
+            query = query.where(cls.model.deleted_at.is_(None))
         result = await db.execute(query)
         return result.scalar_one()
 

--- a/backend/app/services/budget/account_service.py
+++ b/backend/app/services/budget/account_service.py
@@ -23,22 +23,34 @@ class AccountService(BaseFamilyService[BudgetAccount]):
 
     @classmethod
     async def _existing_family_currency(
-        cls, db: AsyncSession, family_id: UUID
+        cls,
+        db: AsyncSession,
+        family_id: UUID,
+        exclude_account_id: Optional[UUID] = None,
     ) -> Optional[str]:
         """Return the currency in use by any non-deleted account in the family,
         or None when the family has no accounts yet.
 
         Reports and balance aggregations sum amounts across accounts without
         currency conversion, so families must use a single currency.
+
+        exclude_account_id lets the update path skip the row being changed,
+        so a sole-account currency change is permitted (no other account is
+        anchored to the old currency).
+
+        ORDER BY created_at, id makes the result deterministic if legacy data
+        ever ends up with mixed currencies — same anchor row every call.
         """
+        conditions = [
+            BudgetAccount.family_id == family_id,
+            BudgetAccount.deleted_at.is_(None),
+        ]
+        if exclude_account_id is not None:
+            conditions.append(BudgetAccount.id != exclude_account_id)
         q = (
             select(BudgetAccount.currency)
-            .where(
-                and_(
-                    BudgetAccount.family_id == family_id,
-                    BudgetAccount.deleted_at.is_(None),
-                )
-            )
+            .where(and_(*conditions))
+            .order_by(BudgetAccount.created_at, BudgetAccount.id)
             .limit(1)
         )
         return (await db.execute(q)).scalar_one_or_none()
@@ -128,7 +140,9 @@ class AccountService(BaseFamilyService[BudgetAccount]):
         """
         update_data = data.model_dump(exclude_unset=True)
         if "currency" in update_data and update_data["currency"] is not None:
-            existing = await cls._existing_family_currency(db, family_id)
+            existing = await cls._existing_family_currency(
+                db, family_id, exclude_account_id=account_id
+            )
             if existing is not None and existing != update_data["currency"]:
                 raise ValidationError(
                     f"Cannot change account currency to {update_data['currency']!r}; "

--- a/backend/app/services/budget/account_service.py
+++ b/backend/app/services/budget/account_service.py
@@ -13,12 +13,35 @@ from uuid import UUID
 from app.models.budget import BudgetAccount, BudgetTransaction
 from app.schemas.budget import AccountCreate, AccountUpdate
 from app.services.base_service import BaseFamilyService
+from app.core.exceptions import ValidationError
 
 
 class AccountService(BaseFamilyService[BudgetAccount]):
     """Service for budget account operations"""
 
     model = BudgetAccount
+
+    @classmethod
+    async def _existing_family_currency(
+        cls, db: AsyncSession, family_id: UUID
+    ) -> Optional[str]:
+        """Return the currency in use by any non-deleted account in the family,
+        or None when the family has no accounts yet.
+
+        Reports and balance aggregations sum amounts across accounts without
+        currency conversion, so families must use a single currency.
+        """
+        q = (
+            select(BudgetAccount.currency)
+            .where(
+                and_(
+                    BudgetAccount.family_id == family_id,
+                    BudgetAccount.deleted_at.is_(None),
+                )
+            )
+            .limit(1)
+        )
+        return (await db.execute(q)).scalar_one_or_none()
 
     @classmethod
     async def create(
@@ -42,6 +65,14 @@ class AccountService(BaseFamilyService[BudgetAccount]):
         Returns:
             Created account
         """
+        existing_currency = await cls._existing_family_currency(db, family_id)
+        if existing_currency is not None and existing_currency != data.currency:
+            raise ValidationError(
+                f"Account currency {data.currency!r} does not match the family's "
+                f"existing currency {existing_currency!r}. Reports do not convert "
+                f"across currencies."
+            )
+
         account = BudgetAccount(
             family_id=family_id,
             name=data.name,
@@ -51,6 +82,7 @@ class AccountService(BaseFamilyService[BudgetAccount]):
             notes=data.notes,
             sort_order=data.sort_order,
             starting_balance=data.starting_balance,
+            currency=data.currency,
         )
 
         db.add(account)
@@ -95,7 +127,45 @@ class AccountService(BaseFamilyService[BudgetAccount]):
             Updated account
         """
         update_data = data.model_dump(exclude_unset=True)
+        if "currency" in update_data and update_data["currency"] is not None:
+            existing = await cls._existing_family_currency(db, family_id)
+            if existing is not None and existing != update_data["currency"]:
+                raise ValidationError(
+                    f"Cannot change account currency to {update_data['currency']!r}; "
+                    f"family already uses {existing!r}. Reports do not convert "
+                    f"across currencies."
+                )
         return await cls.update_by_id(db, account_id, family_id, update_data)
+
+    @classmethod
+    async def list_for_family(
+        cls,
+        db: AsyncSession,
+        family_id: UUID,
+        include_closed: bool = False,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+    ) -> List[BudgetAccount]:
+        """List accounts with the closed filter applied at the SQL level so
+        pagination is stable. The base class list_by_family ignores closed.
+        """
+        query = (
+            select(BudgetAccount)
+            .where(
+                and_(
+                    BudgetAccount.family_id == family_id,
+                    BudgetAccount.deleted_at.is_(None),
+                )
+            )
+            .order_by(BudgetAccount.sort_order, BudgetAccount.name)
+        )
+        if not include_closed:
+            query = query.where(BudgetAccount.closed == False)
+        if limit is not None:
+            query = query.limit(limit)
+        if offset:
+            query = query.offset(offset)
+        return list((await db.execute(query)).scalars().all())
 
     @classmethod
     async def list_by_type(

--- a/backend/app/services/budget/account_service.py
+++ b/backend/app/services/budget/account_service.py
@@ -104,6 +104,8 @@ class AccountService(BaseFamilyService[BudgetAccount]):
         family_id: UUID,
         account_type: str,
         include_closed: bool = False,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
     ) -> List[BudgetAccount]:
         """
         List accounts by type.
@@ -123,6 +125,7 @@ class AccountService(BaseFamilyService[BudgetAccount]):
                 and_(
                     BudgetAccount.family_id == family_id,
                     BudgetAccount.type == account_type,
+                    BudgetAccount.deleted_at.is_(None),
                 )
             )
             .order_by(BudgetAccount.sort_order, BudgetAccount.name)
@@ -130,6 +133,10 @@ class AccountService(BaseFamilyService[BudgetAccount]):
 
         if not include_closed:
             query = query.where(BudgetAccount.closed == False)
+        if limit is not None:
+            query = query.limit(limit)
+        if offset:
+            query = query.offset(offset)
 
         result = await db.execute(query)
         return list(result.scalars().all())
@@ -140,6 +147,8 @@ class AccountService(BaseFamilyService[BudgetAccount]):
         db: AsyncSession,
         family_id: UUID,
         include_closed: bool = False,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
     ) -> List[BudgetAccount]:
         """
         List on-budget accounts (excludes tracking/offbudget accounts).
@@ -158,6 +167,7 @@ class AccountService(BaseFamilyService[BudgetAccount]):
                 and_(
                     BudgetAccount.family_id == family_id,
                     BudgetAccount.offbudget == False,
+                    BudgetAccount.deleted_at.is_(None),
                 )
             )
             .order_by(BudgetAccount.sort_order, BudgetAccount.name)
@@ -165,6 +175,10 @@ class AccountService(BaseFamilyService[BudgetAccount]):
 
         if not include_closed:
             query = query.where(BudgetAccount.closed == False)
+        if limit is not None:
+            query = query.limit(limit)
+        if offset:
+            query = query.offset(offset)
 
         result = await db.execute(query)
         return list(result.scalars().all())
@@ -204,10 +218,11 @@ class AccountService(BaseFamilyService[BudgetAccount]):
                 and_(
                     BudgetTransaction.family_id == family_id,
                     BudgetTransaction.account_id == account_id,
+                    BudgetTransaction.deleted_at.is_(None),
                 )
             )
         )
-        
+
         # Build query for cleared balance (cleared transactions only)
         cleared_query = (
             select(func.coalesce(func.sum(BudgetTransaction.amount), 0))
@@ -216,6 +231,7 @@ class AccountService(BaseFamilyService[BudgetAccount]):
                     BudgetTransaction.family_id == family_id,
                     BudgetTransaction.account_id == account_id,
                     BudgetTransaction.cleared == True,
+                    BudgetTransaction.deleted_at.is_(None),
                 )
             )
         )
@@ -272,6 +288,7 @@ class AccountService(BaseFamilyService[BudgetAccount]):
                     BudgetAccount.family_id == family_id,
                     BudgetAccount.offbudget == False,
                     BudgetAccount.closed == False,
+                    BudgetAccount.deleted_at.is_(None),
                 )
             )
         )
@@ -283,6 +300,7 @@ class AccountService(BaseFamilyService[BudgetAccount]):
                 and_(
                     BudgetTransaction.family_id == family_id,
                     BudgetTransaction.account_id.in_(on_budget_accounts_query),
+                    BudgetTransaction.deleted_at.is_(None),
                 )
             )
         )

--- a/backend/app/services/budget/allocation_service.py
+++ b/backend/app/services/budget/allocation_service.py
@@ -317,6 +317,7 @@ class AllocationService(BaseFamilyService[BudgetAllocation]):
                         BudgetTransaction.family_id == family_id,
                         BudgetTransaction.category_id == category_id,
                         BudgetTransaction.date < month,
+                        BudgetTransaction.deleted_at.is_(None),
                     )
                 )
             )
@@ -424,6 +425,8 @@ class AllocationService(BaseFamilyService[BudgetAllocation]):
                 and_(
                     BudgetCategory.family_id == family_id,
                     BudgetCategoryGroup.is_income == False,
+                    BudgetCategory.deleted_at.is_(None),
+                    BudgetCategoryGroup.deleted_at.is_(None),
                 )
             )
         )
@@ -470,6 +473,8 @@ class AllocationService(BaseFamilyService[BudgetAllocation]):
                 and_(
                     BudgetCategory.family_id == family_id,
                     BudgetCategoryGroup.is_income == False,
+                    BudgetCategory.deleted_at.is_(None),
+                    BudgetCategoryGroup.deleted_at.is_(None),
                 )
             )
         )
@@ -522,6 +527,8 @@ class AllocationService(BaseFamilyService[BudgetAllocation]):
                 and_(
                     BudgetCategory.family_id == family_id,
                     BudgetCategoryGroup.is_income == False,
+                    BudgetCategory.deleted_at.is_(None),
+                    BudgetCategoryGroup.deleted_at.is_(None),
                 )
             )
         )
@@ -533,6 +540,7 @@ class AllocationService(BaseFamilyService[BudgetAllocation]):
                     BudgetTransaction.family_id == family_id,
                     BudgetTransaction.category_id.in_(expense_category_ids_query),
                     BudgetTransaction.date <= end_of_prior,
+                    BudgetTransaction.deleted_at.is_(None),
                 )
             )
         )
@@ -648,6 +656,7 @@ class AllocationService(BaseFamilyService[BudgetAllocation]):
                         BudgetTransaction.category_id == cat.id,
                         BudgetTransaction.date >= start_month,
                         BudgetTransaction.date < target_month,
+                        BudgetTransaction.deleted_at.is_(None),
                     )
                 )
             )

--- a/backend/app/services/budget/allocation_service.py
+++ b/backend/app/services/budget/allocation_service.py
@@ -750,3 +750,223 @@ class AllocationService(BaseFamilyService[BudgetAllocation]):
         )
         result = await db.execute(query)
         return result.scalar_one_or_none()
+
+    # ------------------------------------------------------------------
+    # Bulk month operations: copy / fill_from_average / carry_over
+    # ------------------------------------------------------------------
+
+    @classmethod
+    async def copy_from_month(
+        cls,
+        db: AsyncSession,
+        family_id: UUID,
+        source: date,
+        target: date,
+        overwrite: bool = False,
+    ) -> dict:
+        """Copy non-zero allocations from source month to target month.
+
+        Returns {copied, skipped}. With overwrite=False, target allocations
+        with non-zero amount are kept unchanged and counted as skipped.
+        """
+        source_allocs = await cls.list_by_month(db, family_id, source)
+        copied = 0
+        skipped = 0
+
+        for alloc in source_allocs:
+            if alloc.budgeted_amount == 0:
+                skipped += 1
+                continue
+
+            existing = await cls._get_allocation_for_category_month(
+                db, family_id, alloc.category_id, target
+            )
+            if existing and existing.budgeted_amount != 0 and not overwrite:
+                skipped += 1
+                continue
+
+            if existing:
+                existing.budgeted_amount = alloc.budgeted_amount
+            else:
+                db.add(BudgetAllocation(
+                    family_id=family_id,
+                    category_id=alloc.category_id,
+                    month=target,
+                    budgeted_amount=alloc.budgeted_amount,
+                ))
+            copied += 1
+
+        await db.commit()
+        return {"copied": copied, "skipped": skipped}
+
+    @classmethod
+    async def fill_from_average(
+        cls,
+        db: AsyncSession,
+        family_id: UUID,
+        target: date,
+        months_back: int,
+        overwrite: bool = True,
+    ) -> dict:
+        """Set target month allocations to abs(avg spending) over last N months.
+
+        Excludes income groups and hidden categories. Categories with no
+        spending history are skipped. Returns {filled, skipped}.
+        """
+        if months_back < 1:
+            raise ValidationError("months_back must be >= 1")
+
+        start_month = target - relativedelta(months=months_back)
+
+        # Expense categories only (non-income, non-hidden, non-deleted)
+        expense_q = (
+            select(BudgetCategory)
+            .join(BudgetCategoryGroup, BudgetCategory.group_id == BudgetCategoryGroup.id)
+            .where(
+                and_(
+                    BudgetCategory.family_id == family_id,
+                    BudgetCategoryGroup.is_income == False,
+                    BudgetCategory.hidden == False,
+                    BudgetCategory.deleted_at.is_(None),
+                    BudgetCategoryGroup.deleted_at.is_(None),
+                )
+            )
+        )
+        cats = list((await db.execute(expense_q)).scalars().all())
+
+        filled = 0
+        skipped = 0
+
+        for cat in cats:
+            activity_q = (
+                select(func.coalesce(func.sum(BudgetTransaction.amount), 0))
+                .where(
+                    and_(
+                        BudgetTransaction.family_id == family_id,
+                        BudgetTransaction.category_id == cat.id,
+                        BudgetTransaction.date >= start_month,
+                        BudgetTransaction.date < target,
+                        BudgetTransaction.deleted_at.is_(None),
+                    )
+                )
+            )
+            total = (await db.execute(activity_q)).scalar() or 0
+            if total == 0:
+                skipped += 1
+                continue
+
+            avg = abs(int(total // months_back))
+            if avg == 0:
+                skipped += 1
+                continue
+
+            existing = await cls._get_allocation_for_category_month(
+                db, family_id, cat.id, target
+            )
+            if existing and existing.budgeted_amount != 0 and not overwrite:
+                skipped += 1
+                continue
+
+            if existing:
+                existing.budgeted_amount = avg
+            else:
+                db.add(BudgetAllocation(
+                    family_id=family_id,
+                    category_id=cat.id,
+                    month=target,
+                    budgeted_amount=avg,
+                ))
+            filled += 1
+
+        await db.commit()
+        return {"filled": filled, "skipped": skipped}
+
+    @classmethod
+    async def carry_over_month(
+        cls,
+        db: AsyncSession,
+        family_id: UUID,
+        source: date,
+        target: date,
+        mode: str = "all",
+    ) -> dict:
+        """Carry over remaining balance from source month into target month.
+
+        Modes:
+          - "all": carry both positive (unspent) and negative (overspent) balances
+          - "unspent_only": skip overspent categories (available < 0)
+
+        New target amount = max(0, target.budgeted + source.available).
+        Hidden categories are always skipped. Returns {carried, skipped}.
+        """
+        if mode not in ("all", "unspent_only"):
+            raise ValidationError(f"Invalid mode: {mode}")
+
+        # Expense categories only (non-income, non-hidden, non-deleted)
+        expense_q = (
+            select(BudgetCategory)
+            .join(BudgetCategoryGroup, BudgetCategory.group_id == BudgetCategoryGroup.id)
+            .where(
+                and_(
+                    BudgetCategory.family_id == family_id,
+                    BudgetCategoryGroup.is_income == False,
+                    BudgetCategory.hidden == False,
+                    BudgetCategory.deleted_at.is_(None),
+                    BudgetCategoryGroup.deleted_at.is_(None),
+                )
+            )
+        )
+        cats = list((await db.execute(expense_q)).scalars().all())
+
+        # Count hidden categories with source allocations as skipped
+        hidden_q = (
+            select(BudgetCategory)
+            .join(BudgetCategoryGroup, BudgetCategory.group_id == BudgetCategoryGroup.id)
+            .where(
+                and_(
+                    BudgetCategory.family_id == family_id,
+                    BudgetCategoryGroup.is_income == False,
+                    BudgetCategory.hidden == True,
+                    BudgetCategory.deleted_at.is_(None),
+                )
+            )
+        )
+        hidden_cats = list((await db.execute(hidden_q)).scalars().all())
+
+        carried = 0
+        skipped = 0
+
+        for hcat in hidden_cats:
+            src = await cls._get_allocation_for_category_month(db, family_id, hcat.id, source)
+            if src and src.budgeted_amount != 0:
+                skipped += 1
+
+        for cat in cats:
+            avail_info = await cls.get_category_available_amount(
+                db, family_id, cat.id, source
+            )
+            available = avail_info["available"]
+
+            if mode == "unspent_only" and available < 0:
+                skipped += 1
+                continue
+
+            existing = await cls._get_allocation_for_category_month(
+                db, family_id, cat.id, target
+            )
+            current_target = existing.budgeted_amount if existing else 0
+            new_amount = max(0, current_target + available)
+
+            if existing:
+                existing.budgeted_amount = new_amount
+            else:
+                db.add(BudgetAllocation(
+                    family_id=family_id,
+                    category_id=cat.id,
+                    month=target,
+                    budgeted_amount=new_amount,
+                ))
+            carried += 1
+
+        await db.commit()
+        return {"carried": carried, "skipped": skipped}

--- a/backend/app/services/budget/categorization_rule_service.py
+++ b/backend/app/services/budget/categorization_rule_service.py
@@ -76,6 +76,7 @@ class CategorizationRuleService(BaseFamilyService[BudgetCategorizationRule]):
                 and_(
                     BudgetCategory.id == data.category_id,
                     BudgetCategory.family_id == family_id,
+                    BudgetCategory.deleted_at.is_(None),
                 )
             )
         )

--- a/backend/app/services/budget/categorization_rule_service.py
+++ b/backend/app/services/budget/categorization_rule_service.py
@@ -378,7 +378,8 @@ class CategorizationRuleService(BaseFamilyService[BudgetCategorizationRule]):
 
         Processes up to `max_transactions` rows in batches of APPLY_ALL_BATCH_SIZE
         ordered by created_at desc. Skipped = uncategorized rows that did not match
-        any rule. truncated=True when scan limit was hit.
+        any rule. truncated=True when more uncategorized rows remain beyond the
+        scan window after hitting max_transactions.
         """
         from app.models.budget import BudgetPayee
 
@@ -387,9 +388,12 @@ class CategorizationRuleService(BaseFamilyService[BudgetCategorizationRule]):
         applied = 0
         skipped = 0
         scanned = 0
-        offset = 0
         truncated = False
 
+        # Each loop, applied rows leave the `category_id IS NULL` result set
+        # after autoflush, so paginate by `skipped` (rows we passed over but
+        # could not match) rather than total rows seen — otherwise we'd skip
+        # past real candidates.
         while scanned < max_transactions:
             remaining = max_transactions - scanned
             batch_limit = min(cls.APPLY_ALL_BATCH_SIZE, remaining)
@@ -405,7 +409,7 @@ class CategorizationRuleService(BaseFamilyService[BudgetCategorizationRule]):
                 )
                 .order_by(BudgetTransaction.created_at.desc())
                 .limit(batch_limit)
-                .offset(offset)
+                .offset(skipped)
             )
             rows = (await db.execute(txn_q)).all()
             if not rows:
@@ -424,12 +428,12 @@ class CategorizationRuleService(BaseFamilyService[BudgetCategorizationRule]):
                     skipped += 1
 
             scanned += len(rows)
-            offset += len(rows)
             if len(rows) < batch_limit:
                 break
 
         if scanned >= max_transactions:
-            # Check whether more uncategorized rows exist beyond the scan window.
+            # Total uncategorized = skipped (still in result set) + any rows
+            # that remain beyond the scan window.
             tail_q = (
                 select(func.count())
                 .select_from(BudgetTransaction)
@@ -442,7 +446,7 @@ class CategorizationRuleService(BaseFamilyService[BudgetCategorizationRule]):
                 )
             )
             total = (await db.execute(tail_q)).scalar_one()
-            truncated = total > scanned
+            truncated = total > skipped
 
         await db.commit()
         return {

--- a/backend/app/services/budget/categorization_rule_service.py
+++ b/backend/app/services/budget/categorization_rule_service.py
@@ -364,3 +364,102 @@ class CategorizationRuleService(BaseFamilyService[BudgetCategorizationRule]):
                 return False
         else:
             return False
+
+    @classmethod
+    async def apply_all_rules(
+        cls,
+        db: AsyncSession,
+        family_id: UUID,
+    ) -> dict:
+        """Walk uncategorized transactions, apply matching rules. Returns {applied, skipped}.
+
+        Skipped = uncategorized transactions with no matching rule.
+        """
+        from app.models.budget import BudgetPayee
+
+        rules = await cls.list_rules(db, family_id, enabled_only=True)
+
+        # Get all uncategorized non-deleted transactions
+        txn_q = (
+            select(BudgetTransaction, BudgetPayee.name)
+            .outerjoin(BudgetPayee, BudgetTransaction.payee_id == BudgetPayee.id)
+            .where(
+                and_(
+                    BudgetTransaction.family_id == family_id,
+                    BudgetTransaction.category_id.is_(None),
+                    BudgetTransaction.deleted_at.is_(None),
+                )
+            )
+        )
+        result = await db.execute(txn_q)
+
+        applied = 0
+        skipped = 0
+        for txn, payee_name in result.all():
+            matched_rule = None
+            for rule in rules:
+                if cls._match_rule(rule, payee_name, txn.notes):
+                    matched_rule = rule
+                    break
+            if matched_rule:
+                await cls.apply_rule(db, txn, matched_rule)
+                applied += 1
+            else:
+                skipped += 1
+
+        await db.commit()
+        return {"applied": applied, "skipped": skipped}
+
+    @classmethod
+    async def suggest_new_rules(
+        cls,
+        db: AsyncSession,
+        family_id: UUID,
+        min_count: int = 3,
+    ) -> List[dict]:
+        """Suggest payees with N+ uncategorized transactions and no existing exact rule.
+
+        Returns list of {payee_id, payee_name, transaction_count}.
+        """
+        from sqlalchemy import func as sql_func
+        from app.models.budget import BudgetPayee
+
+        # Group uncategorized txns by payee
+        agg_q = (
+            select(
+                BudgetPayee.id,
+                BudgetPayee.name,
+                sql_func.count(BudgetTransaction.id).label("cnt"),
+            )
+            .join(BudgetPayee, BudgetTransaction.payee_id == BudgetPayee.id)
+            .where(
+                and_(
+                    BudgetTransaction.family_id == family_id,
+                    BudgetTransaction.category_id.is_(None),
+                    BudgetTransaction.deleted_at.is_(None),
+                )
+            )
+            .group_by(BudgetPayee.id, BudgetPayee.name)
+            .having(sql_func.count(BudgetTransaction.id) >= min_count)
+        )
+        rows = (await db.execute(agg_q)).all()
+
+        # Existing exact rules on payee field — exclude those payee names
+        rule_q = select(BudgetCategorizationRule.pattern).where(
+            and_(
+                BudgetCategorizationRule.family_id == family_id,
+                BudgetCategorizationRule.rule_type == "exact",
+                BudgetCategorizationRule.match_field == "payee",
+            )
+        )
+        excluded = {p.lower() for p in (await db.execute(rule_q)).scalars().all()}
+
+        return [
+            {
+                "payee_id": pid,
+                "payee_name": pname,
+                "transaction_count": cnt,
+            }
+            for pid, pname, cnt in rows
+            if pname.lower() not in excluded
+        ]

--- a/backend/app/services/budget/categorization_rule_service.py
+++ b/backend/app/services/budget/categorization_rule_service.py
@@ -10,7 +10,7 @@ from typing import List, Optional
 from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select, and_
+from sqlalchemy import select, and_, func
 
 from app.models.budget import BudgetCategorizationRule, BudgetCategory, BudgetTransaction
 from app.schemas.budget import (
@@ -365,50 +365,92 @@ class CategorizationRuleService(BaseFamilyService[BudgetCategorizationRule]):
         else:
             return False
 
+    APPLY_ALL_BATCH_SIZE = 1000
+
     @classmethod
     async def apply_all_rules(
         cls,
         db: AsyncSession,
         family_id: UUID,
+        max_transactions: int = 10000,
     ) -> dict:
-        """Walk uncategorized transactions, apply matching rules. Returns {applied, skipped}.
+        """Walk uncategorized transactions, apply matching rules. Returns {applied, skipped, scanned, truncated}.
 
-        Skipped = uncategorized transactions with no matching rule.
+        Processes up to `max_transactions` rows in batches of APPLY_ALL_BATCH_SIZE
+        ordered by created_at desc. Skipped = uncategorized rows that did not match
+        any rule. truncated=True when scan limit was hit.
         """
         from app.models.budget import BudgetPayee
 
         rules = await cls.list_rules(db, family_id, enabled_only=True)
 
-        # Get all uncategorized non-deleted transactions
-        txn_q = (
-            select(BudgetTransaction, BudgetPayee.name)
-            .outerjoin(BudgetPayee, BudgetTransaction.payee_id == BudgetPayee.id)
-            .where(
-                and_(
-                    BudgetTransaction.family_id == family_id,
-                    BudgetTransaction.category_id.is_(None),
-                    BudgetTransaction.deleted_at.is_(None),
-                )
-            )
-        )
-        result = await db.execute(txn_q)
-
         applied = 0
         skipped = 0
-        for txn, payee_name in result.all():
-            matched_rule = None
-            for rule in rules:
-                if cls._match_rule(rule, payee_name, txn.notes):
-                    matched_rule = rule
-                    break
-            if matched_rule:
-                await cls.apply_rule(db, txn, matched_rule)
-                applied += 1
-            else:
-                skipped += 1
+        scanned = 0
+        offset = 0
+        truncated = False
+
+        while scanned < max_transactions:
+            remaining = max_transactions - scanned
+            batch_limit = min(cls.APPLY_ALL_BATCH_SIZE, remaining)
+            txn_q = (
+                select(BudgetTransaction, BudgetPayee.name)
+                .outerjoin(BudgetPayee, BudgetTransaction.payee_id == BudgetPayee.id)
+                .where(
+                    and_(
+                        BudgetTransaction.family_id == family_id,
+                        BudgetTransaction.category_id.is_(None),
+                        BudgetTransaction.deleted_at.is_(None),
+                    )
+                )
+                .order_by(BudgetTransaction.created_at.desc())
+                .limit(batch_limit)
+                .offset(offset)
+            )
+            rows = (await db.execute(txn_q)).all()
+            if not rows:
+                break
+
+            for txn, payee_name in rows:
+                matched_rule = None
+                for rule in rules:
+                    if cls._match_rule(rule, payee_name, txn.notes):
+                        matched_rule = rule
+                        break
+                if matched_rule:
+                    await cls.apply_rule(db, txn, matched_rule)
+                    applied += 1
+                else:
+                    skipped += 1
+
+            scanned += len(rows)
+            offset += len(rows)
+            if len(rows) < batch_limit:
+                break
+
+        if scanned >= max_transactions:
+            # Check whether more uncategorized rows exist beyond the scan window.
+            tail_q = (
+                select(func.count())
+                .select_from(BudgetTransaction)
+                .where(
+                    and_(
+                        BudgetTransaction.family_id == family_id,
+                        BudgetTransaction.category_id.is_(None),
+                        BudgetTransaction.deleted_at.is_(None),
+                    )
+                )
+            )
+            total = (await db.execute(tail_q)).scalar_one()
+            truncated = total > scanned
 
         await db.commit()
-        return {"applied": applied, "skipped": skipped}
+        return {
+            "applied": applied,
+            "skipped": skipped,
+            "scanned": scanned,
+            "truncated": truncated,
+        }
 
     @classmethod
     async def suggest_new_rules(

--- a/backend/app/services/budget/category_service.py
+++ b/backend/app/services/budget/category_service.py
@@ -18,7 +18,7 @@ from app.schemas.budget import (
     CategoryUpdate,
 )
 from app.services.base_service import BaseFamilyService
-from app.core.exceptions import NotFoundException
+from app.core.exceptions import NotFoundException, ValidationError
 
 
 class CategoryGroupService(BaseFamilyService[BudgetCategoryGroup]):
@@ -200,6 +200,36 @@ class CategoryService(BaseFamilyService[BudgetCategory]):
             await CategoryGroupService.get_by_id(db, update_data["group_id"], family_id)
 
         return await cls.update_by_id(db, category_id, family_id, update_data)
+
+    @classmethod
+    async def list_for_family(
+        cls,
+        db: AsyncSession,
+        family_id: UUID,
+        include_hidden: bool = False,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+    ) -> List[BudgetCategory]:
+        """List categories with the hidden filter applied at the SQL level so
+        pagination is stable. The base class list_by_family ignores hidden.
+        """
+        query = (
+            select(BudgetCategory)
+            .where(
+                and_(
+                    BudgetCategory.family_id == family_id,
+                    BudgetCategory.deleted_at.is_(None),
+                )
+            )
+            .order_by(BudgetCategory.sort_order, BudgetCategory.name)
+        )
+        if not include_hidden:
+            query = query.where(BudgetCategory.hidden == False)
+        if limit is not None:
+            query = query.limit(limit)
+        if offset:
+            query = query.offset(offset)
+        return list((await db.execute(query)).scalars().all())
 
     @classmethod
     async def list_by_group(
@@ -505,6 +535,11 @@ class CategoryService(BaseFamilyService[BudgetCategory]):
 
         Returns {deleted_name, reassigned_count}.
         """
+        if reassign_to_id is not None and reassign_to_id == category_id:
+            raise ValidationError(
+                "reassign_to_id must differ from the category being deleted"
+            )
+
         category = await cls.get_by_id(db, category_id, family_id)
         if reassign_to_id:
             await cls.get_by_id(db, reassign_to_id, family_id)

--- a/backend/app/services/budget/category_service.py
+++ b/backend/app/services/budget/category_service.py
@@ -5,11 +5,11 @@ Business logic for budget category groups and categories.
 """
 
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select, and_
+from sqlalchemy import select, and_, update as sql_update
 from typing import List, Optional
 from uuid import UUID
 
-from app.models.budget import BudgetCategoryGroup, BudgetCategory
+from app.models.budget import BudgetCategoryGroup, BudgetCategory, BudgetTransaction
 from app.schemas.budget import (
     CategoryGroupCreate,
     CategoryGroupUpdate,
@@ -490,3 +490,48 @@ class CategoryService(BaseFamilyService[BudgetCategory]):
 
         await db.commit()
         return updated_group
+
+    @classmethod
+    async def delete_with_reassign(
+        cls,
+        db: AsyncSession,
+        category_id: UUID,
+        family_id: UUID,
+        reassign_to_id: Optional[UUID] = None,
+    ) -> dict:
+        """Hard-delete a category. Reassign txns to reassign_to_id, or NULL.
+
+        Returns {deleted_name, reassigned_count}.
+        """
+        category = await cls.get_by_id(db, category_id, family_id)
+        if reassign_to_id:
+            await cls.get_by_id(db, reassign_to_id, family_id)
+
+        # Count transactions before reassignment
+        count_q = select(BudgetTransaction).where(
+            and_(
+                BudgetTransaction.family_id == family_id,
+                BudgetTransaction.category_id == category_id,
+            )
+        )
+        reassigned_count = len(list((await db.execute(count_q)).scalars().all()))
+
+        await db.execute(
+            sql_update(BudgetTransaction)
+            .where(
+                and_(
+                    BudgetTransaction.family_id == family_id,
+                    BudgetTransaction.category_id == category_id,
+                )
+            )
+            .values(category_id=reassign_to_id)
+        )
+
+        deleted_name = category.name
+        await db.delete(category)
+        await db.commit()
+
+        return {
+            "deleted_name": deleted_name,
+            "reassigned_count": reassigned_count,
+        }

--- a/backend/app/services/budget/category_service.py
+++ b/backend/app/services/budget/category_service.py
@@ -105,7 +105,10 @@ class CategoryGroupService(BaseFamilyService[BudgetCategoryGroup]):
 
         query = (
             select(BudgetCategoryGroup)
-            .where(BudgetCategoryGroup.family_id == family_id)
+            .where(
+                BudgetCategoryGroup.family_id == family_id,
+                BudgetCategoryGroup.deleted_at.is_(None),
+            )
             .options(selectinload(BudgetCategoryGroup.categories))
             .order_by(BudgetCategoryGroup.sort_order, BudgetCategoryGroup.name)
         )
@@ -116,10 +119,9 @@ class CategoryGroupService(BaseFamilyService[BudgetCategoryGroup]):
         result = await db.execute(query)
         groups = list(result.scalars().all())
 
-        # Filter hidden categories if needed
-        if not include_hidden:
-            for group in groups:
-                group.categories = [c for c in group.categories if not c.hidden]
+        # Filter hidden + soft-deleted categories
+        for group in groups:
+            group.categories = [c for c in group.categories if c.deleted_at is None and (include_hidden or not c.hidden)]
 
         return groups
 
@@ -205,6 +207,8 @@ class CategoryService(BaseFamilyService[BudgetCategory]):
         group_id: UUID,
         family_id: UUID,
         include_hidden: bool = False,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
     ) -> List[BudgetCategory]:
         """
         List all categories in a group.
@@ -230,6 +234,7 @@ class CategoryService(BaseFamilyService[BudgetCategory]):
                 and_(
                     BudgetCategory.family_id == family_id,
                     BudgetCategory.group_id == group_id,
+                    BudgetCategory.deleted_at.is_(None),
                 )
             )
             .order_by(BudgetCategory.sort_order, BudgetCategory.name)
@@ -237,6 +242,10 @@ class CategoryService(BaseFamilyService[BudgetCategory]):
 
         if not include_hidden:
             query = query.where(BudgetCategory.hidden == False)
+        if limit is not None:
+            query = query.limit(limit)
+        if offset:
+            query = query.offset(offset)
 
         result = await db.execute(query)
         return list(result.scalars().all())
@@ -270,6 +279,7 @@ class CategoryService(BaseFamilyService[BudgetCategory]):
                 and_(
                     BudgetCategory.id == category_id,
                     BudgetCategory.family_id == family_id,
+                    BudgetCategory.deleted_at.is_(None),
                 )
             )
             .options(selectinload(BudgetCategory.group))
@@ -372,6 +382,7 @@ class CategoryService(BaseFamilyService[BudgetCategory]):
                     BudgetCategory.family_id == family_id,
                     BudgetCategory.group_id == group_id,
                     BudgetCategory.hidden == True,
+                    BudgetCategory.deleted_at.is_(None),
                 )
             )
             .order_by(BudgetCategory.sort_order, BudgetCategory.name)
@@ -416,6 +427,7 @@ class CategoryService(BaseFamilyService[BudgetCategory]):
                 and_(
                     BudgetCategory.family_id == family_id,
                     BudgetCategory.group_id == group_id,
+                    BudgetCategory.deleted_at.is_(None),
                 )
             )
         )
@@ -465,6 +477,7 @@ class CategoryService(BaseFamilyService[BudgetCategory]):
                 and_(
                     BudgetCategory.family_id == family_id,
                     BudgetCategory.group_id == group_id,
+                    BudgetCategory.deleted_at.is_(None),
                 )
             )
         )

--- a/backend/app/services/budget/category_service.py
+++ b/backend/app/services/budget/category_service.py
@@ -5,9 +5,10 @@ Business logic for budget category groups and categories.
 """
 
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select, and_, update as sql_update
+from sqlalchemy import select, and_, func, update as sql_update
 from typing import List, Optional
 from uuid import UUID
+from datetime import datetime, timezone
 
 from app.models.budget import BudgetCategoryGroup, BudgetCategory, BudgetTransaction
 from app.schemas.budget import (
@@ -498,8 +499,9 @@ class CategoryService(BaseFamilyService[BudgetCategory]):
         category_id: UUID,
         family_id: UUID,
         reassign_to_id: Optional[UUID] = None,
+        deleted_by_id: Optional[UUID] = None,
     ) -> dict:
-        """Hard-delete a category. Reassign txns to reassign_to_id, or NULL.
+        """Soft-delete a category. Reassign txns to reassign_to_id, or NULL.
 
         Returns {deleted_name, reassigned_count}.
         """
@@ -507,14 +509,17 @@ class CategoryService(BaseFamilyService[BudgetCategory]):
         if reassign_to_id:
             await cls.get_by_id(db, reassign_to_id, family_id)
 
-        # Count transactions before reassignment
-        count_q = select(BudgetTransaction).where(
-            and_(
-                BudgetTransaction.family_id == family_id,
-                BudgetTransaction.category_id == category_id,
+        count_q = (
+            select(func.count())
+            .select_from(BudgetTransaction)
+            .where(
+                and_(
+                    BudgetTransaction.family_id == family_id,
+                    BudgetTransaction.category_id == category_id,
+                )
             )
         )
-        reassigned_count = len(list((await db.execute(count_q)).scalars().all()))
+        reassigned_count = (await db.execute(count_q)).scalar_one()
 
         await db.execute(
             sql_update(BudgetTransaction)
@@ -528,7 +533,9 @@ class CategoryService(BaseFamilyService[BudgetCategory]):
         )
 
         deleted_name = category.name
-        await db.delete(category)
+        category.deleted_at = datetime.now(timezone.utc)
+        if deleted_by_id:
+            category.deleted_by_id = deleted_by_id
         await db.commit()
 
         return {

--- a/backend/app/services/budget/csv_import_service.py
+++ b/backend/app/services/budget/csv_import_service.py
@@ -352,6 +352,7 @@ class CSVImportService:
                     BudgetTransaction.date == date_val,
                     BudgetTransaction.amount == amount_val,
                     BudgetTransaction.imported_id == description,
+                    BudgetTransaction.deleted_at.is_(None),
                 )
                 result_set = await db.execute(stmt)
                 existing = result_set.scalars().first()
@@ -390,6 +391,7 @@ class CSVImportService:
                     stmt = select(BudgetCategory).where(
                         BudgetCategory.family_id == family_id,
                         BudgetCategory.name == category_name,
+                        BudgetCategory.deleted_at.is_(None),
                     )
                     cat_result = await db.execute(stmt)
                     category = cat_result.scalars().first()

--- a/backend/app/services/budget/export_service.py
+++ b/backend/app/services/budget/export_service.py
@@ -59,17 +59,26 @@ class ExportService:
         Returns:
             ZIP file bytes containing budget_data.json and metadata.json.
         """
-        # Query all budget entities
+        # Query all budget entities (excludes soft-deleted rows)
         accounts = (await db.execute(
-            select(BudgetAccount).where(BudgetAccount.family_id == family_id)
+            select(BudgetAccount).where(
+                BudgetAccount.family_id == family_id,
+                BudgetAccount.deleted_at.is_(None),
+            )
         )).scalars().all()
 
         category_groups = (await db.execute(
-            select(BudgetCategoryGroup).where(BudgetCategoryGroup.family_id == family_id)
+            select(BudgetCategoryGroup).where(
+                BudgetCategoryGroup.family_id == family_id,
+                BudgetCategoryGroup.deleted_at.is_(None),
+            )
         )).scalars().all()
 
         categories = (await db.execute(
-            select(BudgetCategory).where(BudgetCategory.family_id == family_id)
+            select(BudgetCategory).where(
+                BudgetCategory.family_id == family_id,
+                BudgetCategory.deleted_at.is_(None),
+            )
         )).scalars().all()
 
         payees = (await db.execute(
@@ -77,7 +86,10 @@ class ExportService:
         )).scalars().all()
 
         transactions = (await db.execute(
-            select(BudgetTransaction).where(BudgetTransaction.family_id == family_id)
+            select(BudgetTransaction).where(
+                BudgetTransaction.family_id == family_id,
+                BudgetTransaction.deleted_at.is_(None),
+            )
         )).scalars().all()
 
         allocations = (await db.execute(

--- a/backend/app/services/budget/file_import_service.py
+++ b/backend/app/services/budget/file_import_service.py
@@ -360,6 +360,7 @@ async def import_file_transactions(
                     BudgetTransaction.family_id == family_id,
                     BudgetTransaction.account_id == account_id,
                     BudgetTransaction.imported_id == txn.imported_id,
+                    BudgetTransaction.deleted_at.is_(None),
                 )
                 result = await db.execute(stmt)
                 if result.scalars().first():

--- a/backend/app/services/budget/goal_service.py
+++ b/backend/app/services/budget/goal_service.py
@@ -107,6 +107,8 @@ class GoalService(BaseFamilyService[BudgetGoal]):
         category_id: UUID,
         family_id: UUID,
         active_only: bool = True,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
     ) -> List[BudgetGoal]:
         """
         List all goals for a specific category.
@@ -141,6 +143,10 @@ class GoalService(BaseFamilyService[BudgetGoal]):
 
         if active_only:
             query = query.where(BudgetGoal.is_active == True)
+        if limit is not None:
+            query = query.limit(limit)
+        if offset:
+            query = query.offset(offset)
 
         result = await db.execute(query)
         return list(result.scalars().all())
@@ -151,6 +157,8 @@ class GoalService(BaseFamilyService[BudgetGoal]):
         db: AsyncSession,
         family_id: UUID,
         target_date: Optional[date] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
     ) -> List[BudgetGoal]:
         """
         List all active goals for a family.
@@ -188,6 +196,10 @@ class GoalService(BaseFamilyService[BudgetGoal]):
                 BudgetGoal.end_date >= target_date,
             )
         )
+        if limit is not None:
+            query = query.limit(limit)
+        if offset:
+            query = query.offset(offset)
 
         result = await db.execute(query)
         return list(result.scalars().all())

--- a/backend/app/services/budget/month_locking_service.py
+++ b/backend/app/services/budget/month_locking_service.py
@@ -5,7 +5,7 @@ Business logic for month closing/locking operations.
 Prevents edits to past closed months for data integrity.
 """
 
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, and_, func
 from typing import List, Optional
@@ -58,8 +58,8 @@ class MonthLockingService(BaseFamilyService[BudgetAllocation]):
                 f"No allocations found for family {family_id} in month {month}"
             )
 
-        # Close all allocations for this month
-        closed_at = datetime.utcnow()
+        # Close all allocations for this month (timezone-aware UTC)
+        closed_at = datetime.now(timezone.utc)
         for allocation in allocations:
             allocation.closed_at = closed_at
 

--- a/backend/app/services/budget/payee_service.py
+++ b/backend/app/services/budget/payee_service.py
@@ -195,3 +195,83 @@ class PayeeService(BaseFamilyService[BudgetPayee]):
         await db.commit()
         await db.refresh(target)
         return target
+
+    @classmethod
+    async def merge_payees(
+        cls,
+        db: AsyncSession,
+        family_id: UUID,
+        source_id: UUID,
+        target_id: UUID,
+    ) -> dict:
+        """Merge a single source payee into target. Returns merge stats."""
+        if source_id == target_id:
+            raise ValidationException("source and target must differ")
+
+        source = await cls.get_by_id(db, source_id, family_id)
+        target = await cls.get_by_id(db, target_id, family_id)
+
+        # Count source transactions before reassignment
+        count_q = select(BudgetTransaction).where(
+            and_(
+                BudgetTransaction.family_id == family_id,
+                BudgetTransaction.payee_id == source_id,
+            )
+        )
+        merged_count = len(list((await db.execute(count_q)).scalars().all()))
+
+        await db.execute(
+            sql_update(BudgetTransaction)
+            .where(
+                and_(
+                    BudgetTransaction.family_id == family_id,
+                    BudgetTransaction.payee_id == source_id,
+                )
+            )
+            .values(payee_id=target_id)
+        )
+
+        await db.execute(
+            sql_update(BudgetRecurringTransaction)
+            .where(
+                and_(
+                    BudgetRecurringTransaction.family_id == family_id,
+                    BudgetRecurringTransaction.payee_id == source_id,
+                )
+            )
+            .values(payee_id=target_id)
+        )
+
+        source_name = source.name
+        target_name = target.name
+        await db.delete(source)
+        await db.commit()
+
+        return {
+            "merged_count": merged_count,
+            "source_name": source_name,
+            "target_name": target_name,
+        }
+
+    @classmethod
+    async def get_last_category(
+        cls,
+        db: AsyncSession,
+        payee_id: UUID,
+        family_id: UUID,
+    ) -> Optional[UUID]:
+        """Return category_id of the most recent transaction for payee, or None."""
+        query = (
+            select(BudgetTransaction.category_id)
+            .where(
+                and_(
+                    BudgetTransaction.family_id == family_id,
+                    BudgetTransaction.payee_id == payee_id,
+                    BudgetTransaction.deleted_at.is_(None),
+                )
+            )
+            .order_by(BudgetTransaction.date.desc(), BudgetTransaction.created_at.desc())
+            .limit(1)
+        )
+        result = await db.execute(query)
+        return result.scalar_one_or_none()

--- a/backend/app/services/budget/payee_service.py
+++ b/backend/app/services/budget/payee_service.py
@@ -5,7 +5,7 @@ Business logic for budget payee operations.
 """
 
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select, and_, update as sql_update
+from sqlalchemy import select, and_, func, update as sql_update
 from typing import List, Optional
 from uuid import UUID
 
@@ -212,13 +212,17 @@ class PayeeService(BaseFamilyService[BudgetPayee]):
         target = await cls.get_by_id(db, target_id, family_id)
 
         # Count source transactions before reassignment
-        count_q = select(BudgetTransaction).where(
-            and_(
-                BudgetTransaction.family_id == family_id,
-                BudgetTransaction.payee_id == source_id,
+        count_q = (
+            select(func.count())
+            .select_from(BudgetTransaction)
+            .where(
+                and_(
+                    BudgetTransaction.family_id == family_id,
+                    BudgetTransaction.payee_id == source_id,
+                )
             )
         )
-        merged_count = len(list((await db.execute(count_q)).scalars().all()))
+        merged_count = (await db.execute(count_q)).scalar_one()
 
         await db.execute(
             sql_update(BudgetTransaction)

--- a/backend/app/services/budget/payee_service.py
+++ b/backend/app/services/budget/payee_service.py
@@ -101,6 +101,8 @@ class PayeeService(BaseFamilyService[BudgetPayee]):
         db: AsyncSession,
         family_id: UUID,
         favorites_only: bool = False,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
     ) -> List[BudgetPayee]:
         """
         List payees for a family with optional favorite filter.
@@ -109,6 +111,8 @@ class PayeeService(BaseFamilyService[BudgetPayee]):
             db: Database session
             family_id: Family ID
             favorites_only: If True, only return favorite payees
+            limit: Max results
+            offset: Pagination offset
 
         Returns:
             List of payees
@@ -117,6 +121,10 @@ class PayeeService(BaseFamilyService[BudgetPayee]):
         if favorites_only:
             query = query.where(BudgetPayee.is_favorite == True)
         query = query.order_by(BudgetPayee.created_at.desc())
+        if limit is not None:
+            query = query.limit(limit)
+        if offset:
+            query = query.offset(offset)
         result = await db.execute(query)
         return list(result.scalars().all())
 

--- a/backend/app/services/budget/recurring_transaction_service.py
+++ b/backend/app/services/budget/recurring_transaction_service.py
@@ -170,6 +170,8 @@ class RecurringTransactionService(BaseFamilyService[BudgetRecurringTransaction])
         account_id: UUID,
         family_id: UUID,
         active_only: bool = True,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
     ) -> List[BudgetRecurringTransaction]:
         """
         List all recurring transactions for a specific account.
@@ -196,6 +198,35 @@ class RecurringTransactionService(BaseFamilyService[BudgetRecurringTransaction])
 
         if active_only:
             query = query.where(BudgetRecurringTransaction.is_active == True)
+        if limit is not None:
+            query = query.limit(limit)
+        if offset:
+            query = query.offset(offset)
+
+        result = await db.execute(query)
+        return list(result.scalars().all())
+
+    @classmethod
+    async def list_by_family_filtered(
+        cls,
+        db: AsyncSession,
+        family_id: UUID,
+        active_only: bool = False,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+    ) -> List[BudgetRecurringTransaction]:
+        """List family recurring transactions with optional active filter at SQL level."""
+        query = (
+            select(BudgetRecurringTransaction)
+            .where(BudgetRecurringTransaction.family_id == family_id)
+            .order_by(BudgetRecurringTransaction.created_at.desc())
+        )
+        if active_only:
+            query = query.where(BudgetRecurringTransaction.is_active == True)
+        if limit is not None:
+            query = query.limit(limit)
+        if offset:
+            query = query.offset(offset)
 
         result = await db.execute(query)
         return list(result.scalars().all())

--- a/backend/app/services/budget/recurring_transaction_service.py
+++ b/backend/app/services/budget/recurring_transaction_service.py
@@ -504,3 +504,36 @@ class RecurringTransactionService(BaseFamilyService[BudgetRecurringTransaction])
         await db.commit()
         await db.refresh(transaction)
         return transaction
+
+    @classmethod
+    async def post_all_due(
+        cls,
+        db: AsyncSession,
+        family_id: UUID,
+        as_of_date: Optional[date] = None,
+    ) -> dict:
+        """Post all active recurring transactions due on or before as_of_date.
+
+        Returns {posted, transactions: [{recurring_id, recurring_name, amount, date,
+        transaction_id}]}.
+        """
+        if as_of_date is None:
+            as_of_date = date.today()
+
+        due = await cls.list_due_for_posting(db, family_id, as_of_date)
+
+        posted_info = []
+        for recurring in due:
+            txn = await cls.post_transaction(db, recurring.id, family_id, as_of_date)
+            posted_info.append({
+                "recurring_id": str(recurring.id),
+                "recurring_name": recurring.name,
+                "amount": txn.amount,
+                "date": str(txn.date),
+                "transaction_id": str(txn.id),
+            })
+
+        return {
+            "posted": len(posted_info),
+            "transactions": posted_info,
+        }

--- a/backend/app/services/budget/report_service.py
+++ b/backend/app/services/budget/report_service.py
@@ -83,6 +83,7 @@ class ReportService:
                     BudgetTransaction.date >= start_date,
                     BudgetTransaction.date <= end_date,
                     BudgetTransaction.category_id.isnot(None),
+                    BudgetTransaction.deleted_at.is_(None),
                 )
             )
             .group_by(BudgetCategory.id, BudgetCategory.name, BudgetCategoryGroup.name)
@@ -141,6 +142,7 @@ class ReportService:
                     BudgetTransaction.date >= start_date,
                     BudgetTransaction.date <= end_date,
                     BudgetTransaction.category_id.isnot(None),
+                    BudgetTransaction.deleted_at.is_(None),
                 )
             )
             .group_by(BudgetCategoryGroup.id, BudgetCategoryGroup.name)
@@ -194,6 +196,7 @@ class ReportService:
                     BudgetTransaction.family_id == family_id,
                     BudgetTransaction.date >= start_date,
                     BudgetTransaction.date <= end_date,
+                    BudgetTransaction.deleted_at.is_(None),
                 )
             )
             .group_by('month')
@@ -251,6 +254,7 @@ class ReportService:
                     BudgetTransaction.date >= start_date,
                     BudgetTransaction.date <= end_date,
                     BudgetTransaction.payee_id.isnot(None),
+                    BudgetTransaction.deleted_at.is_(None),
                 )
             )
             .group_by(BudgetPayee.id, BudgetPayee.name)
@@ -328,6 +332,7 @@ class ReportService:
                     BudgetTransaction.family_id == family_id,
                     BudgetTransaction.date >= start_date,
                     BudgetTransaction.date <= end_date,
+                    BudgetTransaction.deleted_at.is_(None),
                 )
             )
             .group_by('period')

--- a/backend/app/services/budget/report_service.py
+++ b/backend/app/services/budget/report_service.py
@@ -448,3 +448,165 @@ class ReportService:
             "net_worth": net_worth,
             "net_worth_currency": net_worth / 100,
         }
+
+    @classmethod
+    async def get_net_worth_history(
+        cls,
+        db: AsyncSession,
+        family_id: UUID,
+        months: int = 12,
+    ) -> Dict:
+        """Net worth at end of each of the last N months.
+
+        Excludes closed accounts. Returns {series, months, current_net_worth,
+        current_net_worth_currency}.
+        """
+        from dateutil.relativedelta import relativedelta
+        from app.services.budget.account_service import AccountService
+
+        accounts = await AccountService.list_by_family(db, family_id)
+        open_accounts = [a for a in accounts if not a.closed]
+
+        if not open_accounts:
+            return {
+                "series": [],
+                "months": months,
+                "current_net_worth": 0,
+                "current_net_worth_currency": 0.0,
+            }
+
+        today = date.today()
+        # First day of current month, then walk back
+        current_month = date(today.year, today.month, 1)
+        month_starts = [current_month - relativedelta(months=i) for i in range(months - 1, -1, -1)]
+
+        series = []
+        for ms in month_starts:
+            # End of month for cumulative balance
+            end_of_month = (ms + relativedelta(months=1)) - timedelta(days=1)
+            net_worth = 0
+            for acct in open_accounts:
+                bal = await AccountService.get_balance(db, acct.id, family_id, end_of_month)
+                net_worth += bal["balance"]
+            series.append({
+                "month": ms.strftime("%Y-%m"),
+                "net_worth": net_worth,
+                "net_worth_currency": net_worth / 100,
+            })
+
+        current = series[-1]["net_worth"] if series else 0
+        return {
+            "series": series,
+            "months": months,
+            "current_net_worth": current,
+            "current_net_worth_currency": current / 100,
+        }
+
+    @classmethod
+    async def get_budget_vs_actual(
+        cls,
+        db: AsyncSession,
+        family_id: UUID,
+        month: date,
+    ) -> Dict:
+        """Budgeted vs actual spending per category for a month (expense groups only).
+
+        Returns {month, groups: [{group_name, categories: [{category_name, budgeted,
+        actual, variance, pct_used}]}], totals: {budgeted, actual, variance}}.
+        actual is reported as the absolute value of expense activity.
+        pct_used is None when budgeted == 0.
+        """
+        from app.models.budget import BudgetAllocation
+
+        # First day of month for allocation lookup; end-of-month for activity range
+        from dateutil.relativedelta import relativedelta
+        end_of_month = (month + relativedelta(months=1)) - timedelta(days=1)
+
+        # Expense groups + categories (non-deleted)
+        group_q = (
+            select(BudgetCategoryGroup)
+            .where(
+                and_(
+                    BudgetCategoryGroup.family_id == family_id,
+                    BudgetCategoryGroup.is_income == False,
+                    BudgetCategoryGroup.deleted_at.is_(None),
+                )
+            )
+            .order_by(BudgetCategoryGroup.sort_order, BudgetCategoryGroup.name)
+        )
+        groups = list((await db.execute(group_q)).scalars().all())
+
+        result_groups = []
+        total_budgeted = 0
+        total_actual = 0
+
+        for grp in groups:
+            cat_q = (
+                select(BudgetCategory)
+                .where(
+                    and_(
+                        BudgetCategory.family_id == family_id,
+                        BudgetCategory.group_id == grp.id,
+                        BudgetCategory.deleted_at.is_(None),
+                        BudgetCategory.hidden == False,
+                    )
+                )
+                .order_by(BudgetCategory.sort_order, BudgetCategory.name)
+            )
+            cats = list((await db.execute(cat_q)).scalars().all())
+
+            cat_entries = []
+            for cat in cats:
+                # Budgeted
+                alloc_q = select(BudgetAllocation.budgeted_amount).where(
+                    and_(
+                        BudgetAllocation.family_id == family_id,
+                        BudgetAllocation.category_id == cat.id,
+                        BudgetAllocation.month == month,
+                    )
+                )
+                budgeted = (await db.execute(alloc_q)).scalar_one_or_none() or 0
+
+                # Actual = abs(sum(activity)) over month
+                act_q = select(func.coalesce(func.sum(BudgetTransaction.amount), 0)).where(
+                    and_(
+                        BudgetTransaction.family_id == family_id,
+                        BudgetTransaction.category_id == cat.id,
+                        BudgetTransaction.date >= month,
+                        BudgetTransaction.date <= end_of_month,
+                        BudgetTransaction.deleted_at.is_(None),
+                    )
+                )
+                activity = (await db.execute(act_q)).scalar() or 0
+                actual = abs(activity)
+
+                variance = budgeted - actual
+                pct_used = None if budgeted == 0 else round(actual / budgeted * 100, 2)
+
+                cat_entries.append({
+                    "category_id": str(cat.id),
+                    "category_name": cat.name,
+                    "budgeted": budgeted,
+                    "actual": actual,
+                    "variance": variance,
+                    "pct_used": pct_used,
+                })
+                total_budgeted += budgeted
+                total_actual += actual
+
+            if cat_entries:
+                result_groups.append({
+                    "group_id": str(grp.id),
+                    "group_name": grp.name,
+                    "categories": cat_entries,
+                })
+
+        return {
+            "month": month.isoformat(),
+            "groups": result_groups,
+            "totals": {
+                "budgeted": total_budgeted,
+                "actual": total_actual,
+                "variance": total_budgeted - total_actual,
+            },
+        }

--- a/backend/app/services/budget/report_service.py
+++ b/backend/app/services/budget/report_service.py
@@ -459,10 +459,12 @@ class ReportService:
         """Net worth at end of each of the last N months.
 
         Excludes closed accounts. Returns {series, months, current_net_worth,
-        current_net_worth_currency}.
+        current_net_worth_currency}. Uses a single grouped query plus an
+        all-time-prior baseline per account to avoid N*M round-trips.
         """
         from dateutil.relativedelta import relativedelta
         from app.services.budget.account_service import AccountService
+        from app.models.budget import BudgetAccount
 
         accounts = await AccountService.list_by_family(db, family_id)
         open_accounts = [a for a in accounts if not a.closed]
@@ -476,18 +478,69 @@ class ReportService:
             }
 
         today = date.today()
-        # First day of current month, then walk back
         current_month = date(today.year, today.month, 1)
-        month_starts = [current_month - relativedelta(months=i) for i in range(months - 1, -1, -1)]
+        month_starts = [
+            current_month - relativedelta(months=i)
+            for i in range(months - 1, -1, -1)
+        ]
+        oldest_month = month_starts[0]
+
+        starting_balance_by_acct = {a.id: a.starting_balance for a in open_accounts}
+        open_account_ids = list(starting_balance_by_acct.keys())
+
+        # Prior-period sum (everything strictly before the oldest displayed month)
+        prior_q = (
+            select(
+                BudgetTransaction.account_id,
+                func.coalesce(func.sum(BudgetTransaction.amount), 0).label("amt"),
+            )
+            .where(
+                and_(
+                    BudgetTransaction.family_id == family_id,
+                    BudgetTransaction.account_id.in_(open_account_ids),
+                    BudgetTransaction.date < oldest_month,
+                    BudgetTransaction.deleted_at.is_(None),
+                )
+            )
+            .group_by(BudgetTransaction.account_id)
+        )
+        prior_by_acct: dict = {row.account_id: row.amt for row in (await db.execute(prior_q)).all()}
+
+        # Per-month activity per account, single query
+        month_col = func.date_trunc("month", BudgetTransaction.date).label("month")
+        period_q = (
+            select(
+                BudgetTransaction.account_id,
+                month_col,
+                func.coalesce(func.sum(BudgetTransaction.amount), 0).label("amt"),
+            )
+            .where(
+                and_(
+                    BudgetTransaction.family_id == family_id,
+                    BudgetTransaction.account_id.in_(open_account_ids),
+                    BudgetTransaction.date >= oldest_month,
+                    BudgetTransaction.date <= (current_month + relativedelta(months=1)) - timedelta(days=1),
+                    BudgetTransaction.deleted_at.is_(None),
+                )
+            )
+            .group_by(BudgetTransaction.account_id, month_col)
+        )
+        activity: dict = {}
+        for row in (await db.execute(period_q)).all():
+            month_key = row.month.date() if hasattr(row.month, "date") else row.month
+            activity[(row.account_id, date(month_key.year, month_key.month, 1))] = row.amt
+
+        running = {
+            acct_id: starting_balance_by_acct[acct_id] + prior_by_acct.get(acct_id, 0)
+            for acct_id in open_account_ids
+        }
 
         series = []
         for ms in month_starts:
-            # End of month for cumulative balance
-            end_of_month = (ms + relativedelta(months=1)) - timedelta(days=1)
             net_worth = 0
-            for acct in open_accounts:
-                bal = await AccountService.get_balance(db, acct.id, family_id, end_of_month)
-                net_worth += bal["balance"]
+            for acct_id in open_account_ids:
+                running[acct_id] += activity.get((acct_id, ms), 0)
+                net_worth += running[acct_id]
             series.append({
                 "month": ms.strftime("%Y-%m"),
                 "net_worth": net_worth,
@@ -517,89 +570,100 @@ class ReportService:
         pct_used is None when budgeted == 0.
         """
         from app.models.budget import BudgetAllocation
-
-        # First day of month for allocation lookup; end-of-month for activity range
         from dateutil.relativedelta import relativedelta
         end_of_month = (month + relativedelta(months=1)) - timedelta(days=1)
 
-        # Expense groups + categories (non-deleted)
-        group_q = (
-            select(BudgetCategoryGroup)
+        # Single query: pull all expense groups + visible non-deleted categories
+        cat_q = (
+            select(BudgetCategoryGroup, BudgetCategory)
+            .join(BudgetCategory, BudgetCategory.group_id == BudgetCategoryGroup.id)
             .where(
                 and_(
                     BudgetCategoryGroup.family_id == family_id,
                     BudgetCategoryGroup.is_income == False,
                     BudgetCategoryGroup.deleted_at.is_(None),
+                    BudgetCategory.deleted_at.is_(None),
+                    BudgetCategory.hidden == False,
                 )
             )
-            .order_by(BudgetCategoryGroup.sort_order, BudgetCategoryGroup.name)
+            .order_by(
+                BudgetCategoryGroup.sort_order, BudgetCategoryGroup.name,
+                BudgetCategory.sort_order, BudgetCategory.name,
+            )
         )
-        groups = list((await db.execute(group_q)).scalars().all())
+        rows = (await db.execute(cat_q)).all()
+        if not rows:
+            return {
+                "month": month.isoformat(),
+                "groups": [],
+                "totals": {"budgeted": 0, "actual": 0, "variance": 0},
+            }
 
-        result_groups = []
+        category_ids = [cat.id for _, cat in rows]
+
+        # Allocations for the target month, all categories at once
+        alloc_q = (
+            select(BudgetAllocation.category_id, BudgetAllocation.budgeted_amount)
+            .where(
+                and_(
+                    BudgetAllocation.family_id == family_id,
+                    BudgetAllocation.month == month,
+                    BudgetAllocation.category_id.in_(category_ids),
+                )
+            )
+        )
+        budgeted_by_cat = {cid: amt for cid, amt in (await db.execute(alloc_q)).all()}
+
+        # Activity sum per category over month, single query
+        act_q = (
+            select(
+                BudgetTransaction.category_id,
+                func.coalesce(func.sum(BudgetTransaction.amount), 0).label("amt"),
+            )
+            .where(
+                and_(
+                    BudgetTransaction.family_id == family_id,
+                    BudgetTransaction.category_id.in_(category_ids),
+                    BudgetTransaction.date >= month,
+                    BudgetTransaction.date <= end_of_month,
+                    BudgetTransaction.deleted_at.is_(None),
+                )
+            )
+            .group_by(BudgetTransaction.category_id)
+        )
+        activity_by_cat = {row.category_id: row.amt for row in (await db.execute(act_q)).all()}
+
+        result_groups: list = []
+        current_group_id = None
+        current_entry: dict = {}
         total_budgeted = 0
         total_actual = 0
 
-        for grp in groups:
-            cat_q = (
-                select(BudgetCategory)
-                .where(
-                    and_(
-                        BudgetCategory.family_id == family_id,
-                        BudgetCategory.group_id == grp.id,
-                        BudgetCategory.deleted_at.is_(None),
-                        BudgetCategory.hidden == False,
-                    )
-                )
-                .order_by(BudgetCategory.sort_order, BudgetCategory.name)
-            )
-            cats = list((await db.execute(cat_q)).scalars().all())
+        for grp, cat in rows:
+            budgeted = budgeted_by_cat.get(cat.id, 0)
+            actual = abs(activity_by_cat.get(cat.id, 0))
+            variance = budgeted - actual
+            pct_used = None if budgeted == 0 else round(actual / budgeted * 100, 2)
 
-            cat_entries = []
-            for cat in cats:
-                # Budgeted
-                alloc_q = select(BudgetAllocation.budgeted_amount).where(
-                    and_(
-                        BudgetAllocation.family_id == family_id,
-                        BudgetAllocation.category_id == cat.id,
-                        BudgetAllocation.month == month,
-                    )
-                )
-                budgeted = (await db.execute(alloc_q)).scalar_one_or_none() or 0
-
-                # Actual = abs(sum(activity)) over month
-                act_q = select(func.coalesce(func.sum(BudgetTransaction.amount), 0)).where(
-                    and_(
-                        BudgetTransaction.family_id == family_id,
-                        BudgetTransaction.category_id == cat.id,
-                        BudgetTransaction.date >= month,
-                        BudgetTransaction.date <= end_of_month,
-                        BudgetTransaction.deleted_at.is_(None),
-                    )
-                )
-                activity = (await db.execute(act_q)).scalar() or 0
-                actual = abs(activity)
-
-                variance = budgeted - actual
-                pct_used = None if budgeted == 0 else round(actual / budgeted * 100, 2)
-
-                cat_entries.append({
-                    "category_id": str(cat.id),
-                    "category_name": cat.name,
-                    "budgeted": budgeted,
-                    "actual": actual,
-                    "variance": variance,
-                    "pct_used": pct_used,
-                })
-                total_budgeted += budgeted
-                total_actual += actual
-
-            if cat_entries:
-                result_groups.append({
+            if grp.id != current_group_id:
+                current_entry = {
                     "group_id": str(grp.id),
                     "group_name": grp.name,
-                    "categories": cat_entries,
-                })
+                    "categories": [],
+                }
+                result_groups.append(current_entry)
+                current_group_id = grp.id
+
+            current_entry["categories"].append({
+                "category_id": str(cat.id),
+                "category_name": cat.name,
+                "budgeted": budgeted,
+                "actual": actual,
+                "variance": variance,
+                "pct_used": pct_used,
+            })
+            total_budgeted += budgeted
+            total_actual += actual
 
         return {
             "month": month.isoformat(),

--- a/backend/app/services/budget/report_service.py
+++ b/backend/app/services/budget/report_service.py
@@ -458,18 +458,21 @@ class ReportService:
     ) -> Dict:
         """Net worth at end of each of the last N months.
 
-        Excludes closed accounts. Returns {series, months, current_net_worth,
-        current_net_worth_currency}. Uses a single grouped query plus an
-        all-time-prior baseline per account to avoid N*M round-trips.
+        Includes closed accounts: a closed account that held a balance during
+        the window must still contribute to historical net worth, otherwise
+        the chart spikes/drops on close events. Soft-deleted accounts are
+        excluded via list_by_family. Returns {series, months,
+        current_net_worth, current_net_worth_currency}. Uses a single grouped
+        query plus an all-time-prior baseline per account to avoid N*M
+        round-trips.
         """
         from dateutil.relativedelta import relativedelta
         from app.services.budget.account_service import AccountService
         from app.models.budget import BudgetAccount
 
         accounts = await AccountService.list_by_family(db, family_id)
-        open_accounts = [a for a in accounts if not a.closed]
 
-        if not open_accounts:
+        if not accounts:
             return {
                 "series": [],
                 "months": months,
@@ -485,8 +488,8 @@ class ReportService:
         ]
         oldest_month = month_starts[0]
 
-        starting_balance_by_acct = {a.id: a.starting_balance for a in open_accounts}
-        open_account_ids = list(starting_balance_by_acct.keys())
+        starting_balance_by_acct = {a.id: a.starting_balance for a in accounts}
+        account_ids = list(starting_balance_by_acct.keys())
 
         # Prior-period sum (everything strictly before the oldest displayed month)
         prior_q = (
@@ -497,7 +500,7 @@ class ReportService:
             .where(
                 and_(
                     BudgetTransaction.family_id == family_id,
-                    BudgetTransaction.account_id.in_(open_account_ids),
+                    BudgetTransaction.account_id.in_(account_ids),
                     BudgetTransaction.date < oldest_month,
                     BudgetTransaction.deleted_at.is_(None),
                 )
@@ -517,7 +520,7 @@ class ReportService:
             .where(
                 and_(
                     BudgetTransaction.family_id == family_id,
-                    BudgetTransaction.account_id.in_(open_account_ids),
+                    BudgetTransaction.account_id.in_(account_ids),
                     BudgetTransaction.date >= oldest_month,
                     BudgetTransaction.date <= (current_month + relativedelta(months=1)) - timedelta(days=1),
                     BudgetTransaction.deleted_at.is_(None),
@@ -532,13 +535,13 @@ class ReportService:
 
         running = {
             acct_id: starting_balance_by_acct[acct_id] + prior_by_acct.get(acct_id, 0)
-            for acct_id in open_account_ids
+            for acct_id in account_ids
         }
 
         series = []
         for ms in month_starts:
             net_worth = 0
-            for acct_id in open_account_ids:
+            for acct_id in account_ids:
                 running[acct_id] += activity.get((acct_id, ms), 0)
                 net_worth += running[acct_id]
             series.append({

--- a/backend/app/services/budget/tag_service.py
+++ b/backend/app/services/budget/tag_service.py
@@ -66,6 +66,7 @@ class TagService(BaseFamilyService[BudgetTag]):
                 and_(
                     BudgetTransaction.id == transaction_id,
                     BudgetTransaction.family_id == family_id,
+                    BudgetTransaction.deleted_at.is_(None),
                 )
             )
         )
@@ -121,6 +122,7 @@ class TagService(BaseFamilyService[BudgetTag]):
                 and_(
                     BudgetTransaction.id == transaction_id,
                     BudgetTransaction.family_id == family_id,
+                    BudgetTransaction.deleted_at.is_(None),
                 )
             )
         )

--- a/backend/app/services/budget/transaction_service.py
+++ b/backend/app/services/budget/transaction_service.py
@@ -675,6 +675,20 @@ class TransactionService(BaseFamilyService[BudgetTransaction]):
         if not filtered:
             return 0
 
+        # Coerce string UUIDs and verify FK targets belong to this family.
+        for field in ("category_id", "payee_id"):
+            if field in filtered and filtered[field] is not None:
+                value = filtered[field]
+                if isinstance(value, str):
+                    value = UUID(value)
+                    filtered[field] = value
+                if field == "category_id":
+                    from app.services.budget.category_service import CategoryService
+                    await CategoryService.get_by_id(db, value, family_id)
+                else:
+                    from app.services.budget.payee_service import PayeeService
+                    await PayeeService.get_by_id(db, value, family_id)
+
         query = select(BudgetTransaction).where(
             and_(
                 BudgetTransaction.id.in_(transaction_ids),
@@ -687,8 +701,6 @@ class TransactionService(BaseFamilyService[BudgetTransaction]):
 
         for txn in rows:
             for field, value in filtered.items():
-                if field.endswith("_id") and isinstance(value, str):
-                    value = UUID(value)
                 setattr(txn, field, value)
 
         await db.commit()
@@ -769,10 +781,15 @@ class TransactionService(BaseFamilyService[BudgetTransaction]):
         adjustment_amount = statement_balance - cleared_total
         adjustment_id = None
         if adjustment_amount != 0:
+            today = date.today()
+            from app.services.budget.month_locking_service import MonthLockingService
+            await MonthLockingService.validate_month_not_closed(
+                db, family_id, date(today.year, today.month, 1)
+            )
             adj = BudgetTransaction(
                 family_id=family_id,
                 account_id=account_id,
-                date=date.today(),
+                date=today,
                 amount=adjustment_amount,
                 notes="Ajuste de Conciliación",
                 cleared=True,

--- a/backend/app/services/budget/transaction_service.py
+++ b/backend/app/services/budget/transaction_service.py
@@ -189,6 +189,7 @@ class TransactionService(BaseFamilyService[BudgetTransaction]):
                 and_(
                     BudgetTransaction.family_id == family_id,
                     BudgetTransaction.account_id == account_id,
+                    BudgetTransaction.deleted_at.is_(None),
                 )
             )
             .order_by(BudgetTransaction.date.desc(), BudgetTransaction.created_at.desc())
@@ -238,6 +239,7 @@ class TransactionService(BaseFamilyService[BudgetTransaction]):
                 and_(
                     BudgetTransaction.family_id == family_id,
                     BudgetTransaction.category_id == category_id,
+                    BudgetTransaction.deleted_at.is_(None),
                 )
             )
             .order_by(BudgetTransaction.date.desc())
@@ -281,6 +283,7 @@ class TransactionService(BaseFamilyService[BudgetTransaction]):
                 and_(
                     BudgetTransaction.family_id == family_id,
                     BudgetTransaction.account_id == account_id,
+                    BudgetTransaction.deleted_at.is_(None),
                 )
             )
         )
@@ -331,6 +334,7 @@ class TransactionService(BaseFamilyService[BudgetTransaction]):
                     BudgetTransaction.category_id == category_id,
                     BudgetTransaction.date >= month,
                     BudgetTransaction.date <= end_of_month,
+                    BudgetTransaction.deleted_at.is_(None),
                 )
             )
         )
@@ -404,6 +408,7 @@ class TransactionService(BaseFamilyService[BudgetTransaction]):
                     BudgetTransaction.id.in_(transaction_ids),
                     BudgetTransaction.account_id == account_id,
                     BudgetTransaction.family_id == family_id,
+                    BudgetTransaction.deleted_at.is_(None),
                 )
             )
         )

--- a/backend/app/services/budget/transaction_service.py
+++ b/backend/app/services/budget/transaction_service.py
@@ -675,19 +675,22 @@ class TransactionService(BaseFamilyService[BudgetTransaction]):
         if not filtered:
             return 0
 
-        # Coerce string UUIDs and verify FK targets belong to this family.
+        # Phase 1: coerce all string UUIDs up front so the dict is fully
+        # normalised before any DB call. Otherwise a validation failure on
+        # field N could leave field N-1 already mutated in-place.
         for field in ("category_id", "payee_id"):
-            if field in filtered and filtered[field] is not None:
-                value = filtered[field]
-                if isinstance(value, str):
-                    value = UUID(value)
-                    filtered[field] = value
-                if field == "category_id":
-                    from app.services.budget.category_service import CategoryService
-                    await CategoryService.get_by_id(db, value, family_id)
-                else:
-                    from app.services.budget.payee_service import PayeeService
-                    await PayeeService.get_by_id(db, value, family_id)
+            value = filtered.get(field)
+            if value is not None and isinstance(value, str):
+                filtered[field] = UUID(value)
+
+        # Phase 2: verify FK targets belong to this family. Either both pass
+        # or we raise before any transaction is mutated.
+        if filtered.get("category_id") is not None:
+            from app.services.budget.category_service import CategoryService
+            await CategoryService.get_by_id(db, filtered["category_id"], family_id)
+        if filtered.get("payee_id") is not None:
+            from app.services.budget.payee_service import PayeeService
+            await PayeeService.get_by_id(db, filtered["payee_id"], family_id)
 
         query = select(BudgetTransaction).where(
             and_(

--- a/backend/app/services/budget/transaction_service.py
+++ b/backend/app/services/budget/transaction_service.py
@@ -11,7 +11,7 @@ from datetime import date
 from uuid import UUID
 
 from app.models.budget import BudgetTransaction
-from app.schemas.budget import TransactionCreate, TransactionUpdate
+from app.schemas.budget import TransactionCreate, TransactionUpdate, SplitChild
 from app.services.base_service import BaseFamilyService
 from app.core.exceptions import NotFoundException, ValidationError
 
@@ -421,6 +421,178 @@ class TransactionService(BaseFamilyService[BudgetTransaction]):
             transaction.reconciled = True
             transaction.cleared = True
             count += 1
-        
+
         await db.commit()
         return count
+
+    # ------------------------------------------------------------------
+    # Split transactions
+    # ------------------------------------------------------------------
+
+    @classmethod
+    async def create_split(
+        cls,
+        db: AsyncSession,
+        family_id: UUID,
+        *,
+        account_id: UUID,
+        txn_date: date,
+        splits: List[SplitChild],
+        payee_id: Optional[UUID] = None,
+        payee_name: Optional[str] = None,
+        notes: Optional[str] = None,
+        cleared: bool = False,
+        reconciled: bool = False,
+    ) -> BudgetTransaction:
+        """Create a parent split transaction with N child legs.
+
+        Parent has aggregate amount, no category. Children share account/date/payee
+        but each has its own category and amount. Sum of children == parent.amount.
+        """
+        if len(splits) < 2:
+            raise ValidationError("Split requires at least 2 child legs")
+
+        from app.services.budget.month_locking_service import MonthLockingService
+        await MonthLockingService.validate_month_not_closed(
+            db, family_id, date(txn_date.year, txn_date.month, 1)
+        )
+
+        from app.services.budget.account_service import AccountService
+        await AccountService.get_by_id(db, account_id, family_id)
+
+        resolved_payee_id = payee_id
+        if payee_id:
+            from app.services.budget.payee_service import PayeeService
+            await PayeeService.get_by_id(db, payee_id, family_id)
+        elif payee_name:
+            from app.services.budget.payee_service import PayeeService
+            payee = await PayeeService.get_or_create_by_name(db, family_id, payee_name)
+            resolved_payee_id = payee.id
+
+        from app.services.budget.category_service import CategoryService
+        for s in splits:
+            if s.category_id:
+                await CategoryService.get_by_id(db, s.category_id, family_id)
+            if s.payee_id:
+                from app.services.budget.payee_service import PayeeService
+                await PayeeService.get_by_id(db, s.payee_id, family_id)
+
+        total = sum(s.amount for s in splits)
+
+        parent = BudgetTransaction(
+            family_id=family_id,
+            account_id=account_id,
+            date=txn_date,
+            amount=total,
+            payee_id=resolved_payee_id,
+            category_id=None,
+            notes=notes,
+            cleared=cleared,
+            reconciled=reconciled,
+            is_parent=True,
+        )
+        db.add(parent)
+        await db.flush()
+
+        for s in splits:
+            child = BudgetTransaction(
+                family_id=family_id,
+                account_id=account_id,
+                date=txn_date,
+                amount=s.amount,
+                payee_id=s.payee_id or resolved_payee_id,
+                category_id=s.category_id,
+                notes=s.notes,
+                cleared=cleared,
+                reconciled=reconciled,
+                parent_id=parent.id,
+                is_parent=False,
+            )
+            db.add(child)
+
+        await db.commit()
+        await db.refresh(parent)
+        return parent
+
+    @classmethod
+    async def get_split_children(
+        cls,
+        db: AsyncSession,
+        parent_id: UUID,
+        family_id: UUID,
+    ) -> List[BudgetTransaction]:
+        """Return child legs of a split parent."""
+        parent = await cls.get_by_id(db, parent_id, family_id)
+        if not parent.is_parent:
+            raise ValidationError("Transaction is not a split parent")
+        query = (
+            select(BudgetTransaction)
+            .where(
+                and_(
+                    BudgetTransaction.parent_id == parent_id,
+                    BudgetTransaction.family_id == family_id,
+                    BudgetTransaction.deleted_at.is_(None),
+                )
+            )
+            .order_by(BudgetTransaction.created_at.asc())
+        )
+        result = await db.execute(query)
+        return list(result.scalars().all())
+
+    @classmethod
+    async def replace_split_children(
+        cls,
+        db: AsyncSession,
+        parent_id: UUID,
+        family_id: UUID,
+        splits: List[SplitChild],
+    ) -> BudgetTransaction:
+        """Replace child legs of a split parent. Updates parent total."""
+        if len(splits) < 2:
+            raise ValidationError("Split requires at least 2 child legs")
+
+        parent = await cls.get_by_id(db, parent_id, family_id)
+        if not parent.is_parent:
+            raise ValidationError("Transaction is not a split parent")
+
+        from app.services.budget.month_locking_service import MonthLockingService
+        await MonthLockingService.validate_month_not_closed(
+            db, family_id, date(parent.date.year, parent.date.month, 1)
+        )
+
+        from app.services.budget.category_service import CategoryService
+        from app.services.budget.payee_service import PayeeService
+        for s in splits:
+            if s.category_id:
+                await CategoryService.get_by_id(db, s.category_id, family_id)
+            if s.payee_id:
+                await PayeeService.get_by_id(db, s.payee_id, family_id)
+
+        # Hard-delete existing children (cascade was set in model relationship)
+        existing = await cls.get_split_children(db, parent_id, family_id)
+        for child in existing:
+            await db.delete(child)
+        await db.flush()
+
+        total = sum(s.amount for s in splits)
+        parent.amount = total
+
+        for s in splits:
+            child = BudgetTransaction(
+                family_id=family_id,
+                account_id=parent.account_id,
+                date=parent.date,
+                amount=s.amount,
+                payee_id=s.payee_id or parent.payee_id,
+                category_id=s.category_id,
+                notes=s.notes,
+                cleared=parent.cleared,
+                reconciled=parent.reconciled,
+                parent_id=parent.id,
+                is_parent=False,
+            )
+            db.add(child)
+
+        await db.commit()
+        await db.refresh(parent)
+        return parent

--- a/backend/app/services/budget/transaction_service.py
+++ b/backend/app/services/budget/transaction_service.py
@@ -596,3 +596,195 @@ class TransactionService(BaseFamilyService[BudgetTransaction]):
         await db.commit()
         await db.refresh(parent)
         return parent
+
+    # ------------------------------------------------------------------
+    # Search & bulk operations
+    # ------------------------------------------------------------------
+
+    @classmethod
+    async def search_transactions(
+        cls,
+        db: AsyncSession,
+        family_id: UUID,
+        *,
+        account_id: Optional[UUID] = None,
+        category_id: Optional[UUID] = None,
+        payee_id: Optional[UUID] = None,
+        cleared: Optional[bool] = None,
+        reconciled: Optional[bool] = None,
+        start_date: Optional[date] = None,
+        end_date: Optional[date] = None,
+        amount_min: Optional[int] = None,
+        amount_max: Optional[int] = None,
+        search: Optional[str] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+    ) -> List[BudgetTransaction]:
+        """Filter transactions by any combination of criteria."""
+        query = select(BudgetTransaction).where(
+            BudgetTransaction.family_id == family_id,
+            BudgetTransaction.deleted_at.is_(None),
+        )
+        if account_id is not None:
+            query = query.where(BudgetTransaction.account_id == account_id)
+        if category_id is not None:
+            query = query.where(BudgetTransaction.category_id == category_id)
+        if payee_id is not None:
+            query = query.where(BudgetTransaction.payee_id == payee_id)
+        if cleared is not None:
+            query = query.where(BudgetTransaction.cleared == cleared)
+        if reconciled is not None:
+            query = query.where(BudgetTransaction.reconciled == reconciled)
+        if start_date is not None:
+            query = query.where(BudgetTransaction.date >= start_date)
+        if end_date is not None:
+            query = query.where(BudgetTransaction.date <= end_date)
+        if amount_min is not None:
+            query = query.where(BudgetTransaction.amount >= amount_min)
+        if amount_max is not None:
+            query = query.where(BudgetTransaction.amount <= amount_max)
+        if search:
+            query = query.where(BudgetTransaction.notes.ilike(f"%{search}%"))
+
+        query = query.order_by(BudgetTransaction.date.desc(), BudgetTransaction.created_at.desc())
+        if limit is not None:
+            query = query.limit(limit)
+        if offset:
+            query = query.offset(offset)
+
+        result = await db.execute(query)
+        return list(result.scalars().all())
+
+    BULK_UPDATE_ALLOWED = frozenset({"cleared", "reconciled", "category_id", "payee_id"})
+
+    @classmethod
+    async def bulk_update_transactions(
+        cls,
+        db: AsyncSession,
+        family_id: UUID,
+        transaction_ids: List[UUID],
+        updates: dict,
+    ) -> int:
+        """Apply same field updates to N transactions. Returns count modified.
+
+        Whitelist: cleared, reconciled, category_id, payee_id. Other fields dropped.
+        """
+        if not transaction_ids:
+            return 0
+        filtered = {k: v for k, v in updates.items() if k in cls.BULK_UPDATE_ALLOWED}
+        if not filtered:
+            return 0
+
+        query = select(BudgetTransaction).where(
+            and_(
+                BudgetTransaction.id.in_(transaction_ids),
+                BudgetTransaction.family_id == family_id,
+                BudgetTransaction.deleted_at.is_(None),
+            )
+        )
+        result = await db.execute(query)
+        rows = list(result.scalars().all())
+
+        for txn in rows:
+            for field, value in filtered.items():
+                if field.endswith("_id") and isinstance(value, str):
+                    value = UUID(value)
+                setattr(txn, field, value)
+
+        await db.commit()
+        return len(rows)
+
+    @classmethod
+    async def bulk_delete_transactions(
+        cls,
+        db: AsyncSession,
+        family_id: UUID,
+        transaction_ids: List[UUID],
+    ) -> int:
+        """Delete N transactions (family-scoped). Returns count deleted."""
+        if not transaction_ids:
+            return 0
+
+        query = select(BudgetTransaction).where(
+            and_(
+                BudgetTransaction.id.in_(transaction_ids),
+                BudgetTransaction.family_id == family_id,
+                BudgetTransaction.deleted_at.is_(None),
+            )
+        )
+        result = await db.execute(query)
+        rows = list(result.scalars().all())
+
+        for txn in rows:
+            await db.delete(txn)
+        await db.commit()
+        return len(rows)
+
+    @classmethod
+    async def finish_reconciliation(
+        cls,
+        db: AsyncSession,
+        family_id: UUID,
+        *,
+        account_id: UUID,
+        statement_balance: int,
+        transaction_ids: List[UUID],
+    ) -> dict:
+        """Mark transactions cleared+reconciled, create adjustment if balance mismatches.
+
+        Returns {reconciled_count, adjustment_amount, adjustment_transaction_id}.
+        """
+        from app.services.budget.account_service import AccountService
+        await AccountService.get_by_id(db, account_id, family_id)
+
+        query = select(BudgetTransaction).where(
+            and_(
+                BudgetTransaction.id.in_(transaction_ids),
+                BudgetTransaction.account_id == account_id,
+                BudgetTransaction.family_id == family_id,
+                BudgetTransaction.deleted_at.is_(None),
+            )
+        )
+        result = await db.execute(query)
+        rows = list(result.scalars().all())
+
+        for txn in rows:
+            txn.cleared = True
+            txn.reconciled = True
+        await db.flush()
+
+        cleared_query = (
+            select(func.coalesce(func.sum(BudgetTransaction.amount), 0))
+            .where(
+                and_(
+                    BudgetTransaction.family_id == family_id,
+                    BudgetTransaction.account_id == account_id,
+                    BudgetTransaction.cleared == True,
+                    BudgetTransaction.deleted_at.is_(None),
+                )
+            )
+        )
+        cleared_total = (await db.execute(cleared_query)).scalar() or 0
+
+        adjustment_amount = statement_balance - cleared_total
+        adjustment_id = None
+        if adjustment_amount != 0:
+            adj = BudgetTransaction(
+                family_id=family_id,
+                account_id=account_id,
+                date=date.today(),
+                amount=adjustment_amount,
+                notes="Ajuste de Conciliación",
+                cleared=True,
+                reconciled=True,
+            )
+            db.add(adj)
+            await db.flush()
+            adjustment_id = adj.id
+
+        await db.commit()
+        return {
+            "reconciled_count": len(rows),
+            "adjustment_amount": adjustment_amount,
+            "adjustment_transaction_id": adjustment_id,
+        }

--- a/backend/app/services/budget/transfer_service.py
+++ b/backend/app/services/budget/transfer_service.py
@@ -57,7 +57,8 @@ class TransferService:
             select(BudgetAccount).where(
                 and_(
                     BudgetAccount.id == from_account_id,
-                    BudgetAccount.family_id == family_id
+                    BudgetAccount.family_id == family_id,
+                    BudgetAccount.deleted_at.is_(None),
                 )
             )
         )
@@ -72,7 +73,8 @@ class TransferService:
             select(BudgetAccount).where(
                 and_(
                     BudgetAccount.id == to_account_id,
-                    BudgetAccount.family_id == family_id
+                    BudgetAccount.family_id == family_id,
+                    BudgetAccount.deleted_at.is_(None),
                 )
             )
         )
@@ -161,7 +163,8 @@ class TransferService:
             select(BudgetCategory).where(
                 and_(
                     BudgetCategory.id == from_category_id,
-                    BudgetCategory.family_id == family_id
+                    BudgetCategory.family_id == family_id,
+                    BudgetCategory.deleted_at.is_(None),
                 )
             )
         )
@@ -176,7 +179,8 @@ class TransferService:
             select(BudgetCategory).where(
                 and_(
                     BudgetCategory.id == to_category_id,
-                    BudgetCategory.family_id == family_id
+                    BudgetCategory.family_id == family_id,
+                    BudgetCategory.deleted_at.is_(None),
                 )
             )
         )

--- a/backend/app/services/usage_service.py
+++ b/backend/app/services/usage_service.py
@@ -46,13 +46,18 @@ class UsageService:
 
     @classmethod
     async def increment(
-        cls, db: AsyncSession, family_id: UUID, feature: str
+        cls, db: AsyncSession, family_id: UUID, feature: str, amount: int = 1
     ) -> int:
         """
         Increment the usage counter for a feature in the current month.
 
         Creates the record if it doesn't exist yet. Returns the new count.
+        Use amount > 1 when a single API call produces multiple chargeable
+        units (e.g. split transactions create N child legs at once).
         """
+        if amount < 1:
+            raise ValueError("amount must be >= 1")
+
         period = cls._current_period()
 
         query = select(UsageTracking).where(
@@ -70,11 +75,11 @@ class UsageService:
                 family_id=family_id,
                 feature=feature,
                 period_start=period,
-                count=1,
+                count=amount,
             )
             db.add(record)
         else:
-            record.count += 1
+            record.count += amount
 
         await db.commit()
         await db.refresh(record)

--- a/backend/tests/test_budget_review_followups.py
+++ b/backend/tests/test_budget_review_followups.py
@@ -535,3 +535,198 @@ async def test_apply_all_rules_processes_all_rows_across_batches(
     for tid in nomatch_ids:
         txn = await TransactionService.get_by_id(db, tid, family_id)
         assert txn.category_id is None
+
+
+# ---------- require_feature(units=N) gating ----------
+
+@pytest.mark.asyncio
+async def test_create_split_blocked_when_units_would_exceed_limit(
+    client, auth_headers, db_session, test_family
+):
+    """A split request whose len(splits) would push usage past the plan limit
+    must be rejected with 403, not silently accepted then over-counted.
+
+    Free plan: max_budget_transactions_per_month = 30. Pre-seed usage=28,
+    attempt 5-leg split → 28+5 > 30 → 403.
+    """
+    from app.models.subscription import SubscriptionPlan, UsageTracking
+    from app.models.budget import BudgetAccount, BudgetCategoryGroup, BudgetCategory
+    from app.core.premium import DEFAULT_FREE_LIMITS
+
+    # Seed free plan + max-out usage near the cap
+    plan = SubscriptionPlan(
+        name="free", display_name="Free", display_name_es="Gratis",
+        price_monthly_cents=0, price_annual_cents=0,
+        limits=dict(DEFAULT_FREE_LIMITS), sort_order=0,
+    )
+    db_session.add(plan)
+    await db_session.commit()
+
+    account = BudgetAccount(
+        family_id=test_family.id, name="Checking", type="checking",
+        starting_balance=0,
+    )
+    group = BudgetCategoryGroup(family_id=test_family.id, name="Food")
+    db_session.add_all([account, group])
+    await db_session.commit()
+    await db_session.refresh(account)
+    await db_session.refresh(group)
+    cat = BudgetCategory(
+        family_id=test_family.id, group_id=group.id, name="Groceries",
+    )
+    db_session.add(cat)
+
+    usage = UsageTracking(
+        family_id=test_family.id, feature="budget_transaction",
+        period_start=date.today().replace(day=1), count=28,
+    )
+    db_session.add(usage)
+    await db_session.commit()
+    await db_session.refresh(cat)
+
+    body = {
+        "account_id": str(account.id),
+        "date": date.today().isoformat(),
+        "splits": [
+            {"amount": -100, "category_id": str(cat.id)} for _ in range(5)
+        ],
+    }
+    response = await client.post(
+        "/api/budget/transactions/split", headers=auth_headers, json=body,
+    )
+    assert response.status_code == 403, response.text
+    assert response.json()["detail"]["error"] == "upgrade_required"
+
+    # 2-leg split fits (28 + 2 == 30) and must succeed
+    body["splits"] = body["splits"][:2]
+    response = await client.post(
+        "/api/budget/transactions/split", headers=auth_headers, json=body,
+    )
+    assert response.status_code == 201, response.text
+
+
+# ---------- UsageService.increment(amount=N) accumulation ----------
+
+@pytest.mark.asyncio
+async def test_usage_service_increment_amount_accumulates(
+    db: AsyncSession, family_id
+):
+    """increment(amount=N) must add N to the counter, not reset to 1."""
+    from app.services.usage_service import UsageService
+
+    count = await UsageService.increment(db, family_id, "budget_transaction", amount=3)
+    assert count == 3
+
+    count = await UsageService.increment(db, family_id, "budget_transaction", amount=3)
+    assert count == 6
+
+    count = await UsageService.increment(db, family_id, "budget_transaction")
+    assert count == 7
+
+
+# ---------- CategoryService.list_for_family hidden filter ----------
+
+@pytest.mark.asyncio
+async def test_category_list_for_family_drops_hidden_in_sql(
+    db: AsyncSession, family_id
+):
+    """Mirror of the closed-accounts test: hidden categories must be filtered
+    in SQL so pagination is stable (not python post-filter after limit/offset).
+    """
+    group = await CategoryGroupService.create(
+        db, family_id, CategoryGroupCreate(name="Mixed", is_income=False)
+    )
+
+    hidden_ids = []
+    for i, name in enumerate(["A_hidden", "B_hidden", "C_hidden"]):
+        c = await CategoryService.create(
+            db, family_id,
+            CategoryCreate(name=name, group_id=group.id, sort_order=i),
+        )
+        hidden_ids.append(c.id)
+
+    visible_d = await CategoryService.create(
+        db, family_id,
+        CategoryCreate(name="D_visible", group_id=group.id, sort_order=4),
+    )
+    visible_e = await CategoryService.create(
+        db, family_id,
+        CategoryCreate(name="E_visible", group_id=group.id, sort_order=5),
+    )
+
+    from app.schemas.budget import CategoryUpdate
+    for cid in hidden_ids:
+        await CategoryService.update(
+            db, cid, family_id, CategoryUpdate(hidden=True)
+        )
+
+    rows = await CategoryService.list_for_family(
+        db, family_id, include_hidden=False, limit=2, offset=0
+    )
+    assert len(rows) == 2
+    assert {r.id for r in rows} == {visible_d.id, visible_e.id}
+
+
+# ---------- bulk_update_transactions partial-mutation safety ----------
+
+@pytest.mark.asyncio
+async def test_bulk_update_does_not_partially_mutate_on_validation_failure(
+    db: AsyncSession, family_id
+):
+    """If FK validation raises (cross-family category), bulk_update must not
+    have applied any of the OTHER whitelisted fields (cleared/reconciled) to
+    matching rows. Locks the two-phase ordering invariant: validate first,
+    mutate second.
+    """
+    from app.models.family import Family
+
+    account = await _make_account(db, family_id)
+    txn = await TransactionService.create(
+        db, family_id,
+        TransactionCreate(account_id=account.id, date=date(2026, 5, 1), amount=-100),
+    )
+    assert txn.cleared is False
+
+    other_family = Family(name="Other Family")
+    db.add(other_family)
+    await db.commit()
+    await db.refresh(other_family)
+    other_group = await CategoryGroupService.create(
+        db, other_family.id, CategoryGroupCreate(name="Other", is_income=False)
+    )
+    other_cat = await CategoryService.create(
+        db, other_family.id,
+        CategoryCreate(name="Foreign", group_id=other_group.id),
+    )
+
+    with pytest.raises(NotFoundException):
+        await TransactionService.bulk_update_transactions(
+            db, family_id, [txn.id],
+            {"cleared": True, "category_id": other_cat.id},
+        )
+
+    await db.refresh(txn)
+    assert txn.cleared is False, "cleared was applied despite FK validation failure"
+    assert txn.category_id is None
+
+
+# ---------- Currency change permitted on the only account in the family ----------
+
+@pytest.mark.asyncio
+async def test_account_update_allows_currency_change_when_sole_account(
+    db: AsyncSession, family_id
+):
+    """A family with a single account must be able to switch its currency.
+    Pre-fix the lookup hit the same row being updated and refused the change.
+    """
+    from app.schemas.budget import AccountUpdate
+
+    a = await AccountService.create(
+        db, family_id, AccountCreate(name="OnlyAccount", type="checking")
+    )
+    assert a.currency == "MXN"
+
+    updated = await AccountService.update(
+        db, a.id, family_id, AccountUpdate(currency="USD")
+    )
+    assert updated.currency == "USD"

--- a/backend/tests/test_budget_review_followups.py
+++ b/backend/tests/test_budget_review_followups.py
@@ -15,10 +15,12 @@ from app.services.budget.payee_service import PayeeService
 from app.services.budget.transaction_service import TransactionService
 from app.services.budget.allocation_service import AllocationService
 from app.services.budget.report_service import ReportService
+from app.services.budget.categorization_rule_service import CategorizationRuleService
 from app.schemas.budget import (
     AccountCreate,
     CategoryGroupCreate,
     CategoryCreate,
+    CategorizationRuleCreate,
     PayeeCreate,
     TransactionCreate,
     AllocationCreate,
@@ -289,3 +291,101 @@ async def test_get_net_worth_history_series_length_matches_months(
     assert len(result["series"]) == 3
     assert result["months"] == 3
     assert result["current_net_worth"] == result["series"][-1]["net_worth"]
+
+
+# ---------- Route ordering: /search must not be shadowed by /{transaction_id} ----------
+
+@pytest.mark.asyncio
+async def test_search_endpoint_is_not_shadowed_by_transaction_id_route(
+    client, auth_headers
+):
+    """GET /api/budget/transactions/search must resolve to the search handler,
+    not be parsed as transaction_id="search" by the /{transaction_id} route.
+
+    Regression: prior to the fix, /search was declared after /{transaction_id},
+    so FastAPI matched the literal "search" against the UUID-typed path param
+    and returned 422.
+    """
+    response = await client.get(
+        "/api/budget/transactions/search",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    assert isinstance(response.json(), list)
+
+
+# ---------- apply_all_rules pagination correctness ----------
+
+@pytest.mark.asyncio
+async def test_apply_all_rules_processes_all_rows_across_batches(
+    db: AsyncSession, family_id, monkeypatch
+):
+    """apply_all_rules must not skip rows when matched rows leave the result set
+    between batches.
+
+    Regression: with offset += len(rows), each applied row caused an offset
+    drift that left uncategorized rows behind the scan window unprocessed.
+    Force a tiny batch size so multiple iterations are required.
+    """
+    monkeypatch.setattr(CategorizationRuleService, "APPLY_ALL_BATCH_SIZE", 2)
+
+    account = await _make_account(db, family_id)
+    _, cat = await _make_category(db, family_id)
+
+    match_payee = await PayeeService.create(
+        db, family_id, PayeeCreate(name="MatchPayee")
+    )
+    nomatch_payee = await PayeeService.create(
+        db, family_id, PayeeCreate(name="NoMatchPayee")
+    )
+
+    # 3 matching, 2 non-matching, all uncategorized
+    matching_ids = []
+    for i in range(3):
+        t = await TransactionService.create(
+            db, family_id,
+            TransactionCreate(
+                account_id=account.id, date=date(2026, 5, 1), amount=-(100 + i),
+                payee_id=match_payee.id,
+            ),
+        )
+        matching_ids.append(t.id)
+
+    nomatch_ids = []
+    for i in range(2):
+        t = await TransactionService.create(
+            db, family_id,
+            TransactionCreate(
+                account_id=account.id, date=date(2026, 5, 1), amount=-(500 + i),
+                payee_id=nomatch_payee.id,
+            ),
+        )
+        nomatch_ids.append(t.id)
+
+    await CategorizationRuleService.create(
+        db, family_id,
+        CategorizationRuleCreate(
+            category_id=cat.id,
+            rule_type="exact",
+            match_field="payee",
+            pattern="MatchPayee",
+            enabled=True,
+            priority=0,
+        ),
+    )
+
+    result = await CategorizationRuleService.apply_all_rules(db, family_id)
+
+    assert result["applied"] == 3, (
+        f"Expected all 3 matching txns categorized, got {result}"
+    )
+    assert result["skipped"] == 2
+    assert result["truncated"] is False
+
+    for tid in matching_ids:
+        txn = await TransactionService.get_by_id(db, tid, family_id)
+        assert txn.category_id == cat.id
+
+    for tid in nomatch_ids:
+        txn = await TransactionService.get_by_id(db, tid, family_id)
+        assert txn.category_id is None

--- a/backend/tests/test_budget_review_followups.py
+++ b/backend/tests/test_budget_review_followups.py
@@ -730,3 +730,52 @@ async def test_account_update_allows_currency_change_when_sole_account(
         db, a.id, family_id, AccountUpdate(currency="USD")
     )
     assert updated.currency == "USD"
+
+
+# ---------- SPLIT_MAX_LEGS cap enforcement ----------
+
+@pytest.mark.asyncio
+async def test_create_split_rejects_beyond_max_legs(
+    client, auth_headers, db_session, test_family
+):
+    """Schema must reject a split request whose splits list exceeds
+    SPLIT_MAX_LEGS, otherwise a Pro-plan caller could create thousands of
+    child rows in one request.
+    """
+    from app.models.budget import BudgetAccount, BudgetCategoryGroup, BudgetCategory
+    from app.schemas.budget import SPLIT_MAX_LEGS
+
+    account = BudgetAccount(
+        family_id=test_family.id, name="Checking", type="checking",
+        starting_balance=0,
+    )
+    group = BudgetCategoryGroup(family_id=test_family.id, name="Food")
+    db_session.add_all([account, group])
+    await db_session.commit()
+    await db_session.refresh(account)
+    await db_session.refresh(group)
+    cat = BudgetCategory(
+        family_id=test_family.id, group_id=group.id, name="Groceries",
+    )
+    db_session.add(cat)
+    await db_session.commit()
+    await db_session.refresh(cat)
+
+    over_cap = SPLIT_MAX_LEGS + 1
+    body = {
+        "account_id": str(account.id),
+        "date": date.today().isoformat(),
+        "splits": [
+            {"amount": -1, "category_id": str(cat.id)} for _ in range(over_cap)
+        ],
+    }
+    response = await client.post(
+        "/api/budget/transactions/split", headers=auth_headers, json=body,
+    )
+    assert response.status_code == 422, response.text
+    # Pydantic location confirms the rejection comes from the schema cap, not
+    # the quota gate (which would be 403 with detail.error="upgrade_required").
+    assert any(
+        err.get("loc", [None, None])[1] == "splits"
+        for err in response.json().get("detail", [])
+    ), response.text

--- a/backend/tests/test_budget_review_followups.py
+++ b/backend/tests/test_budget_review_followups.py
@@ -1,0 +1,291 @@
+"""Regression tests for PR #4 follow-up fixes.
+
+Covers code-review issues B2 / H1 / H3 plus the bulk/merge/reassign and
+report-batching paths that previously had no service-level tests.
+"""
+
+import pytest
+from datetime import date
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.budget import BudgetTransaction
+from app.services.budget.account_service import AccountService
+from app.services.budget.category_service import CategoryGroupService, CategoryService
+from app.services.budget.payee_service import PayeeService
+from app.services.budget.transaction_service import TransactionService
+from app.services.budget.allocation_service import AllocationService
+from app.services.budget.report_service import ReportService
+from app.schemas.budget import (
+    AccountCreate,
+    CategoryGroupCreate,
+    CategoryCreate,
+    PayeeCreate,
+    TransactionCreate,
+    AllocationCreate,
+)
+from app.core.exceptions import NotFoundException
+
+
+# ---------- Helpers ----------
+
+async def _make_account(db, family_id, name="Checking"):
+    return await AccountService.create(
+        db, family_id, AccountCreate(name=name, type="checking")
+    )
+
+
+async def _make_category(db, family_id, group_name="Food", cat_name="Groceries"):
+    group = await CategoryGroupService.create(
+        db, family_id, CategoryGroupCreate(name=group_name, is_income=False)
+    )
+    cat = await CategoryService.create(
+        db, family_id, CategoryCreate(name=cat_name, group_id=group.id)
+    )
+    return group, cat
+
+
+# ---------- bulk_delete_transactions ----------
+
+@pytest.mark.asyncio
+async def test_bulk_delete_removes_only_listed_rows(db: AsyncSession, family_id):
+    account = await _make_account(db, family_id)
+    keep = await TransactionService.create(
+        db, family_id,
+        TransactionCreate(account_id=account.id, date=date(2026, 5, 1), amount=-100),
+    )
+    a = await TransactionService.create(
+        db, family_id,
+        TransactionCreate(account_id=account.id, date=date(2026, 5, 1), amount=-200),
+    )
+    b = await TransactionService.create(
+        db, family_id,
+        TransactionCreate(account_id=account.id, date=date(2026, 5, 1), amount=-300),
+    )
+
+    deleted = await TransactionService.bulk_delete_transactions(
+        db, family_id, [a.id, b.id]
+    )
+    assert deleted == 2
+
+    remaining = await TransactionService.list_by_family(db, family_id)
+    assert {t.id for t in remaining} == {keep.id}
+
+
+# ---------- bulk_update_transactions: family-scoped FK validation ----------
+
+@pytest.mark.asyncio
+async def test_bulk_update_applies_valid_family_category(db: AsyncSession, family_id):
+    account = await _make_account(db, family_id)
+    _, cat = await _make_category(db, family_id)
+    txn = await TransactionService.create(
+        db, family_id,
+        TransactionCreate(account_id=account.id, date=date(2026, 5, 1), amount=-100),
+    )
+
+    count = await TransactionService.bulk_update_transactions(
+        db, family_id, [txn.id], {"category_id": cat.id, "cleared": True}
+    )
+    assert count == 1
+    await db.refresh(txn)
+    assert txn.category_id == cat.id
+    assert txn.cleared is True
+
+
+# ---------- finish_reconciliation: balance match + adjustment branches ----------
+
+@pytest.mark.asyncio
+async def test_finish_reconciliation_matching_balance_no_adjustment(
+    db: AsyncSession, family_id
+):
+    account = await _make_account(db, family_id)
+    txn = await TransactionService.create(
+        db, family_id,
+        TransactionCreate(account_id=account.id, date=date(2026, 5, 1), amount=-5000),
+    )
+
+    result = await TransactionService.finish_reconciliation(
+        db, family_id,
+        account_id=account.id,
+        statement_balance=-5000,
+        transaction_ids=[txn.id],
+    )
+    assert result["reconciled_count"] == 1
+    assert result["adjustment_amount"] == 0
+    assert result["adjustment_transaction_id"] is None
+    await db.refresh(txn)
+    assert txn.cleared is True
+    assert txn.reconciled is True
+
+
+@pytest.mark.asyncio
+async def test_finish_reconciliation_mismatch_creates_adjustment(
+    db: AsyncSession, family_id
+):
+    account = await _make_account(db, family_id)
+    txn = await TransactionService.create(
+        db, family_id,
+        TransactionCreate(account_id=account.id, date=date(2026, 5, 1), amount=-5000),
+    )
+
+    result = await TransactionService.finish_reconciliation(
+        db, family_id,
+        account_id=account.id,
+        statement_balance=-5500,
+        transaction_ids=[txn.id],
+    )
+    assert result["reconciled_count"] == 1
+    assert result["adjustment_amount"] == -500
+    assert result["adjustment_transaction_id"] is not None
+
+    adj = await TransactionService.get_by_id(
+        db, result["adjustment_transaction_id"], family_id
+    )
+    assert adj.amount == -500
+    assert adj.cleared is True
+    assert adj.reconciled is True
+
+
+# ---------- merge_payees ----------
+
+@pytest.mark.asyncio
+async def test_merge_payees_reassigns_transactions_and_deletes_source(
+    db: AsyncSession, family_id
+):
+    account = await _make_account(db, family_id)
+    src = await PayeeService.create(db, family_id, PayeeCreate(name="OXXO Norte"))
+    tgt = await PayeeService.create(db, family_id, PayeeCreate(name="OXXO"))
+
+    t1 = await TransactionService.create(
+        db, family_id,
+        TransactionCreate(
+            account_id=account.id, date=date(2026, 5, 1), amount=-100,
+            payee_id=src.id,
+        ),
+    )
+    t2 = await TransactionService.create(
+        db, family_id,
+        TransactionCreate(
+            account_id=account.id, date=date(2026, 5, 2), amount=-200,
+            payee_id=src.id,
+        ),
+    )
+
+    result = await PayeeService.merge_payees(db, family_id, src.id, tgt.id)
+    assert result["merged_count"] == 2
+    assert result["source_name"] == "OXXO Norte"
+    assert result["target_name"] == "OXXO"
+
+    await db.refresh(t1)
+    await db.refresh(t2)
+    assert t1.payee_id == tgt.id
+    assert t2.payee_id == tgt.id
+
+    with pytest.raises(NotFoundException):
+        await PayeeService.get_by_id(db, src.id, family_id)
+
+
+# ---------- delete_with_reassign: soft-delete + reassign ----------
+
+@pytest.mark.asyncio
+async def test_delete_with_reassign_soft_deletes_and_reassigns(
+    db: AsyncSession, family_id
+):
+    account = await _make_account(db, family_id)
+    _, src_cat = await _make_category(db, family_id, cat_name="OldCat")
+    _, dest_cat = await _make_category(db, family_id, group_name="Food2", cat_name="NewCat")
+
+    txn = await TransactionService.create(
+        db, family_id,
+        TransactionCreate(
+            account_id=account.id, date=date(2026, 5, 1), amount=-100,
+            category_id=src_cat.id,
+        ),
+    )
+
+    result = await CategoryService.delete_with_reassign(
+        db, src_cat.id, family_id, reassign_to_id=dest_cat.id
+    )
+    assert result["deleted_name"] == "OldCat"
+    assert result["reassigned_count"] == 1
+
+    await db.refresh(txn)
+    assert txn.category_id == dest_cat.id
+
+    # Soft-deleted: get_by_id (which filters deleted_at) raises NotFound
+    with pytest.raises(NotFoundException):
+        await CategoryService.get_by_id(db, src_cat.id, family_id)
+
+
+# ---------- AllocationService.copy_from_month ----------
+
+@pytest.mark.asyncio
+async def test_copy_from_month_copies_nonzero_only(db: AsyncSession, family_id):
+    _, cat_a = await _make_category(db, family_id, cat_name="A")
+    _, cat_b = await _make_category(db, family_id, group_name="G2", cat_name="B")
+
+    src_month = date(2026, 4, 1)
+    tgt_month = date(2026, 5, 1)
+
+    await AllocationService.create(
+        db, family_id,
+        AllocationCreate(category_id=cat_a.id, month=src_month, budgeted_amount=15000),
+    )
+    await AllocationService.create(
+        db, family_id,
+        AllocationCreate(category_id=cat_b.id, month=src_month, budgeted_amount=0),
+    )
+
+    result = await AllocationService.copy_from_month(
+        db, family_id, src_month, tgt_month
+    )
+    assert result["copied"] == 1
+    assert result["skipped"] == 1
+
+
+# ---------- ReportService: shape sanity for batched paths ----------
+
+@pytest.mark.asyncio
+async def test_get_budget_vs_actual_returns_expected_shape(
+    db: AsyncSession, family_id
+):
+    account = await _make_account(db, family_id)
+    _, cat = await _make_category(db, family_id)
+
+    month = date(2026, 5, 1)
+    await AllocationService.create(
+        db, family_id,
+        AllocationCreate(category_id=cat.id, month=month, budgeted_amount=20000),
+    )
+    await TransactionService.create(
+        db, family_id,
+        TransactionCreate(
+            account_id=account.id, date=month, amount=-7000, category_id=cat.id,
+        ),
+    )
+
+    report = await ReportService.get_budget_vs_actual(db, family_id, month)
+    assert report["month"] == month.isoformat()
+    assert report["totals"]["budgeted"] == 20000
+    assert report["totals"]["actual"] == 7000
+    assert report["totals"]["variance"] == 13000
+    assert len(report["groups"]) == 1
+    cats = report["groups"][0]["categories"]
+    assert cats[0]["budgeted"] == 20000
+    assert cats[0]["actual"] == 7000
+    assert cats[0]["pct_used"] == 35.0
+
+
+@pytest.mark.asyncio
+async def test_get_net_worth_history_series_length_matches_months(
+    db: AsyncSession, family_id
+):
+    account = await _make_account(db, family_id)
+    await TransactionService.create(
+        db, family_id,
+        TransactionCreate(account_id=account.id, date=date(2026, 4, 15), amount=10000),
+    )
+
+    result = await ReportService.get_net_worth_history(db, family_id, months=3)
+    assert len(result["series"]) == 3
+    assert result["months"] == 3
+    assert result["current_net_worth"] == result["series"][-1]["net_worth"]

--- a/backend/tests/test_budget_review_followups.py
+++ b/backend/tests/test_budget_review_followups.py
@@ -218,6 +218,123 @@ async def test_delete_with_reassign_soft_deletes_and_reassigns(
         await CategoryService.get_by_id(db, src_cat.id, family_id)
 
 
+@pytest.mark.asyncio
+async def test_delete_with_reassign_rejects_self_reassignment(
+    db: AsyncSession, family_id
+):
+    """Reassigning a category onto itself would orphan its txns when the row
+    gets soft-deleted. Service must refuse with ValidationError before
+    mutating any state.
+    """
+    from app.core.exceptions import ValidationError
+
+    account = await _make_account(db, family_id)
+    _, cat = await _make_category(db, family_id, cat_name="LoneCat")
+    txn = await TransactionService.create(
+        db, family_id,
+        TransactionCreate(
+            account_id=account.id, date=date(2026, 5, 1), amount=-100,
+            category_id=cat.id,
+        ),
+    )
+
+    with pytest.raises(ValidationError):
+        await CategoryService.delete_with_reassign(
+            db, cat.id, family_id, reassign_to_id=cat.id
+        )
+
+    # Category and txn must be untouched
+    await db.refresh(txn)
+    assert txn.category_id == cat.id
+    fetched = await CategoryService.get_by_id(db, cat.id, family_id)
+    assert fetched.deleted_at is None
+
+
+# ---------- Currency safety ----------
+
+@pytest.mark.asyncio
+async def test_account_create_rejects_mismatched_currency(
+    db: AsyncSession, family_id
+):
+    """Family currency is implicit and singular. A second account with a
+    different currency must be refused — reports sum amounts blindly across
+    accounts and have no FX conversion.
+    """
+    from app.core.exceptions import ValidationError
+
+    await AccountService.create(
+        db, family_id, AccountCreate(name="MXN Checking", type="checking")
+    )
+
+    with pytest.raises(ValidationError):
+        await AccountService.create(
+            db, family_id,
+            AccountCreate(name="USD Savings", type="savings", currency="USD"),
+        )
+
+
+@pytest.mark.asyncio
+async def test_account_update_rejects_currency_change(
+    db: AsyncSession, family_id
+):
+    """Once set, currency cannot be changed if other accounts exist on the
+    family with the original currency."""
+    from app.core.exceptions import ValidationError
+    from app.schemas.budget import AccountUpdate
+
+    a = await AccountService.create(
+        db, family_id, AccountCreate(name="A", type="checking")
+    )
+    await AccountService.create(
+        db, family_id, AccountCreate(name="B", type="checking")
+    )
+
+    with pytest.raises(ValidationError):
+        await AccountService.update(
+            db, a.id, family_id, AccountUpdate(currency="USD")
+        )
+
+
+# ---------- SQL-side filtering for paginated list endpoints ----------
+
+@pytest.mark.asyncio
+async def test_list_for_family_drops_closed_in_sql_not_python(
+    db: AsyncSession, family_id
+):
+    """list_for_family must filter closed accounts in SQL so the requested
+    limit reflects the count of returned (open) rows, not pre-filter rows.
+
+    Layout: 3 closed + 2 open. limit=2, include_closed=False must return
+    exactly 2 open accounts. Pre-fix python-filter would return 0 (the first
+    2 in sort order are closed and stripped after pagination).
+    """
+    closed_a = await AccountService.create(
+        db, family_id, AccountCreate(name="A_closed", type="checking", sort_order=1)
+    )
+    closed_b = await AccountService.create(
+        db, family_id, AccountCreate(name="B_closed", type="checking", sort_order=2)
+    )
+    closed_c = await AccountService.create(
+        db, family_id, AccountCreate(name="C_closed", type="checking", sort_order=3)
+    )
+    open_d = await AccountService.create(
+        db, family_id, AccountCreate(name="D_open", type="checking", sort_order=4)
+    )
+    open_e = await AccountService.create(
+        db, family_id, AccountCreate(name="E_open", type="checking", sort_order=5)
+    )
+
+    from app.schemas.budget import AccountUpdate
+    for a in (closed_a, closed_b, closed_c):
+        await AccountService.update(db, a.id, family_id, AccountUpdate(closed=True))
+
+    rows = await AccountService.list_for_family(
+        db, family_id, include_closed=False, limit=2, offset=0
+    )
+    assert len(rows) == 2
+    assert {r.id for r in rows} == {open_d.id, open_e.id}
+
+
 # ---------- AllocationService.copy_from_month ----------
 
 @pytest.mark.asyncio
@@ -291,6 +408,35 @@ async def test_get_net_worth_history_series_length_matches_months(
     assert len(result["series"]) == 3
     assert result["months"] == 3
     assert result["current_net_worth"] == result["series"][-1]["net_worth"]
+
+
+@pytest.mark.asyncio
+async def test_get_net_worth_history_includes_closed_accounts(
+    db: AsyncSession, family_id
+):
+    """Closing an account must not retroactively erase its historical
+    contribution — net worth at month T should be the same regardless of
+    whether the account is closed today.
+    """
+    from app.schemas.budget import AccountUpdate
+
+    account = await _make_account(db, family_id, name="ClosedSavings")
+    await TransactionService.create(
+        db, family_id,
+        TransactionCreate(account_id=account.id, date=date(2026, 4, 15), amount=50_000),
+    )
+
+    before = await ReportService.get_net_worth_history(db, family_id, months=3)
+    before_total = before["current_net_worth"]
+    assert before_total != 0, "precondition: account should contribute"
+
+    await AccountService.update(
+        db, account.id, family_id, AccountUpdate(closed=True)
+    )
+
+    after = await ReportService.get_net_worth_history(db, family_id, months=3)
+    assert after["current_net_worth"] == before_total
+    assert after["series"] == before["series"]
 
 
 # ---------- Route ordering: /search must not be shadowed by /{transaction_id} ----------

--- a/backend/tests/test_split_transactions.py
+++ b/backend/tests/test_split_transactions.py
@@ -1,0 +1,164 @@
+"""Tests for split transaction service."""
+
+import pytest
+from datetime import date
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from app.models.budget import BudgetTransaction
+from app.services.budget.account_service import AccountService
+from app.services.budget.category_service import CategoryGroupService, CategoryService
+from app.services.budget.transaction_service import TransactionService
+from app.schemas.budget import (
+    AccountCreate,
+    CategoryGroupCreate,
+    CategoryCreate,
+    SplitChild,
+)
+from app.core.exceptions import ValidationError, NotFoundException
+
+
+@pytest.mark.asyncio
+async def test_create_split_creates_parent_and_children(db: AsyncSession, family_id):
+    account = await AccountService.create(
+        db, family_id, AccountCreate(name="Checking", type="checking")
+    )
+    group = await CategoryGroupService.create(
+        db, family_id, CategoryGroupCreate(name="Food", is_income=False)
+    )
+    cat_a = await CategoryService.create(
+        db, family_id, CategoryCreate(name="Groceries", group_id=group.id)
+    )
+    cat_b = await CategoryService.create(
+        db, family_id, CategoryCreate(name="Snacks", group_id=group.id)
+    )
+
+    parent = await TransactionService.create_split(
+        db, family_id,
+        account_id=account.id,
+        txn_date=date(2026, 5, 1),
+        splits=[
+            SplitChild(amount=-7000, category_id=cat_a.id),
+            SplitChild(amount=-3000, category_id=cat_b.id),
+        ],
+    )
+
+    assert parent.is_parent is True
+    assert parent.parent_id is None
+    assert parent.amount == -10000
+    assert parent.category_id is None
+
+    children = await TransactionService.get_split_children(db, parent.id, family_id)
+    assert len(children) == 2
+    assert sum(c.amount for c in children) == parent.amount
+    assert {c.category_id for c in children} == {cat_a.id, cat_b.id}
+    for c in children:
+        assert c.parent_id == parent.id
+        assert c.is_parent is False
+
+
+@pytest.mark.asyncio
+async def test_create_split_rejects_single_leg(db: AsyncSession, family_id):
+    account = await AccountService.create(
+        db, family_id, AccountCreate(name="Checking", type="checking")
+    )
+    group = await CategoryGroupService.create(
+        db, family_id, CategoryGroupCreate(name="Food", is_income=False)
+    )
+    cat = await CategoryService.create(
+        db, family_id, CategoryCreate(name="Groceries", group_id=group.id)
+    )
+    with pytest.raises(ValidationError):
+        await TransactionService.create_split(
+            db, family_id,
+            account_id=account.id,
+            txn_date=date(2026, 5, 1),
+            splits=[SplitChild(amount=-100, category_id=cat.id)],
+        )
+
+
+@pytest.mark.asyncio
+async def test_replace_split_children_updates_parent_total(db: AsyncSession, family_id):
+    account = await AccountService.create(
+        db, family_id, AccountCreate(name="Checking", type="checking")
+    )
+    group = await CategoryGroupService.create(
+        db, family_id, CategoryGroupCreate(name="Food", is_income=False)
+    )
+    cat_a = await CategoryService.create(
+        db, family_id, CategoryCreate(name="Groceries", group_id=group.id)
+    )
+    cat_b = await CategoryService.create(
+        db, family_id, CategoryCreate(name="Snacks", group_id=group.id)
+    )
+
+    parent = await TransactionService.create_split(
+        db, family_id,
+        account_id=account.id,
+        txn_date=date(2026, 5, 1),
+        splits=[
+            SplitChild(amount=-7000, category_id=cat_a.id),
+            SplitChild(amount=-3000, category_id=cat_b.id),
+        ],
+    )
+    assert parent.amount == -10000
+
+    parent = await TransactionService.replace_split_children(
+        db, parent.id, family_id,
+        splits=[
+            SplitChild(amount=-2000, category_id=cat_a.id),
+            SplitChild(amount=-2500, category_id=cat_b.id),
+            SplitChild(amount=-1500, category_id=cat_a.id),
+        ],
+    )
+    assert parent.amount == -6000
+
+    children = await TransactionService.get_split_children(db, parent.id, family_id)
+    assert len(children) == 3
+    assert sum(c.amount for c in children) == -6000
+
+
+@pytest.mark.asyncio
+async def test_delete_parent_cascades_children(db: AsyncSession, family_id):
+    account = await AccountService.create(
+        db, family_id, AccountCreate(name="Checking", type="checking")
+    )
+    group = await CategoryGroupService.create(
+        db, family_id, CategoryGroupCreate(name="Food", is_income=False)
+    )
+    cat = await CategoryService.create(
+        db, family_id, CategoryCreate(name="Groceries", group_id=group.id)
+    )
+
+    parent = await TransactionService.create_split(
+        db, family_id,
+        account_id=account.id,
+        txn_date=date(2026, 5, 1),
+        splits=[
+            SplitChild(amount=-100, category_id=cat.id),
+            SplitChild(amount=-200, category_id=cat.id),
+        ],
+    )
+    parent_id = parent.id
+
+    await TransactionService.delete_by_id(db, parent_id, family_id)
+
+    # Children should be gone via FK cascade (parent_id ondelete=CASCADE)
+    remaining = (await db.execute(
+        select(BudgetTransaction).where(BudgetTransaction.parent_id == parent_id)
+    )).scalars().all()
+    assert remaining == []
+
+
+@pytest.mark.asyncio
+async def test_get_split_children_rejects_non_parent(db: AsyncSession, family_id):
+    from app.schemas.budget import TransactionCreate
+    account = await AccountService.create(
+        db, family_id, AccountCreate(name="Checking", type="checking")
+    )
+    standalone = await TransactionService.create(
+        db, family_id,
+        TransactionCreate(account_id=account.id, date=date(2026, 5, 1), amount=-100),
+    )
+    with pytest.raises(ValidationError):
+        await TransactionService.get_split_children(db, standalone.id, family_id)

--- a/backend/tests/test_split_transactions.py
+++ b/backend/tests/test_split_transactions.py
@@ -162,3 +162,41 @@ async def test_get_split_children_rejects_non_parent(db: AsyncSession, family_id
     )
     with pytest.raises(ValidationError):
         await TransactionService.get_split_children(db, standalone.id, family_id)
+
+
+@pytest.mark.asyncio
+async def test_bulk_update_rejects_cross_family_category(db: AsyncSession, family_id):
+    """bulk_update_transactions must refuse to set a category from another family."""
+    from app.schemas.budget import TransactionCreate
+    from app.models.family import Family
+
+    # Owner family + transaction
+    account = await AccountService.create(
+        db, family_id, AccountCreate(name="Checking", type="checking")
+    )
+    txn = await TransactionService.create(
+        db, family_id,
+        TransactionCreate(account_id=account.id, date=date(2026, 5, 1), amount=-100),
+    )
+
+    # Foreign family + category that the owner must not be allowed to attach
+    other_family = Family(name="Other Family")
+    db.add(other_family)
+    await db.commit()
+    await db.refresh(other_family)
+
+    other_group = await CategoryGroupService.create(
+        db, other_family.id, CategoryGroupCreate(name="Other Food", is_income=False)
+    )
+    other_cat = await CategoryService.create(
+        db, other_family.id, CategoryCreate(name="Their Groceries", group_id=other_group.id)
+    )
+
+    with pytest.raises(NotFoundException):
+        await TransactionService.bulk_update_transactions(
+            db, family_id, [txn.id], {"category_id": other_cat.id}
+        )
+
+    # Verify txn untouched
+    await db.refresh(txn)
+    assert txn.category_id is None


### PR DESCRIPTION
## Summary
- Closes production blockers: soft-delete filters, pagination, currency, timezone (5a744ea)
- Split transactions implementation + tests (7fb55dd)
- Transaction search, bulk update/delete, reconciliation finalization (561a15f)
- Allocation `copy_from_month`, `fill_from_average`, `carry_over_month` (cd32c84)
- Payee `merge_payees`, `get_last_category`; category `delete_with_reassign`; rule `apply_all`/`suggest_new` (f14f896)
- Net worth history, budget vs actual, recurring auto-post (c6d7906)

## Test plan
- [ ] `docker exec -e PYTHONPATH=/app family_app_backend pytest tests/ -v`
- [ ] Verify split transactions via `/budget/transactions`
- [ ] Allocation copy/fill/carry-over flows in `/budget/`
- [ ] Net worth + budget-vs-actual reports render
- [ ] Recurring auto-post fires on schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)