### PR TITLE
chore(frontend): Google OAuth client ID from env + configurable backend host port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,7 +94,10 @@ services:
       # PAYPAL_*, RESEND_API_KEY, ANTHROPIC_API_KEY, BASE_URL, ...) is fetched
       # from Vault exclusively — no compose-side leak of secrets.
     ports:
-       - "8003:8000"
+       # Host port is configurable so a deployment can avoid collisions with
+       # other services on the same host. Defaults to 8003 to match local-dev
+       # docs. Internal Docker network is unchanged (frontend → backend:8000).
+       - "${BACKEND_HOST_PORT:-8003}:8000"
     volumes:
       - receipt_uploads:/app/uploads
     depends_on:
@@ -120,6 +123,12 @@ services:
     build:
       context: .
       dockerfile: frontend/Dockerfile
+      args:
+        # Astro/Vite inlines PUBLIC_* into the client bundle at build time,
+        # so this must be a build arg, not a runtime env var. Empty string
+        # is fine — the Sign-In button degrades to no-op and password login
+        # still works.
+        PUBLIC_GOOGLE_CLIENT_ID: ${PUBLIC_GOOGLE_CLIENT_ID:-}
     container_name: family_app_frontend
     environment:
       API_BASE_URL: http://backend:8000

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -21,6 +21,12 @@ RUN npm ci
 COPY frontend/ ./
 COPY docs/ ./docs/
 
+# Build-time public env. Astro/Vite inlines anything matching PUBLIC_* into
+# the client bundle at build, so per-environment values (dev, stage, prod)
+# must be supplied as docker build args — they cannot be patched at runtime.
+ARG PUBLIC_GOOGLE_CLIENT_ID=""
+ENV PUBLIC_GOOGLE_CLIENT_ID=${PUBLIC_GOOGLE_CLIENT_ID}
+
 RUN npm run build
 
 

--- a/frontend/src/pages/login.astro
+++ b/frontend/src/pages/login.astro
@@ -14,6 +14,13 @@ if (flashError) {
     error = flashError;
     Astro.cookies.delete("login_error", { path: "/" });
 }
+
+// Google OAuth client ID. Read from PUBLIC_GOOGLE_CLIENT_ID at build time
+// (Astro/Vite inlines PUBLIC_* into the client bundle) so dev, stage, and
+// prod can each point at their own OAuth client without code changes. If
+// unset, the Sign-In button renders but does nothing — falls back to
+// password login.
+const googleClientId = import.meta.env.PUBLIC_GOOGLE_CLIENT_ID ?? "";
 ---
 
 <Layout title={`${t(lang, "login_submit")} - Family Task Manager`}>
@@ -153,7 +160,7 @@ if (flashError) {
                         <div class="mb-6">
                             <div
                                 id="g_id_onload"
-                                data-client_id="355849593-42c0kgc5hbq2l0mr23g95b74jv3nprod.apps.googleusercontent.com"
+                                data-client_id={googleClientId}
                                 data-callback="handleGoogleLogin"
                                 data-auto_prompt="false"
                                 data-use_fedcm_for_prompt="true">
@@ -273,8 +280,10 @@ if (flashError) {
     <script>
         import { showToast } from '../lib/toast';
 
-        const GOOGLE_CLIENT_ID =
-            '355849593-42c0kgc5hbq2l0mr23g95b74jv3nprod.apps.googleusercontent.com';
+        // Vite inlines import.meta.env.PUBLIC_* at build time. Empty string
+        // when unset; the GIS prompt() call below is a no-op without a real
+        // client_id, so the page degrades to password-only login.
+        const GOOGLE_CLIENT_ID = import.meta.env.PUBLIC_GOOGLE_CLIENT_ID ?? '';
 
         // Expose showToast to the inline Google callback defined above.
         // The inline callback runs outside this module scope, so it can't


### PR DESCRIPTION
## Summary
Two small ops fixes from the prod deploy retro.

### 1. Hardcoded Google OAuth client ID → env var

`frontend/src/pages/login.astro` had the client ID inline in two places (data-client_id attribute and JS const), so dev / stage / prod all pointed at the same OAuth client. Replaced both with `import.meta.env.PUBLIC_GOOGLE_CLIENT_ID`.

Astro/Vite inlines `PUBLIC_*` into the client bundle **at build time**, so the value must arrive as a docker build arg, not a runtime env. Wired through:
- `frontend/Dockerfile`: `ARG PUBLIC_GOOGLE_CLIENT_ID` + `ENV` before `npm run build`
- `docker-compose.yml`: `build.args.PUBLIC_GOOGLE_CLIENT_ID: ${PUBLIC_GOOGLE_CLIENT_ID:-}`

Empty string is graceful — GIS `prompt()` becomes a no-op, password login still works.

### 2. Backend host port → env-configurable

Was hardcoded `"8003:8000"`. Collided with `platform-vllm-vision` on the on-prem host. Now `"${BACKEND_HOST_PORT:-8003}:8000"`. Default unchanged for everyone; deployments override via env. Internal network unchanged.

## Per-environment config
```
PUBLIC_GOOGLE_CLIENT_ID=<id>.apps.googleusercontent.com
BACKEND_HOST_PORT=8013   # set when default 8003 is taken
```

## Test plan
- [x] `docker build --build-arg PUBLIC_GOOGLE_CLIENT_ID=test-id` succeeds
- [x] Inlined value present in client bundle: `grep "test-id" /app/dist/client/_astro/*.js`
- [ ] Deploy to prod with `PUBLIC_GOOGLE_CLIENT_ID` set, log in via Google

🤖 Generated with [Claude Code](https://claude.com/claude-code)