### PR TITLE
Mandatory tasks zero points, gigs gated + parent-approved

### DIFF
--- a/backend/app/api/routes/task_assignments.py
+++ b/backend/app/api/routes/task_assignments.py
@@ -5,7 +5,8 @@ Handles weekly shuffle, assignment queries, completion with bonus gating,
 and daily progress tracking.
 """
 
-from fastapi import APIRouter, Depends, status, Query
+from fastapi import APIRouter, Depends, HTTPException, status, Query
+from sqlalchemy import select as sa_select
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing import List, Optional
 from datetime import date
@@ -23,8 +24,12 @@ from app.schemas.task_assignment import (
     TaskAssignmentWithDetails,
     DailyProgressResponse,
     AssignmentPatch,
+    CompleteAssignmentRequest,
+    ApprovalDecision,
+    GigApprovalRow,
 )
 from app.models import User
+from app.models.user import UserRole
 from app.models.task_assignment import AssignmentStatus
 
 router = APIRouter()
@@ -87,13 +92,31 @@ async def list_week_assignments(
 ):
     """List all assignments for a given week"""
     target = week_of or date.today()
+    family_id = to_uuid_required(current_user.family_id)
     assignments = await TaskAssignmentService.list_assignments_for_week(
         db,
-        family_id=to_uuid_required(current_user.family_id),
+        family_id=family_id,
         week_of=target,
         user_id=user_id,
         status=status,
     )
+
+    # Per-user, per-date lock cache. Only today (or future) can be locked;
+    # historical dates always render unlocked since the day has passed.
+    today = date.today()
+    lock_cache: dict[tuple, bool] = {}
+    for a in assignments:
+        is_bonus = a.template.is_bonus if a.template else False
+        if is_bonus and a.assigned_date == today and a.status != AssignmentStatus.COMPLETED:
+            key = (a.assigned_to, a.assigned_date)
+            if key not in lock_cache:
+                all_done = await TaskAssignmentService.check_all_required_done_today(
+                    db, a.assigned_to, family_id, a.assigned_date
+                )
+                lock_cache[key] = not all_done
+            a._is_locked = lock_cache[key]
+        else:
+            a._is_locked = False
 
     return [_assignment_to_detail(a) for a in assignments]
 
@@ -106,12 +129,29 @@ async def list_today_assignments(
 ):
     """List assignments for today (defaults to current user)"""
     target_user = user_id or to_uuid_required(current_user.id)
+    family_id = to_uuid_required(current_user.family_id)
     assignments = await TaskAssignmentService.list_assignments_for_date(
         db,
-        family_id=to_uuid_required(current_user.family_id),
+        family_id=family_id,
         target_date=date.today(),
         user_id=target_user,
     )
+
+    # Compute lock state once per (user, date) — needed because /today may
+    # include multiple users when filtered by user_id query param.
+    lock_cache: dict[tuple, bool] = {}
+    for a in assignments:
+        is_bonus = a.template.is_bonus if a.template else False
+        if is_bonus and a.status != AssignmentStatus.COMPLETED:
+            key = (a.assigned_to, a.assigned_date)
+            if key not in lock_cache:
+                all_done = await TaskAssignmentService.check_all_required_done_today(
+                    db, a.assigned_to, family_id, a.assigned_date
+                )
+                lock_cache[key] = not all_done
+            a._is_locked = lock_cache[key]
+        else:
+            a._is_locked = False
 
     return [_assignment_to_detail(a) for a in assignments]
 
@@ -136,6 +176,44 @@ async def get_daily_progress(
     progress["assignments"] = [_assignment_to_detail(a) for a in progress["assignments"]]
 
     return DailyProgressResponse(**progress)
+
+
+# ─── Approvals ───────────────────────────────────────────────────────
+# NOTE: must be registered BEFORE @router.get("/{assignment_id}") so FastAPI
+# doesn't try to coerce "pending-approvals" into a UUID.
+
+@router.get("/pending-approvals", response_model=List[GigApprovalRow])
+async def list_pending_approvals(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """List gigs awaiting parent approval (parents only)."""
+    if current_user.role != UserRole.PARENT:
+        raise HTTPException(status_code=403, detail="Parents only")
+
+    family_id = to_uuid_required(current_user.family_id)
+    rows = await TaskAssignmentService.list_pending_approvals(db, family_id)
+
+    # One query for assignee names — avoids N+1.
+    user_ids = list({r.assigned_to for r in rows})
+    user_names: dict = {}
+    if user_ids:
+        q = sa_select(User.id, User.name).where(User.id.in_(user_ids))
+        user_names = {uid: name for uid, name in (await db.execute(q)).all()}
+
+    return [
+        GigApprovalRow(
+            assignment_id=r.id,
+            template_id=r.template_id,
+            template_title=r.template.title if r.template else "",
+            points=r.template.points if r.template else 0,
+            assigned_to=r.assigned_to,
+            assigned_to_name=user_names.get(r.assigned_to, ""),
+            completed_at=r.completed_at,
+            proof_text=r.proof_text,
+        )
+        for r in rows
+    ]
 
 
 # ─── Assignment Actions ──────────────────────────────────────────────
@@ -178,23 +256,54 @@ async def patch_assignment(
 @router.patch("/{assignment_id}/complete", response_model=TaskAssignmentWithDetails)
 async def complete_assignment(
     assignment_id: UUID,
+    payload: Optional[CompleteAssignmentRequest] = None,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
     """
     Mark an assignment as completed.
-    Awards points automatically. Bonus tasks require all required tasks to be done first.
+
+    Mandatory tasks complete silently (no points). Gigs (is_bonus=true) require
+    `proof_text` in the body and enter PENDING approval — points are credited
+    only when a parent approves via POST /{id}/approve.
     """
-    assignment = await TaskAssignmentService.complete_assignment(
+    family_id = to_uuid_required(current_user.family_id)
+    await TaskAssignmentService.complete_assignment(
         db,
         assignment_id,
-        family_id=to_uuid_required(current_user.family_id),
+        family_id=family_id,
         user_id=to_uuid_required(current_user.id),
+        proof_text=(payload.proof_text if payload else None),
     )
 
     # Re-fetch with template loaded
     assignment = await TaskAssignmentService.get_assignment(
-        db, assignment_id, to_uuid_required(current_user.family_id)
+        db, assignment_id, family_id
+    )
+    return _assignment_to_detail(assignment)
+
+
+@router.post("/{assignment_id}/approve", response_model=TaskAssignmentWithDetails)
+async def approve_assignment(
+    assignment_id: UUID,
+    decision: ApprovalDecision,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Parent decision on a pending gig. Approve credits points; reject does not.
+    """
+    family_id = to_uuid_required(current_user.family_id)
+    await TaskAssignmentService.approve_gig(
+        db,
+        assignment_id=assignment_id,
+        family_id=family_id,
+        parent_id=to_uuid_required(current_user.id),
+        approve=decision.approve,
+        notes=decision.notes,
+    )
+    assignment = await TaskAssignmentService.get_assignment(
+        db, assignment_id, family_id
     )
     return _assignment_to_detail(assignment)
 
@@ -214,7 +323,12 @@ async def check_overdue_assignments(
 # ─── Helpers ─────────────────────────────────────────────────────────
 
 def _assignment_to_detail(assignment) -> dict:
-    """Convert a TaskAssignment ORM object to TaskAssignmentWithDetails dict"""
+    """Convert a TaskAssignment ORM object to TaskAssignmentWithDetails dict.
+
+    Synthetic enrichment: callers may set assignment._is_locked = True on the
+    Python object before calling this helper (used by /today and /week to
+    surface bonus-gating state without re-querying).
+    """
     template = assignment.template
     assigned_user = getattr(assignment, "assigned_user", None)
     return {
@@ -241,4 +355,12 @@ def _assignment_to_detail(assignment) -> dict:
         # Computed
         "is_overdue": assignment.is_overdue,
         "can_complete": assignment.can_complete,
+        # Gig gating + approval enrichment
+        "is_locked": bool(getattr(assignment, "_is_locked", False)),
+        "approval_status": (
+            assignment.approval_status.value
+            if getattr(assignment, "approval_status", None)
+            else "none"
+        ),
+        "proof_text": getattr(assignment, "proof_text", None),
     }

--- a/backend/app/api/routes/task_assignments.py
+++ b/backend/app/api/routes/task_assignments.py
@@ -103,7 +103,8 @@ async def list_week_assignments(
 
     # Per-user, per-date lock cache. Only today (or future) can be locked;
     # historical dates always render unlocked since the day has passed.
-    today = date.today()
+    # "today" is computed in the viewer's family timezone.
+    today = await TaskAssignmentService._user_local_today(db, current_user.id)
     lock_cache: dict[tuple, bool] = {}
     for a in assignments:
         is_bonus = a.template.is_bonus if a.template else False
@@ -130,10 +131,11 @@ async def list_today_assignments(
     """List assignments for today (defaults to current user)"""
     target_user = user_id or to_uuid_required(current_user.id)
     family_id = to_uuid_required(current_user.family_id)
+    today = await TaskAssignmentService._user_local_today(db, target_user)
     assignments = await TaskAssignmentService.list_assignments_for_date(
         db,
         family_id=family_id,
-        target_date=date.today(),
+        target_date=today,
         user_id=target_user,
     )
 

--- a/backend/app/models/family.py
+++ b/backend/app/models/family.py
@@ -22,6 +22,7 @@ class Family(Base):
     
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, index=True)
     name = Column(String(100), nullable=False)
+    timezone = Column(String(64), nullable=False, default="UTC", server_default="UTC")
     created_by = Column(UUID(as_uuid=True), nullable=True)  # Nullable during creation, set after user created
     join_code = Column(String(10), unique=True, nullable=True, index=True)  # Short code for family invites
     is_active = Column(Boolean, default=True, nullable=False)

--- a/backend/app/models/point_transaction.py
+++ b/backend/app/models/point_transaction.py
@@ -19,6 +19,7 @@ class TransactionType(str, enum.Enum):
     REWARD_REDEEMED = "reward_redeemed"  # Points spent on reward
     PARENT_ADJUSTMENT = "parent_adjustment"  # Manual adjustment by parent
     BONUS = "bonus"  # Bonus points
+    GIG_APPROVED = "gig_approved"  # Points credited after parent approves a gig
     PENALTY = "penalty"  # Point deduction
     TRANSFER = "transfer"  # Transfer between users
 
@@ -85,6 +86,18 @@ class PointTransaction(Base):
             balance_before=balance_before,
             balance_after=balance_before + points,
             description=f"Completed task and earned {points} points"
+        )
+
+    @classmethod
+    def create_gig_approval(cls, user_id, assignment_id, points: int, balance_before: int):
+        return cls(
+            type=TransactionType.GIG_APPROVED,
+            user_id=user_id,
+            assignment_id=assignment_id,
+            points=points,
+            balance_before=balance_before,
+            balance_after=balance_before + points,
+            description=f"Gig approved — earned {points} points",
         )
 
     @classmethod

--- a/backend/app/models/task_assignment.py
+++ b/backend/app/models/task_assignment.py
@@ -14,6 +14,7 @@ from sqlalchemy import (
     DateTime,
     Date,
     ForeignKey,
+    Text,
     Enum as SQLEnum,
 )
 from sqlalchemy.dialects.postgresql import UUID
@@ -32,6 +33,14 @@ class AssignmentStatus(str, enum.Enum):
     COMPLETED = "completed"
     OVERDUE = "overdue"
     CANCELLED = "cancelled"
+
+
+class ApprovalStatus(str, enum.Enum):
+    """Gig approval lifecycle."""
+    NONE = "none"
+    PENDING = "pending"
+    APPROVED = "approved"
+    REJECTED = "rejected"
 
 
 class TaskAssignment(Base):
@@ -73,6 +82,26 @@ class TaskAssignment(Base):
         nullable=False,
         index=True,
     )
+
+    approval_status = Column(
+        SQLEnum(
+            ApprovalStatus,
+            values_callable=lambda x: [e.value for e in x],
+            name="approval_status",
+        ),
+        nullable=False,
+        default=ApprovalStatus.NONE,
+        server_default="none",
+        index=True,
+    )
+    proof_text = Column(Text, nullable=True)
+    approved_by = Column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    approved_at = Column(DateTime(timezone=True), nullable=True)
+    approval_notes = Column(Text, nullable=True)
 
     # Scheduling
     assigned_date = Column(Date, nullable=False)  # The specific date this task is for

--- a/backend/app/models/task_template.py
+++ b/backend/app/models/task_template.py
@@ -14,6 +14,7 @@ from sqlalchemy import (
     DateTime,
     ForeignKey,
     Text,
+    CheckConstraint,
     Enum as SQLEnum,
 )
 from sqlalchemy.dialects.postgresql import UUID, JSONB
@@ -36,6 +37,12 @@ class TaskTemplate(Base):
     """Reusable task template for weekly assignment generation"""
 
     __tablename__ = "task_templates"
+    __table_args__ = (
+        CheckConstraint(
+            "is_bonus = true OR points = 0",
+            name="chk_mandatory_zero_points",
+        ),
+    )
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, index=True)
     title = Column(String(200), nullable=False)

--- a/backend/app/schemas/task_assignment.py
+++ b/backend/app/schemas/task_assignment.py
@@ -69,6 +69,9 @@ class TaskAssignmentWithDetails(TaskAssignmentResponse):
     assigned_user_name: str = ""
     is_overdue: bool = False
     can_complete: bool = True
+    is_locked: bool = False
+    approval_status: str = "none"
+    proof_text: Optional[str] = None
 
 
 class ShuffleResponse(BaseModel):
@@ -114,3 +117,25 @@ class DailyProgressResponse(BaseModel):
     bonus_total: int
     bonus_completed: int
     assignments: List[TaskAssignmentWithDetails]
+
+
+class CompleteAssignmentRequest(BaseModel):
+    proof_text: Optional[str] = Field(None, max_length=4000)
+
+
+class ApprovalDecision(BaseModel):
+    approve: bool
+    notes: Optional[str] = Field(None, max_length=2000)
+
+
+class GigApprovalRow(BaseModel):
+    assignment_id: UUID
+    template_id: UUID
+    template_title: str
+    points: int
+    assigned_to: UUID
+    assigned_to_name: str
+    completed_at: datetime
+    proof_text: Optional[str] = None
+
+    model_config = {"from_attributes": True}

--- a/backend/app/schemas/task_template.py
+++ b/backend/app/schemas/task_template.py
@@ -4,7 +4,7 @@ TaskTemplate Pydantic schemas
 Request and response models for task template operations.
 """
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 from typing import Optional, List
 from uuid import UUID
 
@@ -35,7 +35,14 @@ class TaskTemplateBase(BaseModel):
 class TaskTemplateCreate(TaskTemplateBase):
     """Schema for creating a new task template"""
 
-    pass
+    @model_validator(mode="after")
+    def _enforce_mandatory_zero_points(self):
+        if not self.is_bonus and self.points != 0:
+            raise ValueError(
+                "Mandatory tasks (is_bonus=false) must have points=0. "
+                "Set is_bonus=true to award points."
+            )
+        return self
 
 
 class TaskTemplateUpdate(BaseModel):
@@ -52,6 +59,16 @@ class TaskTemplateUpdate(BaseModel):
     assignment_type: Optional[AssignmentType] = None
     assigned_user_ids: Optional[List[UUID]] = None
     allowed_roles: Optional[List[str]] = None
+
+    @model_validator(mode="after")
+    def _enforce_mandatory_zero_points(self):
+        # Only validate if both fields are present in the update; otherwise
+        # we cannot know the combined state without the existing row.
+        if self.is_bonus is False and self.points is not None and self.points != 0:
+            raise ValueError(
+                "Mandatory tasks (is_bonus=false) must have points=0."
+            )
+        return self
 
 
 # Response schemas

--- a/backend/app/services/family_service.py
+++ b/backend/app/services/family_service.py
@@ -19,6 +19,31 @@ from app.core.exceptions import NotFoundException, ValidationException
 class FamilyService:
     """Service for family-related operations"""
 
+    DEFAULT_GIGS = [
+        ("Learn a topic + writeup", "Pick something new (podman, git, a recipe). Read up, then write 5-10 sentences on what you learned.", 30),
+        ("Read book chapter + discuss", "Read a chapter, then sit with a parent to discuss the main idea.", 20),
+        ("Plan next 3 days of meals", "Propose breakfasts, lunches, and dinners for the next 3 days. List groceries needed.", 25),
+        ("Help with grocery shopping", "Help compile the list, go to the store, and help carry/put away.", 15),
+        ("Cook family dinner", "Plan, cook, and serve a family dinner with parent supervision.", 25),
+        ("Tech-help parent (15 min)", "Help a parent with a phone/computer task for at least 15 minutes.", 10),
+    ]
+
+    @staticmethod
+    async def _seed_default_gigs(db: AsyncSession, family_id: UUID) -> None:
+        from app.models.task_template import TaskTemplate, AssignmentType
+        for title, description, points in FamilyService.DEFAULT_GIGS:
+            db.add(TaskTemplate(
+                title=title,
+                description=description,
+                points=points,
+                interval_days=7,
+                assignment_type=AssignmentType.AUTO,
+                is_bonus=True,
+                is_active=True,
+                family_id=family_id,
+            ))
+        await db.flush()
+
     @staticmethod
     async def create_family(
         db: AsyncSession,
@@ -31,10 +56,14 @@ class FamilyService:
             created_by=created_by,
             is_active=True,
         )
-        
+
         db.add(family)
         await db.commit()
         await db.refresh(family)
+
+        await FamilyService._seed_default_gigs(db, family.id)
+        await db.commit()
+
         return family
 
     @staticmethod

--- a/backend/app/services/family_service.py
+++ b/backend/app/services/family_service.py
@@ -19,6 +19,12 @@ from app.core.exceptions import NotFoundException, ValidationException
 class FamilyService:
     """Service for family-related operations"""
 
+    # Default gig starter pack.
+    # NOTE: this list is duplicated in
+    # `backend/migrations/versions/2026_05_22_mandatory_zero_points_and_gigs.py`
+    # because migrations must be self-contained (they cannot safely import
+    # application code that changes over time). Keep the two copies in sync
+    # if the canonical content ever changes.
     DEFAULT_GIGS = [
         ("Learn a topic + writeup", "Pick something new (podman, git, a recipe). Read up, then write 5-10 sentences on what you learned.", 30),
         ("Read book chapter + discuss", "Read a chapter, then sit with a parent to discuss the main idea.", 20),
@@ -31,7 +37,19 @@ class FamilyService:
     @staticmethod
     async def _seed_default_gigs(db: AsyncSession, family_id: UUID) -> None:
         from app.models.task_template import TaskTemplate, AssignmentType
+
+        titles = [t for t, _, _ in FamilyService.DEFAULT_GIGS]
+        existing = (await db.execute(
+            select(TaskTemplate.title).where(
+                TaskTemplate.family_id == family_id,
+                TaskTemplate.title.in_(titles),
+            )
+        )).scalars().all()
+        existing_set = set(existing)
+
         for title, description, points in FamilyService.DEFAULT_GIGS:
+            if title in existing_set:
+                continue
             db.add(TaskTemplate(
                 title=title,
                 description=description,

--- a/backend/app/services/points_service.py
+++ b/backend/app/services/points_service.py
@@ -70,6 +70,25 @@ class PointsService:
         return transaction
 
     @staticmethod
+    async def award_gig_points(
+        db: AsyncSession,
+        user_id: UUID,
+        assignment_id: UUID,
+        points: int,
+    ) -> PointTransaction:
+        """Credit gig points after parent approval. Caller commits."""
+        user = await get_user_by_id(db, user_id)
+        transaction = PointTransaction.create_gig_approval(
+            user_id=user_id,
+            assignment_id=assignment_id,
+            points=points,
+            balance_before=user.points,
+        )
+        user.points += points
+        db.add(transaction)
+        return transaction
+
+    @staticmethod
     async def deduct_points_for_reward(
         db: AsyncSession,
         user_id: UUID,

--- a/backend/app/services/task_assignment_service.py
+++ b/backend/app/services/task_assignment_service.py
@@ -643,6 +643,65 @@ class TaskAssignmentService(BaseFamilyService[TaskAssignment]):
         await db.refresh(assignment)
         return assignment
 
+    # ─── Gig approval (parent-only) ──────────────────────────────────
+
+    @staticmethod
+    async def approve_gig(
+        db: AsyncSession,
+        assignment_id: UUID,
+        family_id: UUID,
+        parent_id: UUID,
+        approve: bool,
+        notes: Optional[str] = None,
+    ) -> TaskAssignment:
+        from app.models.user import UserRole
+        from app.services.points_service import PointsService
+
+        parent = await get_user_by_id(db, parent_id)
+        if parent.family_id != family_id or parent.role != UserRole.PARENT:
+            raise ForbiddenException("Only parents in this family can approve gigs")
+
+        assignment = await TaskAssignmentService.get_assignment(db, assignment_id, family_id)
+
+        if assignment.approval_status != ApprovalStatus.PENDING:
+            raise ValidationException(
+                f"Gig already decided (status: {assignment.approval_status.value})"
+            )
+
+        assignment.approved_by = parent_id
+        assignment.approved_at = datetime.utcnow()
+        assignment.approval_notes = notes
+
+        if approve:
+            assignment.approval_status = ApprovalStatus.APPROVED
+            await PointsService.award_gig_points(
+                db, assignment.assigned_to, assignment.id, assignment.template.points
+            )
+        else:
+            assignment.approval_status = ApprovalStatus.REJECTED
+
+        await db.commit()
+        await db.refresh(assignment)
+        return assignment
+
+    @staticmethod
+    async def list_pending_approvals(
+        db: AsyncSession,
+        family_id: UUID,
+    ) -> list[TaskAssignment]:
+        from sqlalchemy.orm import selectinload
+        q = (
+            select(TaskAssignment)
+            .options(selectinload(TaskAssignment.template))
+            .where(
+                TaskAssignment.family_id == family_id,
+                TaskAssignment.approval_status == ApprovalStatus.PENDING,
+            )
+            .order_by(TaskAssignment.completed_at.asc())
+        )
+        result = await db.execute(q)
+        return list(result.scalars().all())
+
     # ─── Parent Edit (reassign / reschedule / cancel) ────────────────
 
     @staticmethod

--- a/backend/app/services/task_assignment_service.py
+++ b/backend/app/services/task_assignment_service.py
@@ -685,6 +685,46 @@ class TaskAssignmentService(BaseFamilyService[TaskAssignment]):
         return assignment
 
     @staticmethod
+    async def list_for_user_today_with_locks(
+        db: AsyncSession,
+        user_id: UUID,
+        family_id: UUID,
+    ) -> list[dict]:
+        """Return today's assignments for a user with is_locked + approval fields."""
+        today = await TaskAssignmentService._user_local_today(db, user_id)
+        all_done = await TaskAssignmentService.check_all_required_done_today(
+            db, user_id, family_id, today
+        )
+        q = (
+            select(TaskAssignment)
+            .options(selectinload(TaskAssignment.template))
+            .where(
+                TaskAssignment.assigned_to == user_id,
+                TaskAssignment.family_id == family_id,
+                TaskAssignment.assigned_date == today,
+            )
+            .order_by(TaskAssignment.assigned_date)
+        )
+        rows = (await db.execute(q)).scalars().all()
+        out = []
+        for r in rows:
+            is_bonus = r.template.is_bonus
+            out.append({
+                "id": r.id,
+                "template_id": r.template_id,
+                "title": r.template.title,
+                "points": r.template.points,
+                "is_bonus": is_bonus,
+                "status": r.status.value,
+                "approval_status": r.approval_status.value if r.approval_status else "none",
+                "proof_text": r.proof_text,
+                "is_locked": is_bonus and not all_done and r.status != AssignmentStatus.COMPLETED,
+                "assigned_date": r.assigned_date,
+                "completed_at": r.completed_at,
+            })
+        return out
+
+    @staticmethod
     async def list_pending_approvals(
         db: AsyncSession,
         family_id: UUID,

--- a/backend/app/services/task_assignment_service.py
+++ b/backend/app/services/task_assignment_service.py
@@ -808,8 +808,9 @@ class TaskAssignmentService(BaseFamilyService[TaskAssignment]):
         """
         Get daily progress summary for a user.
         Returns required/bonus counts and whether bonus is unlocked.
+        "today" is computed in the user's family timezone when target_date is None.
         """
-        check_date = target_date or date.today()
+        check_date = target_date or await TaskAssignmentService._user_local_today(db, user_id)
 
         assignments = await TaskAssignmentService.list_assignments_for_date(
             db, family_id, check_date, user_id

--- a/backend/app/services/task_assignment_service.py
+++ b/backend/app/services/task_assignment_service.py
@@ -13,7 +13,7 @@ from datetime import datetime, date, timedelta
 from uuid import UUID
 
 from app.models.task_template import TaskTemplate, AssignmentType
-from app.models.task_assignment import TaskAssignment, AssignmentStatus
+from app.models.task_assignment import TaskAssignment, AssignmentStatus, ApprovalStatus
 from app.models.user import User
 from app.models.point_transaction import PointTransaction, TransactionType
 from app.core.exceptions import (
@@ -590,57 +590,57 @@ class TaskAssignmentService(BaseFamilyService[TaskAssignment]):
         assignment_id: UUID,
         family_id: UUID,
         user_id: UUID,
+        proof_text: Optional[str] = None,
     ) -> TaskAssignment:
         """
-        Mark an assignment as completed, award points, and enforce bonus gating.
+        Mark an assignment as completed.
+
+        Mandatory (is_bonus=false): completes silently, awards no points.
+        Gig (is_bonus=true): requires all today's mandatory done first, requires
+        proof_text, and enters PENDING approval state. Points are credited only
+        when a parent approves via approve_gig().
         """
         assignment = await TaskAssignmentService.get_assignment(
             db, assignment_id, family_id
         )
 
-        # Validate assignment can be completed
         if not assignment.can_complete:
             raise ValidationException(
                 f"Assignment cannot be completed. Current status: {assignment.status.value}"
             )
 
-        # Verify user is the assigned user
         if assignment.assigned_to != user_id:
             raise ForbiddenException(
                 "Only the assigned user can complete this assignment"
             )
 
-        # Check bonus gating: if this is a bonus task, required tasks must be done first
         template = assignment.template
+
         if template.is_bonus:
-            all_required_done = (
-                await TaskAssignmentService.check_all_required_done_today(
-                    db, user_id, family_id, assignment.assigned_date
-                )
+            # Gig path
+            all_required_done = await TaskAssignmentService.check_all_required_done_today(
+                db, user_id, family_id, assignment.assigned_date
             )
             if not all_required_done:
                 raise ForbiddenException(
-                    "Complete all required tasks for today before accessing bonus tasks"
+                    "Complete today's mandatory tasks before claiming a gig"
                 )
 
-        # Mark as completed
-        assignment.status = AssignmentStatus.COMPLETED
-        assignment.completed_at = datetime.utcnow()
+            if not proof_text or not proof_text.strip():
+                raise ValidationException("Gigs require proof text describing what you did")
 
-        # Award points
-        user = await get_user_by_id(db, user_id)
-        transaction = PointTransaction.create_assignment_completion(
-            user_id=user_id,
-            assignment_id=assignment.id,
-            points=template.points,
-            balance_before=user.points,
-        )
-        user.points += template.points
+            assignment.status = AssignmentStatus.COMPLETED
+            assignment.completed_at = datetime.utcnow()
+            assignment.approval_status = ApprovalStatus.PENDING
+            assignment.proof_text = proof_text.strip()
+        else:
+            # Mandatory path — silent, no points, no approval
+            assignment.status = AssignmentStatus.COMPLETED
+            assignment.completed_at = datetime.utcnow()
+            # approval_status stays NONE; no PointTransaction row
 
-        db.add(transaction)
         await db.commit()
         await db.refresh(assignment)
-
         return assignment
 
     # ─── Parent Edit (reassign / reschedule / cancel) ────────────────

--- a/backend/app/services/task_assignment_service.py
+++ b/backend/app/services/task_assignment_service.py
@@ -33,6 +33,24 @@ class TaskAssignmentService(BaseFamilyService[TaskAssignment]):
 
     model = TaskAssignment
 
+    @staticmethod
+    async def _user_local_today(db: AsyncSession, user_id: UUID) -> date:
+        """Return today's date in the user's family timezone."""
+        from zoneinfo import ZoneInfo
+        from app.models.family import Family
+        from app.services.base_service import get_user_by_id
+        user = await get_user_by_id(db, user_id)
+        tz_name = "UTC"
+        if user.family_id is not None:
+            family = await db.get(Family, user.family_id)
+            if family and family.timezone:
+                tz_name = family.timezone
+        try:
+            tz = ZoneInfo(tz_name)
+        except Exception:
+            tz = ZoneInfo("UTC")
+        return datetime.now(tz).date()
+
     # ─── Shuffle Algorithm ───────────────────────────────────────────
 
     @staticmethod

--- a/backend/migrations/versions/2026_05_22_mandatory_zero_points_and_gigs.py
+++ b/backend/migrations/versions/2026_05_22_mandatory_zero_points_and_gigs.py
@@ -75,7 +75,10 @@ def upgrade() -> None:
     )
 
     # 4. new transaction type value
-    op.execute("ALTER TYPE transactiontype ADD VALUE IF NOT EXISTS 'gig_approved'")
+    # NOTE: existing values use uppercase (TASK_COMPLETED, etc.) because the
+    # SQLAlchemy column was declared without values_callable, so it sends the
+    # Python enum NAME, not the value. Match that convention.
+    op.execute("ALTER TYPE transactiontype ADD VALUE IF NOT EXISTS 'GIG_APPROVED'")
 
     # 5. seed default gig pack per existing family
     seed_default_gig_pack(bind)

--- a/backend/migrations/versions/2026_05_22_mandatory_zero_points_and_gigs.py
+++ b/backend/migrations/versions/2026_05_22_mandatory_zero_points_and_gigs.py
@@ -1,0 +1,133 @@
+"""mandatory zero points + gig approval columns
+
+Revision ID: gigs_v1_approval
+Revises: seed_sub_plans_v1
+Create Date: 2026-05-22
+
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "gigs_v1_approval"
+down_revision = "seed_sub_plans_v1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    # 1. families.timezone
+    op.add_column(
+        "families",
+        sa.Column("timezone", sa.String(length=64), nullable=True),
+    )
+    op.execute("UPDATE families SET timezone = 'UTC' WHERE timezone IS NULL")
+    op.alter_column("families", "timezone", nullable=False, server_default="UTC")
+
+    # 2. zero out mandatory template points
+    op.execute("UPDATE task_templates SET points = 0 WHERE is_bonus = false")
+    op.create_check_constraint(
+        "chk_mandatory_zero_points",
+        "task_templates",
+        "is_bonus = true OR points = 0",
+    )
+
+    # 3. approval_status enum + columns on task_assignments
+    approval_status = postgresql.ENUM(
+        "none", "pending", "approved", "rejected",
+        name="approval_status",
+    )
+    approval_status.create(bind, checkfirst=True)
+
+    op.add_column(
+        "task_assignments",
+        sa.Column(
+            "approval_status",
+            sa.Enum("none", "pending", "approved", "rejected", name="approval_status", create_type=False),
+            nullable=False,
+            server_default="none",
+        ),
+    )
+    op.add_column("task_assignments", sa.Column("proof_text", sa.Text(), nullable=True))
+    op.add_column(
+        "task_assignments",
+        sa.Column("approved_by", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_assignments_approved_by_users",
+        "task_assignments", "users",
+        ["approved_by"], ["id"],
+        ondelete="SET NULL",
+    )
+    op.add_column(
+        "task_assignments",
+        sa.Column("approved_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column("task_assignments", sa.Column("approval_notes", sa.Text(), nullable=True))
+    op.create_index(
+        "idx_assignments_family_approval",
+        "task_assignments",
+        ["family_id", "approval_status"],
+    )
+
+    # 4. new transaction type value
+    op.execute("ALTER TYPE transactiontype ADD VALUE IF NOT EXISTS 'gig_approved'")
+
+    # 5. seed default gig pack per existing family
+    seed_default_gig_pack(bind)
+
+
+def downgrade() -> None:
+    op.drop_index("idx_assignments_family_approval", table_name="task_assignments")
+    op.drop_constraint("fk_assignments_approved_by_users", "task_assignments", type_="foreignkey")
+    op.drop_column("task_assignments", "approval_notes")
+    op.drop_column("task_assignments", "approved_at")
+    op.drop_column("task_assignments", "approved_by")
+    op.drop_column("task_assignments", "proof_text")
+    op.drop_column("task_assignments", "approval_status")
+
+    bind = op.get_bind()
+    sa.Enum(name="approval_status").drop(bind, checkfirst=True)
+
+    op.drop_constraint("chk_mandatory_zero_points", "task_templates", type_="check")
+    op.drop_column("families", "timezone")
+
+
+DEFAULT_GIGS = [
+    ("Learn a topic + writeup", "Pick something new (podman, git, a recipe). Read up, then write 5-10 sentences on what you learned.", 30),
+    ("Read book chapter + discuss", "Read a chapter, then sit with a parent to discuss the main idea.", 20),
+    ("Plan next 3 days of meals", "Propose breakfasts, lunches, and dinners for the next 3 days. List groceries needed.", 25),
+    ("Help with grocery shopping", "Help compile the list, go to the store, and help carry/put away.", 15),
+    ("Cook family dinner", "Plan, cook, and serve a family dinner with parent supervision.", 25),
+    ("Tech-help parent (15 min)", "Help a parent with a phone/computer task for at least 15 minutes.", 10),
+]
+
+
+def seed_default_gig_pack(bind):
+    family_ids = bind.execute(sa.text("SELECT id FROM families")).scalars().all()
+    for family_id in family_ids:
+        existing = bind.execute(
+            sa.text(
+                "SELECT title FROM task_templates "
+                "WHERE family_id = :fid AND title = ANY(:titles)"
+            ),
+            {"fid": family_id, "titles": [t[0] for t in DEFAULT_GIGS]},
+        ).scalars().all()
+        existing_set = set(existing)
+        for title, description, points in DEFAULT_GIGS:
+            if title in existing_set:
+                continue
+            bind.execute(
+                sa.text(
+                    "INSERT INTO task_templates "
+                    "(id, title, description, points, interval_days, assignment_type, "
+                    " is_bonus, is_active, family_id, created_at, updated_at) "
+                    "VALUES (gen_random_uuid(), :title, :desc, :points, 7, 'auto', "
+                    " true, true, :fid, NOW(), NOW())"
+                ),
+                {"title": title, "desc": description, "points": points, "fid": family_id},
+            )

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -72,9 +72,10 @@ async def test_engine_session():
             ("userrole", ["PARENT", "CHILD", "TEEN"]),
             ("taskstatus", ["PENDING", "COMPLETED", "OVERDUE", "CANCELLED"]),
             ("taskfrequency", ["DAILY", "WEEKLY", "MONTHLY", "ONE_TIME"]),
-            ("transactiontype", ["TASK_COMPLETED", "REWARD_REDEEMED", "PARENT_ADJUSTMENT", "BONUS", "PENALTY", "TRANSFER"]),
+            ("transactiontype", ["TASK_COMPLETED", "REWARD_REDEEMED", "PARENT_ADJUSTMENT", "BONUS", "PENALTY", "TRANSFER", "GIG_APPROVED"]),
             ("rewardcategory", ["SCREEN_TIME", "TREATS", "ACTIVITIES", "PRIVILEGES", "MONEY", "TOYS"]),
             ("assignmentstatus", ["pending", "completed", "overdue", "cancelled"]),
+            ("approval_status", ["none", "pending", "approved", "rejected"]),
             ("invitationstatus", ["PENDING", "ACCEPTED", "REJECTED", "EXPIRED"]),
             ("restrictiontype", ["SCREEN_TIME", "REWARDS", "EXTRA_TASKS", "ALLOWANCE", "ACTIVITIES", "CUSTOM"]),
             ("consequenceseverity", ["LOW", "MEDIUM", "HIGH"]),
@@ -201,6 +202,27 @@ async def test_child_user(db_session: AsyncSession, test_family):
         family_id=test_family.id,
         email_verified=True,
         points=100,
+    )
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+    return user
+
+
+@pytest_asyncio.fixture
+async def test_teen_user(db_session: AsyncSession, test_family):
+    """Create a test teen user (used for non-parent permission tests)."""
+    from app.models.user import User, UserRole
+    from app.core.security import get_password_hash
+
+    user = User(
+        email="teen@test.local",
+        password_hash=get_password_hash("password123"),
+        name="Test Teen",
+        role=UserRole.TEEN,
+        family_id=test_family.id,
+        email_verified=True,
+        points=0,
     )
     db_session.add(user)
     await db_session.commit()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -290,3 +290,44 @@ async def sample_family(db_session: AsyncSession):
     await db_session.commit()
     await db_session.refresh(fam)
     return fam
+
+
+# Task template factories for gig gating tests
+
+
+@pytest_asyncio.fixture
+async def mandatory_template_factory(db_session: AsyncSession):
+    """Factory for a mandatory (is_bonus=False) task template."""
+    from uuid import uuid4
+    from app.models.task_template import TaskTemplate, AssignmentType
+
+    async def _make(*, family, points: int = 0, title: str = "Brush teeth"):
+        t = TaskTemplate(
+            id=uuid4(), title=title, points=points, interval_days=1,
+            assignment_type=AssignmentType.AUTO, is_bonus=False, is_active=True,
+            family_id=family.id,
+        )
+        db_session.add(t)
+        await db_session.commit()
+        return t
+
+    return _make
+
+
+@pytest_asyncio.fixture
+async def gig_template_factory(db_session: AsyncSession):
+    """Factory for a gig (is_bonus=True) task template."""
+    from uuid import uuid4
+    from app.models.task_template import TaskTemplate, AssignmentType
+
+    async def _make(*, family, points: int = 20, title: str = "Learn topic"):
+        t = TaskTemplate(
+            id=uuid4(), title=title, points=points, interval_days=7,
+            assignment_type=AssignmentType.AUTO, is_bonus=True, is_active=True,
+            family_id=family.id,
+        )
+        db_session.add(t)
+        await db_session.commit()
+        return t
+
+    return _make

--- a/backend/tests/test_gig_approval.py
+++ b/backend/tests/test_gig_approval.py
@@ -1,0 +1,118 @@
+"""Gig approval flow."""
+from datetime import date, timedelta
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select, func
+
+from app.models.task_assignment import TaskAssignment, AssignmentStatus, ApprovalStatus
+from app.models.point_transaction import PointTransaction, TransactionType
+from app.services.task_assignment_service import TaskAssignmentService
+from app.core.exceptions import ForbiddenException, ValidationException
+
+
+def _monday_of(d):
+    return d - timedelta(days=d.weekday())
+
+
+async def _make_pending_gig(db_session, family, child, template):
+    today = date.today()
+    assignment = TaskAssignment(
+        id=uuid4(), template_id=template.id, assigned_to=child.id,
+        family_id=family.id, assigned_date=today, week_of=_monday_of(today),
+        status=AssignmentStatus.COMPLETED,
+        approval_status=ApprovalStatus.PENDING,
+        proof_text="did the thing",
+    )
+    db_session.add(assignment)
+    await db_session.commit()
+    return assignment
+
+
+@pytest.mark.asyncio
+async def test_parent_approves_gig_credits_points(
+    db_session, test_family, test_parent_user, test_child_user, gig_template_factory,
+):
+    gig = await gig_template_factory(family=test_family, points=25)
+    assignment = await _make_pending_gig(db_session, test_family, test_child_user, gig)
+    before = test_child_user.points
+
+    await TaskAssignmentService.approve_gig(
+        db_session, assignment.id, test_family.id, test_parent_user.id,
+        approve=True, notes="great writeup",
+    )
+
+    await db_session.refresh(test_child_user)
+    await db_session.refresh(assignment)
+    assert assignment.approval_status == ApprovalStatus.APPROVED
+    assert test_child_user.points == before + 25
+
+    txn = await db_session.scalar(
+        select(PointTransaction).where(PointTransaction.user_id == test_child_user.id)
+    )
+    assert txn.type == TransactionType.GIG_APPROVED
+    assert txn.points == 25
+
+
+@pytest.mark.asyncio
+async def test_parent_rejects_gig_no_credit(
+    db_session, test_family, test_parent_user, test_child_user, gig_template_factory,
+):
+    gig = await gig_template_factory(family=test_family, points=25)
+    assignment = await _make_pending_gig(db_session, test_family, test_child_user, gig)
+    before = test_child_user.points
+
+    await TaskAssignmentService.approve_gig(
+        db_session, assignment.id, test_family.id, test_parent_user.id,
+        approve=False, notes="no proof of conclusions",
+    )
+    await db_session.refresh(test_child_user)
+    await db_session.refresh(assignment)
+    assert assignment.approval_status == ApprovalStatus.REJECTED
+    assert test_child_user.points == before
+    count = await db_session.scalar(select(func.count()).select_from(PointTransaction))
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_non_parent_cannot_approve(
+    db_session, test_family, test_child_user, test_teen_user, gig_template_factory,
+):
+    gig = await gig_template_factory(family=test_family, points=25)
+    assignment = await _make_pending_gig(db_session, test_family, test_child_user, gig)
+
+    with pytest.raises(ForbiddenException):
+        await TaskAssignmentService.approve_gig(
+            db_session, assignment.id, test_family.id, test_teen_user.id,
+            approve=True, notes=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_double_approve_conflicts(
+    db_session, test_family, test_parent_user, test_child_user, gig_template_factory,
+):
+    gig = await gig_template_factory(family=test_family, points=25)
+    assignment = await _make_pending_gig(db_session, test_family, test_child_user, gig)
+
+    await TaskAssignmentService.approve_gig(
+        db_session, assignment.id, test_family.id, test_parent_user.id,
+        approve=True, notes=None,
+    )
+    with pytest.raises(ValidationException, match="already"):
+        await TaskAssignmentService.approve_gig(
+            db_session, assignment.id, test_family.id, test_parent_user.id,
+            approve=True, notes=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_list_pending_approvals_family_scoped(
+    db_session, test_family, test_child_user, gig_template_factory,
+):
+    gig = await gig_template_factory(family=test_family, points=10)
+    await _make_pending_gig(db_session, test_family, test_child_user, gig)
+
+    rows = await TaskAssignmentService.list_pending_approvals(db_session, test_family.id)
+    assert len(rows) == 1
+    assert rows[0].approval_status == ApprovalStatus.PENDING

--- a/backend/tests/test_gig_gating.py
+++ b/backend/tests/test_gig_gating.py
@@ -1,10 +1,20 @@
 """Gig gating + zero-point mandatory tests."""
-from datetime import date
+from datetime import date, timedelta
+from uuid import uuid4
 
 import pytest
+from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.exceptions import ForbiddenException
+from app.models.point_transaction import PointTransaction
+from app.models.task_assignment import TaskAssignment, AssignmentStatus, ApprovalStatus
 from app.services.task_assignment_service import TaskAssignmentService
+
+
+def _monday_of(d: date) -> date:
+    """Helper: return Monday of the week containing d."""
+    return d - timedelta(days=d.weekday())
 
 
 @pytest.mark.asyncio
@@ -16,3 +26,94 @@ async def test_local_today_returns_family_tz(db_session: AsyncSession, test_fami
     result = await TaskAssignmentService._user_local_today(db_session, test_child_user.id)
 
     assert isinstance(result, date)
+
+
+@pytest.mark.asyncio
+async def test_mandatory_completion_awards_no_points(
+    db_session, test_family, test_child_user, mandatory_template_factory,
+):
+    template = await mandatory_template_factory(family=test_family, points=0)
+    today = date.today()
+    assignment = TaskAssignment(
+        id=uuid4(),
+        template_id=template.id,
+        assigned_to=test_child_user.id,
+        family_id=test_family.id,
+        assigned_date=today,
+        week_of=_monday_of(today),
+        status=AssignmentStatus.PENDING,
+    )
+    db_session.add(assignment)
+    await db_session.commit()
+
+    before = test_child_user.points
+    result = await TaskAssignmentService.complete_assignment(
+        db_session, assignment.id, test_family.id, test_child_user.id, proof_text=None,
+    )
+
+    await db_session.refresh(test_child_user)
+    assert result.status == AssignmentStatus.COMPLETED
+    assert result.approval_status == ApprovalStatus.NONE
+    assert test_child_user.points == before
+
+    count = await db_session.scalar(
+        select(func.count()).select_from(PointTransaction).where(PointTransaction.user_id == test_child_user.id)
+    )
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_gig_locked_when_mandatory_pending(
+    db_session, test_family, test_child_user,
+    mandatory_template_factory, gig_template_factory,
+):
+    mandatory = await mandatory_template_factory(family=test_family)
+    gig = await gig_template_factory(family=test_family, points=20)
+
+    today = date.today()
+    monday = _monday_of(today)
+    mand_assign = TaskAssignment(
+        id=uuid4(), template_id=mandatory.id, assigned_to=test_child_user.id,
+        family_id=test_family.id, assigned_date=today, week_of=monday,
+        status=AssignmentStatus.PENDING,
+    )
+    gig_assign = TaskAssignment(
+        id=uuid4(), template_id=gig.id, assigned_to=test_child_user.id,
+        family_id=test_family.id, assigned_date=today, week_of=monday,
+        status=AssignmentStatus.PENDING,
+    )
+    db_session.add_all([mand_assign, gig_assign])
+    await db_session.commit()
+
+    with pytest.raises(ForbiddenException, match="mandatory"):
+        await TaskAssignmentService.complete_assignment(
+            db_session, gig_assign.id, test_family.id, test_child_user.id,
+            proof_text="did the gig",
+        )
+
+
+@pytest.mark.asyncio
+async def test_gig_unlocked_completes_pending(
+    db_session, test_family, test_child_user, gig_template_factory,
+):
+    gig = await gig_template_factory(family=test_family, points=20)
+    today = date.today()
+    assignment = TaskAssignment(
+        id=uuid4(), template_id=gig.id, assigned_to=test_child_user.id,
+        family_id=test_family.id, assigned_date=today, week_of=_monday_of(today),
+        status=AssignmentStatus.PENDING,
+    )
+    db_session.add(assignment)
+    await db_session.commit()
+
+    before = test_child_user.points
+    result = await TaskAssignmentService.complete_assignment(
+        db_session, assignment.id, test_family.id, test_child_user.id,
+        proof_text="learned about rootless podman storage",
+    )
+    await db_session.refresh(test_child_user)
+
+    assert result.status == AssignmentStatus.COMPLETED
+    assert result.approval_status == ApprovalStatus.PENDING
+    assert result.proof_text == "learned about rootless podman storage"
+    assert test_child_user.points == before  # not yet credited

--- a/backend/tests/test_gig_gating.py
+++ b/backend/tests/test_gig_gating.py
@@ -1,0 +1,18 @@
+"""Gig gating + zero-point mandatory tests."""
+from datetime import date
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.task_assignment_service import TaskAssignmentService
+
+
+@pytest.mark.asyncio
+async def test_local_today_returns_family_tz(db_session: AsyncSession, test_family, test_child_user):
+    """Helper computes today in family timezone."""
+    test_family.timezone = "America/Mexico_City"
+    await db_session.commit()
+
+    result = await TaskAssignmentService._user_local_today(db_session, test_child_user.id)
+
+    assert isinstance(result, date)

--- a/backend/tests/test_gig_gating.py
+++ b/backend/tests/test_gig_gating.py
@@ -117,3 +117,35 @@ async def test_gig_unlocked_completes_pending(
     assert result.approval_status == ApprovalStatus.PENDING
     assert result.proof_text == "learned about rootless podman storage"
     assert test_child_user.points == before  # not yet credited
+
+
+@pytest.mark.asyncio
+async def test_list_marks_gigs_locked_when_mandatory_pending(
+    db_session, test_family, test_child_user,
+    mandatory_template_factory, gig_template_factory,
+):
+    mand = await mandatory_template_factory(family=test_family)
+    gig = await gig_template_factory(family=test_family, points=20)
+    today = date.today()
+    week_of = today - timedelta(days=today.weekday())
+    db_session.add_all([
+        TaskAssignment(
+            id=uuid4(), template_id=mand.id, assigned_to=test_child_user.id,
+            family_id=test_family.id, assigned_date=today, week_of=week_of,
+            status=AssignmentStatus.PENDING,
+        ),
+        TaskAssignment(
+            id=uuid4(), template_id=gig.id, assigned_to=test_child_user.id,
+            family_id=test_family.id, assigned_date=today, week_of=week_of,
+            status=AssignmentStatus.PENDING,
+        ),
+    ])
+    await db_session.commit()
+
+    rows = await TaskAssignmentService.list_for_user_today_with_locks(
+        db_session, test_child_user.id, test_family.id
+    )
+
+    locked = [r for r in rows if r["is_locked"]]
+    assert len(locked) == 1
+    assert locked[0]["is_bonus"] is True

--- a/backend/tests/test_migration_mandatory_zero.py
+++ b/backend/tests/test_migration_mandatory_zero.py
@@ -41,6 +41,21 @@ async def test_new_family_gets_default_gigs(db_session):
     assert count == len(FamilyService.DEFAULT_GIGS)
 
 
+def test_schema_rejects_mandatory_nonzero_points():
+    from pydantic import ValidationError
+    from app.schemas.task_template import TaskTemplateCreate, TaskTemplateUpdate
+
+    with pytest.raises(ValidationError, match="Mandatory tasks"):
+        TaskTemplateCreate(title="bad", points=5, interval_days=1, is_bonus=False)
+
+    # Update path: explicit is_bonus=false + points>0 should also reject
+    with pytest.raises(ValidationError, match="Mandatory tasks"):
+        TaskTemplateUpdate(points=5, is_bonus=False)
+
+    # Bonus path accepts non-zero
+    TaskTemplateCreate(title="ok", points=20, interval_days=7, is_bonus=True)
+
+
 @pytest.mark.asyncio
 async def test_check_constraint_rejects_nonzero_mandatory_insert(db_session, test_family):
     from sqlalchemy.exc import IntegrityError

--- a/backend/tests/test_migration_mandatory_zero.py
+++ b/backend/tests/test_migration_mandatory_zero.py
@@ -1,0 +1,37 @@
+"""Assert migration outcomes are durable."""
+import pytest
+from sqlalchemy import select, func, text
+
+from app.models.task_template import TaskTemplate
+
+
+@pytest.mark.asyncio
+async def test_all_mandatory_templates_have_zero_points(db_session):
+    bad = await db_session.scalar(
+        select(func.count())
+        .select_from(TaskTemplate)
+        .where(
+            TaskTemplate.is_bonus.is_(False),
+            TaskTemplate.points != 0,
+        )
+    )
+    assert bad == 0
+
+
+@pytest.mark.asyncio
+async def test_check_constraint_rejects_nonzero_mandatory_insert(db_session, test_family):
+    from sqlalchemy.exc import IntegrityError
+
+    with pytest.raises(IntegrityError, match="chk_mandatory_zero_points|check constraint"):
+        await db_session.execute(
+            text(
+                "INSERT INTO task_templates "
+                "(id, title, points, interval_days, assignment_type, is_bonus, "
+                " is_active, family_id, created_at, updated_at) "
+                "VALUES (gen_random_uuid(), 'bad', 5, 1, 'auto', false, true, "
+                " :fid, NOW(), NOW())"
+            ),
+            {"fid": str(test_family.id)},
+        )
+        await db_session.commit()
+    await db_session.rollback()

--- a/backend/tests/test_migration_mandatory_zero.py
+++ b/backend/tests/test_migration_mandatory_zero.py
@@ -19,6 +19,29 @@ async def test_all_mandatory_templates_have_zero_points(db_session):
 
 
 @pytest.mark.asyncio
+async def test_new_family_gets_default_gigs(db_session):
+    from uuid import uuid4
+    from app.services.family_service import FamilyService
+    from app.schemas.family import FamilyCreate
+
+    family = await FamilyService.create_family(
+        db_session,
+        FamilyCreate(name="Brand New Fam"),
+        created_by=uuid4(),
+    )
+
+    count = await db_session.scalar(
+        select(func.count())
+        .select_from(TaskTemplate)
+        .where(
+            TaskTemplate.family_id == family.id,
+            TaskTemplate.is_bonus.is_(True),
+        )
+    )
+    assert count == len(FamilyService.DEFAULT_GIGS)
+
+
+@pytest.mark.asyncio
 async def test_check_constraint_rejects_nonzero_mandatory_insert(db_session, test_family):
     from sqlalchemy.exc import IntegrityError
 

--- a/backend/tests/test_task_assignment_service.py
+++ b/backend/tests/test_task_assignment_service.py
@@ -34,6 +34,8 @@ async def _create_template(db, family_id, parent_id, **kwargs):
         "is_bonus": False,
     }
     defaults.update(kwargs)
+    if not defaults["is_bonus"]:
+        defaults["points"] = 0  # mandatory templates enforced to zero
     data = TaskTemplateCreate(**defaults)
     return await TaskTemplateService.create_template(
         db, data, family_id, parent_id
@@ -280,9 +282,9 @@ class TestCompletion:
         assert completed.status == AssignmentStatus.COMPLETED
         assert completed.completed_at is not None
 
-        # Points should be awarded
+        # Mandatory tasks award no points (baseline duty)
         await db_session.refresh(user)
-        assert user.points == initial_points + 50
+        assert user.points == initial_points
 
     async def test_complete_already_completed_raises(
         self, db_session, test_family, test_parent_user, test_child_user
@@ -392,7 +394,8 @@ class TestBonusGating:
         if child_bonus:
             # Should succeed: no required tasks means bonus unlocked
             completed = await TaskAssignmentService.complete_assignment(
-                db_session, child_bonus[0].id, test_family.id, test_child_user.id
+                db_session, child_bonus[0].id, test_family.id, test_child_user.id,
+                proof_text="completed the bonus",
             )
             assert completed.status == AssignmentStatus.COMPLETED
 

--- a/docs/superpowers/plans/2026-05-22-mandatory-vs-gigs.md
+++ b/docs/superpowers/plans/2026-05-22-mandatory-vs-gigs.md
@@ -1,0 +1,1723 @@
+# Mandatory vs Gigs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make mandatory tasks award zero points (baseline duty) and convert bonus tasks ("gigs") into the only point-earning activity, gated by today's mandatory completion and parent approval.
+
+**Architecture:** Reuse existing `task_templates.is_bonus` flag. A new alembic migration zeros all non-bonus template points, adds a CHECK constraint, adds `families.timezone`, and adds approval-tracking columns to `task_assignments`. Service-layer changes in `TaskAssignmentService.complete_assignment` skip point awards for mandatory and gate gig completions into a `PENDING` approval queue. A new `approve_gig` service + two parent-only routes credit points on approval. Frontend adds a lock badge on the assignment list and a `/parent/approvals` review page.
+
+**Tech Stack:** Python 3.12 / FastAPI / SQLAlchemy async / Alembic / Astro 5 / Tailwind / Playwright
+
+**Spec:** [`docs/superpowers/specs/2026-05-22-mandatory-vs-gigs-design.md`](../specs/2026-05-22-mandatory-vs-gigs-design.md)
+
+---
+
+## File Structure
+
+**New files:**
+- `backend/migrations/versions/2026_05_22_mandatory_zero_points_and_gigs.py` — Alembic migration
+- `backend/tests/test_gig_gating.py` — service-layer guard + zero-point tests
+- `backend/tests/test_gig_approval.py` — approval flow tests
+- `backend/tests/test_migration_mandatory_zero.py` — migration assertions
+- `frontend/src/pages/parent/approvals.astro` — parent approval queue page
+- `frontend/src/pages/api/assignments/approve.ts` — Astro proxy for approve route
+- `frontend/src/pages/api/assignments/pending-approvals.ts` — Astro proxy for queue listing
+- `e2e-tests/tests/gigs.spec.ts` — Playwright E2E
+
+**Modified files:**
+- `backend/app/models/family.py` — add `timezone` column
+- `backend/app/models/task_assignment.py` — add approval columns, `ApprovalStatus` enum
+- `backend/app/models/point_transaction.py` — add `GIG_APPROVED` enum + factory
+- `backend/app/schemas/task_assignment.py` — add fields to response, complete payload, approve payload
+- `backend/app/services/task_assignment_service.py` — `complete_assignment` rewrite (split mandatory vs gig), new `approve_gig` + `list_pending_approvals`, `_user_local_today`, list enrichment
+- `backend/app/services/points_service.py` — new `award_gig_points`
+- `backend/app/api/routes/task_assignments.py` — proof_text on complete, two new routes
+- `backend/app/services/family_service.py` — seed default gig pack on family create
+- `frontend/src/pages/parent/assignments.astro` — render lock + approval badges, proof modal
+- `frontend/src/pages/api/assignments/complete.ts` — forward `proof_text`
+
+---
+
+## Task 1: Migration — schema + zero mandatory points + seed default gigs
+
+**Files:**
+- Create: `backend/migrations/versions/2026_05_22_mandatory_zero_points_and_gigs.py`
+
+- [ ] **Step 1: Write the migration file**
+
+```python
+"""mandatory zero points + gig approval columns
+
+Revision ID: gigs_v1_approval
+Revises: seed_sub_plans_v1
+Create Date: 2026-05-22
+
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "gigs_v1_approval"
+down_revision = "seed_sub_plans_v1"
+branch_labels = None
+depends_on = None
+
+
+APPROVAL_STATUS = postgresql.ENUM(
+    "none", "pending", "approved", "rejected",
+    name="approval_status",
+    create_type=False,
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    # 1. families.timezone
+    op.add_column(
+        "families",
+        sa.Column("timezone", sa.String(length=64), nullable=True),
+    )
+    op.execute("UPDATE families SET timezone = 'UTC' WHERE timezone IS NULL")
+    op.alter_column("families", "timezone", nullable=False, server_default="UTC")
+
+    # 2. zero out mandatory template points
+    op.execute("UPDATE task_templates SET points = 0 WHERE is_bonus = false")
+    op.create_check_constraint(
+        "chk_mandatory_zero_points",
+        "task_templates",
+        "is_bonus = true OR points = 0",
+    )
+
+    # 3. approval_status enum + columns on task_assignments
+    approval_status = postgresql.ENUM(
+        "none", "pending", "approved", "rejected",
+        name="approval_status",
+    )
+    approval_status.create(bind, checkfirst=True)
+
+    op.add_column(
+        "task_assignments",
+        sa.Column(
+            "approval_status",
+            sa.Enum("none", "pending", "approved", "rejected", name="approval_status", create_type=False),
+            nullable=False,
+            server_default="none",
+        ),
+    )
+    op.add_column("task_assignments", sa.Column("proof_text", sa.Text(), nullable=True))
+    op.add_column(
+        "task_assignments",
+        sa.Column("approved_by", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_assignments_approved_by_users",
+        "task_assignments", "users",
+        ["approved_by"], ["id"],
+        ondelete="SET NULL",
+    )
+    op.add_column(
+        "task_assignments",
+        sa.Column("approved_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column("task_assignments", sa.Column("approval_notes", sa.Text(), nullable=True))
+    op.create_index(
+        "idx_assignments_family_approval",
+        "task_assignments",
+        ["family_id", "approval_status"],
+    )
+
+    # 4. new transaction type value
+    op.execute("ALTER TYPE transactiontype ADD VALUE IF NOT EXISTS 'gig_approved'")
+
+    # 5. seed default gig pack per existing family
+    seed_default_gig_pack(bind)
+
+
+def downgrade() -> None:
+    op.drop_index("idx_assignments_family_approval", table_name="task_assignments")
+    op.drop_constraint("fk_assignments_approved_by_users", "task_assignments", type_="foreignkey")
+    op.drop_column("task_assignments", "approval_notes")
+    op.drop_column("task_assignments", "approved_at")
+    op.drop_column("task_assignments", "approved_by")
+    op.drop_column("task_assignments", "proof_text")
+    op.drop_column("task_assignments", "approval_status")
+
+    bind = op.get_bind()
+    sa.Enum(name="approval_status").drop(bind, checkfirst=True)
+
+    op.drop_constraint("chk_mandatory_zero_points", "task_templates", type_="check")
+    op.drop_column("families", "timezone")
+
+
+DEFAULT_GIGS = [
+    ("Learn a topic + writeup", "Pick something new (podman, git, a recipe). Read up, then write 5-10 sentences on what you learned.", 30),
+    ("Read book chapter + discuss", "Read a chapter, then sit with a parent to discuss the main idea.", 20),
+    ("Plan next 3 days of meals", "Propose breakfasts, lunches, and dinners for the next 3 days. List groceries needed.", 25),
+    ("Help with grocery shopping", "Help compile the list, go to the store, and help carry/put away.", 15),
+    ("Cook family dinner", "Plan, cook, and serve a family dinner with parent supervision.", 25),
+    ("Tech-help parent (15 min)", "Help a parent with a phone/computer task for at least 15 minutes.", 10),
+]
+
+
+def seed_default_gig_pack(bind):
+    family_ids = bind.execute(sa.text("SELECT id FROM families")).scalars().all()
+    for family_id in family_ids:
+        # Skip if any of these titles already exist for the family
+        existing = bind.execute(
+            sa.text(
+                "SELECT title FROM task_templates "
+                "WHERE family_id = :fid AND title = ANY(:titles)"
+            ),
+            {"fid": family_id, "titles": [t[0] for t in DEFAULT_GIGS]},
+        ).scalars().all()
+        existing_set = set(existing)
+        for title, description, points in DEFAULT_GIGS:
+            if title in existing_set:
+                continue
+            bind.execute(
+                sa.text(
+                    "INSERT INTO task_templates "
+                    "(id, title, description, points, interval_days, assignment_type, "
+                    " is_bonus, is_active, family_id, created_at, updated_at) "
+                    "VALUES (gen_random_uuid(), :title, :desc, :points, 7, 'auto', "
+                    " true, true, :fid, NOW(), NOW())"
+                ),
+                {"title": title, "desc": description, "points": points, "fid": family_id},
+            )
+```
+
+- [ ] **Step 2: Apply migration locally**
+
+Run: `docker exec family_app_backend alembic upgrade head`
+Expected: prints `INFO  [alembic.runtime.migration] Running upgrade seed_sub_plans_v1 -> gigs_v1_approval`
+
+- [ ] **Step 3: Verify schema + data in psql**
+
+Run:
+```bash
+docker exec family_app_db psql -U familyapp familyapp -c "\d task_assignments" | grep approval
+docker exec family_app_db psql -U familyapp familyapp -c "SELECT title, points, is_bonus FROM task_templates WHERE is_bonus = false LIMIT 5;"
+docker exec family_app_db psql -U familyapp familyapp -c "SELECT COUNT(*) FROM task_templates WHERE title='Cook family dinner';"
+```
+Expected:
+- `approval_status`, `proof_text`, `approved_by`, `approved_at`, `approval_notes` columns visible
+- All listed mandatory templates have `points = 0`
+- Count = number of families (1 in dev demo, 1+ in prod)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/migrations/versions/2026_05_22_mandatory_zero_points_and_gigs.py
+git commit -m "feat(db): mandatory zero points + gig approval columns + default gig pack"
+```
+
+---
+
+## Task 2: Model updates — Family.timezone, TaskAssignment approval fields, GIG_APPROVED txn type
+
+**Files:**
+- Modify: `backend/app/models/family.py` (add `timezone`)
+- Modify: `backend/app/models/task_assignment.py` (add `ApprovalStatus` enum + 5 columns)
+- Modify: `backend/app/models/point_transaction.py` (add enum value + factory)
+
+- [ ] **Step 1: Add `timezone` to Family model**
+
+In `backend/app/models/family.py`, locate the column list inside `class Family(Base):`. Add after the existing `name` column:
+
+```python
+timezone = Column(String(64), nullable=False, default="UTC", server_default="UTC")
+```
+
+Ensure `String` is imported from `sqlalchemy`.
+
+- [ ] **Step 2: Add `ApprovalStatus` enum + columns to TaskAssignment**
+
+In `backend/app/models/task_assignment.py`, after the `AssignmentStatus` enum (around line 35), add:
+
+```python
+class ApprovalStatus(str, enum.Enum):
+    """Gig approval lifecycle."""
+    NONE = "none"
+    PENDING = "pending"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+```
+
+Inside `class TaskAssignment(Base):`, after the existing `status` column block (around line 75), add:
+
+```python
+    approval_status = Column(
+        SQLEnum(
+            ApprovalStatus,
+            values_callable=lambda x: [e.value for e in x],
+            name="approval_status",
+        ),
+        nullable=False,
+        default=ApprovalStatus.NONE,
+        server_default="none",
+        index=True,
+    )
+    proof_text = Column(Text, nullable=True)
+    approved_by = Column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    approved_at = Column(DateTime(timezone=True), nullable=True)
+    approval_notes = Column(Text, nullable=True)
+```
+
+Ensure `Text` is in the `sqlalchemy` import line.
+
+- [ ] **Step 3: Add `GIG_APPROVED` to TransactionType and a factory**
+
+In `backend/app/models/point_transaction.py`, locate `class TransactionType(str, Enum):` and add after `BONUS`:
+
+```python
+    GIG_APPROVED = "gig_approved"  # Points credited after parent approves a gig
+```
+
+Then after the existing `create_assignment_completion` classmethod, add:
+
+```python
+    @classmethod
+    def create_gig_approval(cls, user_id, assignment_id, points: int, balance_before: int):
+        return cls(
+            type=TransactionType.GIG_APPROVED,
+            user_id=user_id,
+            assignment_id=assignment_id,
+            points=points,
+            balance_before=balance_before,
+            balance_after=balance_before + points,
+            description=f"Gig approved — earned {points} points",
+        )
+```
+
+- [ ] **Step 4: Sanity-check imports load**
+
+Run: `docker exec family_app_backend python -c "from app.models.task_assignment import ApprovalStatus; from app.models.point_transaction import TransactionType; print(ApprovalStatus.PENDING, TransactionType.GIG_APPROVED)"`
+Expected: `ApprovalStatus.PENDING TransactionType.GIG_APPROVED` (no traceback)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/models/family.py backend/app/models/task_assignment.py backend/app/models/point_transaction.py
+git commit -m "feat(models): ApprovalStatus enum, gig approval fields, family timezone"
+```
+
+---
+
+## Task 3: Schemas — proof_text + approval payloads
+
+**Files:**
+- Modify: `backend/app/schemas/task_assignment.py`
+
+- [ ] **Step 1: Add schemas**
+
+In `backend/app/schemas/task_assignment.py`, after the existing response schema (search for `class TaskAssignmentWithDetails`), add at file bottom:
+
+```python
+class CompleteAssignmentRequest(BaseModel):
+    proof_text: Optional[str] = Field(None, max_length=4000)
+
+
+class ApprovalDecision(BaseModel):
+    approve: bool
+    notes: Optional[str] = Field(None, max_length=2000)
+
+
+class GigApprovalRow(BaseModel):
+    assignment_id: UUID
+    template_id: UUID
+    template_title: str
+    points: int
+    assigned_to: UUID
+    assigned_to_name: str
+    completed_at: datetime
+    proof_text: Optional[str] = None
+
+    model_config = {"from_attributes": True}
+```
+
+Also extend the response model — find `class TaskAssignmentWithDetails(...)` and add (in field block):
+
+```python
+    is_locked: bool = False
+    approval_status: str = "none"
+    proof_text: Optional[str] = None
+```
+
+Ensure `from typing import Optional` and pydantic `Field`, plus `from uuid import UUID` and `from datetime import datetime` imports exist at top of the file.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add backend/app/schemas/task_assignment.py
+git commit -m "feat(schemas): proof_text on complete, approval decision, gig row"
+```
+
+---
+
+## Task 4: Service helper — local today date in family timezone
+
+**Files:**
+- Modify: `backend/app/services/task_assignment_service.py`
+- Test: `backend/tests/test_gig_gating.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/test_gig_gating.py`:
+
+```python
+"""Gig gating + zero-point mandatory tests."""
+from datetime import date, timedelta
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.task_template import TaskTemplate, AssignmentType
+from app.models.task_assignment import TaskAssignment, AssignmentStatus, ApprovalStatus
+from app.models.point_transaction import PointTransaction
+from app.services.task_assignment_service import TaskAssignmentService
+from app.core.exceptions import ForbiddenException
+from sqlalchemy import select, func
+
+
+@pytest.mark.asyncio
+async def test_local_today_returns_family_tz(db_session: AsyncSession, demo_family, demo_child):
+    """Helper computes today in family timezone."""
+    demo_family.timezone = "America/Mexico_City"
+    await db_session.commit()
+
+    result = await TaskAssignmentService._user_local_today(db_session, demo_child.id)
+
+    assert isinstance(result, date)
+```
+
+- [ ] **Step 2: Run test, confirm it fails**
+
+Run: `docker exec -e PYTHONPATH=/app family_app_backend pytest tests/test_gig_gating.py::test_local_today_returns_family_tz -v`
+Expected: FAIL with `AttributeError: type object 'TaskAssignmentService' has no attribute '_user_local_today'`
+
+- [ ] **Step 3: Implement helper**
+
+In `backend/app/services/task_assignment_service.py`, near the top of the class add:
+
+```python
+    @staticmethod
+    async def _user_local_today(db: AsyncSession, user_id: UUID) -> date:
+        """Return today's date in the user's family timezone."""
+        from zoneinfo import ZoneInfo
+        from app.services.base_service import get_user_by_id
+        user = await get_user_by_id(db, user_id)
+        tz_name = (user.family.timezone if user.family else None) or "UTC"
+        try:
+            tz = ZoneInfo(tz_name)
+        except Exception:
+            tz = ZoneInfo("UTC")
+        return datetime.now(tz).date()
+```
+
+Ensure `from datetime import date, datetime` is at top of file.
+
+- [ ] **Step 4: Verify test passes**
+
+Run: `docker exec -e PYTHONPATH=/app family_app_backend pytest tests/test_gig_gating.py::test_local_today_returns_family_tz -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/task_assignment_service.py backend/tests/test_gig_gating.py
+git commit -m "feat(service): _user_local_today helper using family timezone"
+```
+
+---
+
+## Task 5: complete_assignment — split mandatory vs gig
+
+**Files:**
+- Modify: `backend/app/services/task_assignment_service.py:570-626`
+- Test: `backend/tests/test_gig_gating.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `backend/tests/test_gig_gating.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_mandatory_completion_awards_no_points(
+    db_session, demo_family, demo_child, mandatory_template_factory,
+):
+    template = await mandatory_template_factory(family=demo_family, points=0)
+    assignment = TaskAssignment(
+        id=uuid4(),
+        template_id=template.id,
+        assigned_to=demo_child.id,
+        family_id=demo_family.id,
+        assigned_date=date.today(),
+        status=AssignmentStatus.PENDING,
+    )
+    db_session.add(assignment)
+    await db_session.commit()
+
+    before = demo_child.points
+    result = await TaskAssignmentService.complete_assignment(
+        db_session, assignment.id, demo_family.id, demo_child.id, proof_text=None,
+    )
+
+    await db_session.refresh(demo_child)
+    assert result.status == AssignmentStatus.COMPLETED
+    assert result.approval_status == ApprovalStatus.NONE
+    assert demo_child.points == before
+
+    count = await db_session.scalar(
+        select(func.count()).select_from(PointTransaction).where(PointTransaction.user_id == demo_child.id)
+    )
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_gig_locked_when_mandatory_pending(
+    db_session, demo_family, demo_child,
+    mandatory_template_factory, gig_template_factory,
+):
+    mandatory = await mandatory_template_factory(family=demo_family)
+    gig = await gig_template_factory(family=demo_family, points=20)
+
+    today = date.today()
+    db_session.add_all([
+        TaskAssignment(
+            id=uuid4(), template_id=mandatory.id, assigned_to=demo_child.id,
+            family_id=demo_family.id, assigned_date=today, status=AssignmentStatus.PENDING,
+        ),
+        gig_assignment := TaskAssignment(
+            id=uuid4(), template_id=gig.id, assigned_to=demo_child.id,
+            family_id=demo_family.id, assigned_date=today, status=AssignmentStatus.PENDING,
+        ),
+    ])
+    await db_session.commit()
+
+    with pytest.raises(ForbiddenException, match="mandatory"):
+        await TaskAssignmentService.complete_assignment(
+            db_session, gig_assignment.id, demo_family.id, demo_child.id,
+            proof_text="did the gig",
+        )
+
+
+@pytest.mark.asyncio
+async def test_gig_unlocked_completes_pending(
+    db_session, demo_family, demo_child, gig_template_factory,
+):
+    gig = await gig_template_factory(family=demo_family, points=20)
+    today = date.today()
+    assignment = TaskAssignment(
+        id=uuid4(), template_id=gig.id, assigned_to=demo_child.id,
+        family_id=demo_family.id, assigned_date=today, status=AssignmentStatus.PENDING,
+    )
+    db_session.add(assignment)
+    await db_session.commit()
+
+    before = demo_child.points
+    result = await TaskAssignmentService.complete_assignment(
+        db_session, assignment.id, demo_family.id, demo_child.id,
+        proof_text="learned about rootless podman storage",
+    )
+    await db_session.refresh(demo_child)
+
+    assert result.status == AssignmentStatus.COMPLETED
+    assert result.approval_status == ApprovalStatus.PENDING
+    assert result.proof_text == "learned about rootless podman storage"
+    assert demo_child.points == before  # not yet credited
+```
+
+Fixtures referenced (`mandatory_template_factory`, `gig_template_factory`) — add to `backend/tests/conftest.py`:
+
+```python
+import pytest_asyncio
+from uuid import uuid4
+from app.models.task_template import TaskTemplate, AssignmentType
+
+@pytest_asyncio.fixture
+async def mandatory_template_factory(db_session):
+    async def _make(*, family, points: int = 0, title: str = "Brush teeth"):
+        t = TaskTemplate(
+            id=uuid4(), title=title, points=points, interval_days=1,
+            assignment_type=AssignmentType.AUTO, is_bonus=False, is_active=True,
+            family_id=family.id,
+        )
+        db_session.add(t)
+        await db_session.commit()
+        return t
+    return _make
+
+@pytest_asyncio.fixture
+async def gig_template_factory(db_session):
+    async def _make(*, family, points: int = 20, title: str = "Learn topic"):
+        t = TaskTemplate(
+            id=uuid4(), title=title, points=points, interval_days=7,
+            assignment_type=AssignmentType.AUTO, is_bonus=True, is_active=True,
+            family_id=family.id,
+        )
+        db_session.add(t)
+        await db_session.commit()
+        return t
+    return _make
+```
+
+- [ ] **Step 2: Run tests, confirm they fail**
+
+Run: `docker exec -e PYTHONPATH=/app family_app_backend pytest tests/test_gig_gating.py -v`
+Expected: FAIL — current `complete_assignment` does not accept `proof_text`, awards points for mandatory, does not set `approval_status`.
+
+- [ ] **Step 3: Rewrite `complete_assignment`**
+
+In `backend/app/services/task_assignment_service.py`, replace the existing `complete_assignment` method (lines ~569-626) with:
+
+```python
+    @staticmethod
+    async def complete_assignment(
+        db: AsyncSession,
+        assignment_id: UUID,
+        family_id: UUID,
+        user_id: UUID,
+        proof_text: Optional[str] = None,
+    ) -> TaskAssignment:
+        """
+        Mark an assignment as completed.
+
+        Mandatory (is_bonus=false): completes silently, awards no points.
+        Gig (is_bonus=true): requires all today's mandatory done first, requires
+        proof_text, and enters PENDING approval state. Points are credited only
+        when a parent approves via approve_gig().
+        """
+        assignment = await TaskAssignmentService.get_assignment(
+            db, assignment_id, family_id
+        )
+
+        if not assignment.can_complete:
+            raise ValidationException(
+                f"Assignment cannot be completed. Current status: {assignment.status.value}"
+            )
+
+        if assignment.assigned_to != user_id:
+            raise ForbiddenException(
+                "Only the assigned user can complete this assignment"
+            )
+
+        template = assignment.template
+
+        if template.is_bonus:
+            # Gig path
+            all_required_done = await TaskAssignmentService.check_all_required_done_today(
+                db, user_id, family_id, assignment.assigned_date
+            )
+            if not all_required_done:
+                raise ForbiddenException(
+                    "Complete today's mandatory tasks before claiming a gig"
+                )
+
+            if not proof_text or not proof_text.strip():
+                raise ValidationException("Gigs require proof text describing what you did")
+
+            assignment.status = AssignmentStatus.COMPLETED
+            assignment.completed_at = datetime.utcnow()
+            assignment.approval_status = ApprovalStatus.PENDING
+            assignment.proof_text = proof_text.strip()
+        else:
+            # Mandatory path — silent, no points, no approval
+            assignment.status = AssignmentStatus.COMPLETED
+            assignment.completed_at = datetime.utcnow()
+            # approval_status stays NONE; no PointTransaction row
+
+        await db.commit()
+        await db.refresh(assignment)
+        return assignment
+```
+
+Add imports at top of file if missing: `from app.models.task_assignment import ApprovalStatus`, `from typing import Optional`.
+
+- [ ] **Step 4: Run tests, confirm they pass**
+
+Run: `docker exec -e PYTHONPATH=/app family_app_backend pytest tests/test_gig_gating.py -v`
+Expected: all 4 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/task_assignment_service.py backend/tests/test_gig_gating.py backend/tests/conftest.py
+git commit -m "feat(service): mandatory completes silently, gig enters PENDING approval"
+```
+
+---
+
+## Task 6: approve_gig service + list_pending_approvals
+
+**Files:**
+- Modify: `backend/app/services/task_assignment_service.py`
+- Modify: `backend/app/services/points_service.py`
+- Test: `backend/tests/test_gig_approval.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `backend/tests/test_gig_approval.py`:
+
+```python
+"""Gig approval flow."""
+from datetime import date
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select, func
+
+from app.models.task_assignment import TaskAssignment, AssignmentStatus, ApprovalStatus
+from app.models.point_transaction import PointTransaction, TransactionType
+from app.services.task_assignment_service import TaskAssignmentService
+from app.core.exceptions import ForbiddenException, ValidationException, NotFoundException
+
+
+async def _make_pending_gig(db_session, family, child, template):
+    assignment = TaskAssignment(
+        id=uuid4(), template_id=template.id, assigned_to=child.id,
+        family_id=family.id, assigned_date=date.today(),
+        status=AssignmentStatus.COMPLETED,
+        approval_status=ApprovalStatus.PENDING,
+        proof_text="did the thing",
+    )
+    db_session.add(assignment)
+    await db_session.commit()
+    return assignment
+
+
+@pytest.mark.asyncio
+async def test_parent_approves_gig_credits_points(
+    db_session, demo_family, demo_parent, demo_child, gig_template_factory,
+):
+    gig = await gig_template_factory(family=demo_family, points=25)
+    assignment = await _make_pending_gig(db_session, demo_family, demo_child, gig)
+    before = demo_child.points
+
+    await TaskAssignmentService.approve_gig(
+        db_session, assignment.id, demo_family.id, demo_parent.id,
+        approve=True, notes="great writeup",
+    )
+
+    await db_session.refresh(demo_child)
+    await db_session.refresh(assignment)
+    assert assignment.approval_status == ApprovalStatus.APPROVED
+    assert demo_child.points == before + 25
+
+    txn = await db_session.scalar(
+        select(PointTransaction).where(PointTransaction.user_id == demo_child.id)
+    )
+    assert txn.type == TransactionType.GIG_APPROVED
+    assert txn.points == 25
+
+
+@pytest.mark.asyncio
+async def test_parent_rejects_gig_no_credit(
+    db_session, demo_family, demo_parent, demo_child, gig_template_factory,
+):
+    gig = await gig_template_factory(family=demo_family, points=25)
+    assignment = await _make_pending_gig(db_session, demo_family, demo_child, gig)
+    before = demo_child.points
+
+    await TaskAssignmentService.approve_gig(
+        db_session, assignment.id, demo_family.id, demo_parent.id,
+        approve=False, notes="no proof of conclusions",
+    )
+    await db_session.refresh(demo_child)
+    await db_session.refresh(assignment)
+    assert assignment.approval_status == ApprovalStatus.REJECTED
+    assert demo_child.points == before
+    count = await db_session.scalar(select(func.count()).select_from(PointTransaction))
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_non_parent_cannot_approve(
+    db_session, demo_family, demo_child, demo_teen, gig_template_factory,
+):
+    gig = await gig_template_factory(family=demo_family, points=25)
+    assignment = await _make_pending_gig(db_session, demo_family, demo_child, gig)
+
+    with pytest.raises(ForbiddenException):
+        await TaskAssignmentService.approve_gig(
+            db_session, assignment.id, demo_family.id, demo_teen.id,
+            approve=True, notes=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_double_approve_conflicts(
+    db_session, demo_family, demo_parent, demo_child, gig_template_factory,
+):
+    gig = await gig_template_factory(family=demo_family, points=25)
+    assignment = await _make_pending_gig(db_session, demo_family, demo_child, gig)
+
+    await TaskAssignmentService.approve_gig(
+        db_session, assignment.id, demo_family.id, demo_parent.id,
+        approve=True, notes=None,
+    )
+    with pytest.raises(ValidationException, match="already"):
+        await TaskAssignmentService.approve_gig(
+            db_session, assignment.id, demo_family.id, demo_parent.id,
+            approve=True, notes=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_list_pending_approvals_family_scoped(
+    db_session, demo_family, demo_child, gig_template_factory,
+):
+    gig = await gig_template_factory(family=demo_family, points=10)
+    await _make_pending_gig(db_session, demo_family, demo_child, gig)
+
+    rows = await TaskAssignmentService.list_pending_approvals(db_session, demo_family.id)
+    assert len(rows) == 1
+    assert rows[0].approval_status == ApprovalStatus.PENDING
+```
+
+- [ ] **Step 2: Run tests, confirm they fail**
+
+Run: `docker exec -e PYTHONPATH=/app family_app_backend pytest tests/test_gig_approval.py -v`
+Expected: FAIL with `AttributeError: type object 'TaskAssignmentService' has no attribute 'approve_gig'`
+
+- [ ] **Step 3: Implement `approve_gig` + `list_pending_approvals`**
+
+In `backend/app/services/task_assignment_service.py`, add inside the class:
+
+```python
+    @staticmethod
+    async def approve_gig(
+        db: AsyncSession,
+        assignment_id: UUID,
+        family_id: UUID,
+        parent_id: UUID,
+        approve: bool,
+        notes: Optional[str] = None,
+    ) -> TaskAssignment:
+        from app.models.user import User, UserRole  # local import to avoid cycles
+        from app.services.points_service import PointsService
+
+        # Verify parent is a parent in this family
+        parent = await get_user_by_id(db, parent_id)
+        if parent.family_id != family_id or parent.role != UserRole.PARENT:
+            raise ForbiddenException("Only parents in this family can approve gigs")
+
+        assignment = await TaskAssignmentService.get_assignment(db, assignment_id, family_id)
+
+        if assignment.approval_status != ApprovalStatus.PENDING:
+            raise ValidationException(
+                f"Gig already decided (status: {assignment.approval_status.value})"
+            )
+
+        assignment.approved_by = parent_id
+        assignment.approved_at = datetime.utcnow()
+        assignment.approval_notes = notes
+
+        if approve:
+            assignment.approval_status = ApprovalStatus.APPROVED
+            await PointsService.award_gig_points(
+                db, assignment.assigned_to, assignment.id, assignment.template.points
+            )
+        else:
+            assignment.approval_status = ApprovalStatus.REJECTED
+
+        await db.commit()
+        await db.refresh(assignment)
+        return assignment
+
+    @staticmethod
+    async def list_pending_approvals(
+        db: AsyncSession,
+        family_id: UUID,
+    ) -> list[TaskAssignment]:
+        from sqlalchemy.orm import selectinload
+        q = (
+            select(TaskAssignment)
+            .options(
+                selectinload(TaskAssignment.template),
+                selectinload(TaskAssignment.assignee),
+            )
+            .where(
+                TaskAssignment.family_id == family_id,
+                TaskAssignment.approval_status == ApprovalStatus.PENDING,
+            )
+            .order_by(TaskAssignment.completed_at.asc())
+        )
+        result = await db.execute(q)
+        return list(result.scalars().all())
+```
+
+If `TaskAssignment.assignee` relationship doesn't exist yet, use `selectinload(TaskAssignment.assigned_to_user)` — check the model. (If neither exists, add `assignee = relationship("User", foreign_keys=[assigned_to])` to the model and re-run.)
+
+- [ ] **Step 4: Implement `PointsService.award_gig_points`**
+
+In `backend/app/services/points_service.py`, after `award_points_for_task`, add:
+
+```python
+    @staticmethod
+    async def award_gig_points(
+        db: AsyncSession,
+        user_id: UUID,
+        assignment_id: UUID,
+        points: int,
+    ) -> PointTransaction:
+        user = await get_user_by_id(db, user_id)
+        transaction = PointTransaction.create_gig_approval(
+            user_id=user_id,
+            assignment_id=assignment_id,
+            points=points,
+            balance_before=user.points,
+        )
+        user.points += points
+        db.add(transaction)
+        # caller is responsible for commit
+        return transaction
+```
+
+- [ ] **Step 5: Run tests, confirm they pass**
+
+Run: `docker exec -e PYTHONPATH=/app family_app_backend pytest tests/test_gig_approval.py -v`
+Expected: 5 tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/services/task_assignment_service.py backend/app/services/points_service.py backend/tests/test_gig_approval.py
+git commit -m "feat(service): approve_gig credits points, list_pending_approvals queue"
+```
+
+---
+
+## Task 7: List enrichment — is_locked + approval fields
+
+**Files:**
+- Modify: `backend/app/services/task_assignment_service.py` (list endpoints)
+- Modify: `backend/app/api/routes/task_assignments.py:80-145` (week/today/get one response shaping)
+
+- [ ] **Step 1: Write failing test**
+
+Append to `backend/tests/test_gig_gating.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_list_marks_gigs_locked_when_mandatory_pending(
+    db_session, demo_family, demo_child,
+    mandatory_template_factory, gig_template_factory,
+):
+    mand = await mandatory_template_factory(family=demo_family)
+    gig = await gig_template_factory(family=demo_family, points=20)
+    today = date.today()
+    db_session.add_all([
+        TaskAssignment(
+            id=uuid4(), template_id=mand.id, assigned_to=demo_child.id,
+            family_id=demo_family.id, assigned_date=today, status=AssignmentStatus.PENDING,
+        ),
+        TaskAssignment(
+            id=uuid4(), template_id=gig.id, assigned_to=demo_child.id,
+            family_id=demo_family.id, assigned_date=today, status=AssignmentStatus.PENDING,
+        ),
+    ])
+    await db_session.commit()
+
+    rows = await TaskAssignmentService.list_for_user_today_with_locks(
+        db_session, demo_child.id, demo_family.id
+    )
+
+    locked = [r for r in rows if r["is_locked"]]
+    assert len(locked) == 1
+    assert locked[0]["is_bonus"] is True
+```
+
+- [ ] **Step 2: Run, confirm it fails**
+
+Run: `docker exec -e PYTHONPATH=/app family_app_backend pytest tests/test_gig_gating.py::test_list_marks_gigs_locked_when_mandatory_pending -v`
+Expected: FAIL — method missing.
+
+- [ ] **Step 3: Implement list enrichment**
+
+Add to `TaskAssignmentService`:
+
+```python
+    @staticmethod
+    async def list_for_user_today_with_locks(
+        db: AsyncSession,
+        user_id: UUID,
+        family_id: UUID,
+    ) -> list[dict]:
+        """Return today's assignments for user with is_locked, approval_status, proof_text."""
+        today = await TaskAssignmentService._user_local_today(db, user_id)
+        all_done = await TaskAssignmentService.check_all_required_done_today(
+            db, user_id, family_id, today
+        )
+        from sqlalchemy.orm import selectinload
+        q = (
+            select(TaskAssignment)
+            .options(selectinload(TaskAssignment.template))
+            .where(
+                TaskAssignment.assigned_to == user_id,
+                TaskAssignment.family_id == family_id,
+                TaskAssignment.assigned_date == today,
+            )
+            .order_by(TaskAssignment.assigned_date)
+        )
+        rows = (await db.execute(q)).scalars().all()
+        out = []
+        for r in rows:
+            is_bonus = r.template.is_bonus
+            out.append({
+                "id": r.id,
+                "template_id": r.template_id,
+                "title": r.template.title,
+                "points": r.template.points,
+                "is_bonus": is_bonus,
+                "status": r.status.value,
+                "approval_status": r.approval_status.value,
+                "proof_text": r.proof_text,
+                "is_locked": is_bonus and not all_done and r.status != AssignmentStatus.COMPLETED,
+                "assigned_date": r.assigned_date,
+                "completed_at": r.completed_at,
+            })
+        return out
+```
+
+- [ ] **Step 4: Confirm test passes**
+
+Run: `docker exec -e PYTHONPATH=/app family_app_backend pytest tests/test_gig_gating.py::test_list_marks_gigs_locked_when_mandatory_pending -v`
+Expected: PASS
+
+- [ ] **Step 5: Wire `/today` and `/week` routes to expose new fields**
+
+In `backend/app/api/routes/task_assignments.py`, locate the `@router.get("/today")` handler (around line 101). After the existing query, attach the same `is_locked`/`approval_status`/`proof_text` fields to the response rows. For the existing serialization (search for the dict literal around line 220-250 — the inline mapping of fields), add:
+
+```python
+        "is_locked": getattr(assignment, "_is_locked", False),
+        "approval_status": (
+            assignment.approval_status.value
+            if assignment.approval_status else "none"
+        ),
+        "proof_text": assignment.proof_text,
+```
+
+Then in the `/today` handler, before serialization, mark each assignment:
+
+```python
+    all_done = await TaskAssignmentService.check_all_required_done_today(
+        db, current_user.id, current_user.family_id, date.today()
+    )
+    for a in assignments:
+        a._is_locked = (
+            a.template.is_bonus
+            and not all_done
+            and a.status != AssignmentStatus.COMPLETED
+        )
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/services/task_assignment_service.py backend/app/api/routes/task_assignments.py backend/tests/test_gig_gating.py
+git commit -m "feat(api): expose is_locked + approval_status on assignment list"
+```
+
+---
+
+## Task 8: API routes — proof on complete, approval endpoints
+
+**Files:**
+- Modify: `backend/app/api/routes/task_assignments.py`
+
+- [ ] **Step 1: Update `/complete` route to accept proof_text**
+
+In `backend/app/api/routes/task_assignments.py` near line 178, change the route signature to accept body:
+
+```python
+from app.schemas.task_assignment import (
+    ...existing imports...,
+    CompleteAssignmentRequest,
+    ApprovalDecision,
+    GigApprovalRow,
+)
+
+
+@router.patch("/{assignment_id}/complete", response_model=TaskAssignmentWithDetails)
+async def complete_assignment(
+    assignment_id: UUID,
+    payload: CompleteAssignmentRequest | None = None,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Mark an assignment as completed (proof_text required for gigs)."""
+    assignment = await TaskAssignmentService.complete_assignment(
+        db,
+        assignment_id=assignment_id,
+        family_id=current_user.family_id,
+        user_id=current_user.id,
+        proof_text=(payload.proof_text if payload else None),
+    )
+    return _to_response(assignment)
+```
+
+(If a `_to_response` helper isn't present, mirror the existing inline serialization.)
+
+- [ ] **Step 2: Add `/pending-approvals` and `/{id}/approve` routes**
+
+Append to the same file:
+
+```python
+@router.get("/pending-approvals", response_model=List[GigApprovalRow])
+async def list_pending_approvals(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    if current_user.role != UserRole.PARENT:
+        raise HTTPException(status_code=403, detail="Parents only")
+    rows = await TaskAssignmentService.list_pending_approvals(db, current_user.family_id)
+    return [
+        GigApprovalRow(
+            assignment_id=r.id,
+            template_id=r.template_id,
+            template_title=r.template.title,
+            points=r.template.points,
+            assigned_to=r.assigned_to,
+            assigned_to_name=r.assignee.name if r.assignee else "",
+            completed_at=r.completed_at,
+            proof_text=r.proof_text,
+        )
+        for r in rows
+    ]
+
+
+@router.post("/{assignment_id}/approve", response_model=TaskAssignmentWithDetails)
+async def approve_assignment(
+    assignment_id: UUID,
+    decision: ApprovalDecision,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    assignment = await TaskAssignmentService.approve_gig(
+        db,
+        assignment_id=assignment_id,
+        family_id=current_user.family_id,
+        parent_id=current_user.id,
+        approve=decision.approve,
+        notes=decision.notes,
+    )
+    return _to_response(assignment)
+```
+
+Add `from app.models.user import UserRole` if not already imported.
+
+- [ ] **Step 3: Smoke test routes via curl**
+
+Run:
+```bash
+docker compose restart backend
+sleep 3
+curl -s http://localhost:8003/openapi.json | python3 -c "import sys,json; ops=json.load(sys.stdin)['paths']; print([p for p in ops if 'approv' in p or 'complete' in p])"
+```
+Expected: prints list including `/api/task-assignments/pending-approvals` and `/api/task-assignments/{assignment_id}/approve`.
+
+- [ ] **Step 4: Run full backend tests**
+
+Run: `docker exec -e PYTHONPATH=/app family_app_backend pytest tests/test_gig_gating.py tests/test_gig_approval.py -v`
+Expected: all PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/api/routes/task_assignments.py
+git commit -m "feat(api): proof_text on complete, /pending-approvals, /approve routes"
+```
+
+---
+
+## Task 9: Migration assertions test
+
+**Files:**
+- Create: `backend/tests/test_migration_mandatory_zero.py`
+
+- [ ] **Step 1: Write the test**
+
+```python
+"""Assert migration outcomes are durable."""
+import pytest
+from sqlalchemy import select, func, text
+from app.models.task_template import TaskTemplate
+
+
+@pytest.mark.asyncio
+async def test_all_mandatory_templates_have_zero_points(db_session):
+    bad = await db_session.scalar(
+        select(func.count()).select_from(TaskTemplate).where(
+            TaskTemplate.is_bonus.is_(False),
+            TaskTemplate.points != 0,
+        )
+    )
+    assert bad == 0
+
+
+@pytest.mark.asyncio
+async def test_check_constraint_rejects_nonzero_mandatory_insert(db_session, demo_family):
+    with pytest.raises(Exception, match="chk_mandatory_zero_points|check constraint"):
+        await db_session.execute(text(
+            "INSERT INTO task_templates "
+            "(id, title, points, interval_days, assignment_type, is_bonus, is_active, family_id, created_at, updated_at) "
+            "VALUES (gen_random_uuid(), 'bad', 5, 1, 'auto', false, true, :fid, NOW(), NOW())"
+        ), {"fid": str(demo_family.id)})
+        await db_session.commit()
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_default_gig_pack_seeded(db_session, demo_family):
+    titles = ["Cook family dinner", "Plan next 3 days of meals", "Help with grocery shopping"]
+    for t in titles:
+        found = await db_session.scalar(
+            select(func.count()).select_from(TaskTemplate).where(
+                TaskTemplate.family_id == demo_family.id,
+                TaskTemplate.title == t,
+                TaskTemplate.is_bonus.is_(True),
+            )
+        )
+        assert found >= 1, f"Default gig '{t}' missing"
+```
+
+- [ ] **Step 2: Run**
+
+Run: `docker exec -e PYTHONPATH=/app family_app_backend pytest tests/test_migration_mandatory_zero.py -v`
+Expected: 3 PASS (assumes migration already applied locally in Task 1).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/tests/test_migration_mandatory_zero.py
+git commit -m "test(migration): assert zero-mandatory, CHECK constraint, gig pack seed"
+```
+
+---
+
+## Task 10: Seed gig pack on new family creation
+
+**Files:**
+- Modify: `backend/app/services/family_service.py`
+
+- [ ] **Step 1: Add helper + call from create**
+
+In `backend/app/services/family_service.py`, locate `class FamilyService:` and add:
+
+```python
+    DEFAULT_GIGS = [
+        ("Learn a topic + writeup", "Pick something new (podman, git, a recipe). Read up, then write 5-10 sentences on what you learned.", 30),
+        ("Read book chapter + discuss", "Read a chapter, then sit with a parent to discuss the main idea.", 20),
+        ("Plan next 3 days of meals", "Propose breakfasts, lunches, and dinners for the next 3 days. List groceries needed.", 25),
+        ("Help with grocery shopping", "Help compile the list, go to the store, and help carry/put away.", 15),
+        ("Cook family dinner", "Plan, cook, and serve a family dinner with parent supervision.", 25),
+        ("Tech-help parent (15 min)", "Help a parent with a phone/computer task for at least 15 minutes.", 10),
+    ]
+
+    @staticmethod
+    async def _seed_default_gigs(db: AsyncSession, family_id):
+        from app.models.task_template import TaskTemplate, AssignmentType
+        for title, description, points in FamilyService.DEFAULT_GIGS:
+            db.add(TaskTemplate(
+                title=title,
+                description=description,
+                points=points,
+                interval_days=7,
+                assignment_type=AssignmentType.AUTO,
+                is_bonus=True,
+                is_active=True,
+                family_id=family_id,
+            ))
+        await db.flush()
+```
+
+In the existing `create_family` (or equivalent creation method), after the family row is committed:
+
+```python
+        await FamilyService._seed_default_gigs(db, family.id)
+        await db.commit()
+```
+
+- [ ] **Step 2: Add a test**
+
+Append to `backend/tests/test_migration_mandatory_zero.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_new_family_gets_default_gigs(db_session):
+    from app.services.family_service import FamilyService
+    family = await FamilyService.create_family(db_session, name="Brand New Fam")
+    count = await db_session.scalar(
+        select(func.count()).select_from(TaskTemplate).where(
+            TaskTemplate.family_id == family.id,
+            TaskTemplate.is_bonus.is_(True),
+        )
+    )
+    assert count == len(FamilyService.DEFAULT_GIGS)
+```
+
+- [ ] **Step 3: Run**
+
+Run: `docker exec -e PYTHONPATH=/app family_app_backend pytest tests/test_migration_mandatory_zero.py::test_new_family_gets_default_gigs -v`
+Expected: PASS
+
+If the existing `create_family` signature differs, adjust call args accordingly. (Read the file before editing if uncertain.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/app/services/family_service.py backend/tests/test_migration_mandatory_zero.py
+git commit -m "feat(family): seed default gig pack on new family creation"
+```
+
+---
+
+## Task 11: Frontend — assignment list lock badge + gig completion modal
+
+**Files:**
+- Modify: `frontend/src/pages/parent/assignments.astro`
+- Modify: `frontend/src/pages/api/assignments/complete.ts`
+
+- [ ] **Step 1: Update complete.ts proxy to forward proof_text**
+
+Edit `frontend/src/pages/api/assignments/complete.ts`. Locate the body construction and ensure the body forwarded to the backend includes `proof_text` from the inbound request body:
+
+```ts
+export const POST: APIRoute = async ({ request, cookies }) => {
+  const body = await request.json().catch(() => ({}));
+  const { assignment_id, proof_text } = body;
+  const token = cookies.get("access_token")?.value;
+  const res = await fetch(
+    `${API_BASE}/api/task-assignments/${assignment_id}/complete`,
+    {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ proof_text: proof_text ?? null }),
+    }
+  );
+  return new Response(await res.text(), {
+    status: res.status,
+    headers: { "Content-Type": "application/json" },
+  });
+};
+```
+
+Match the existing import style (`API_BASE`) used in sibling files.
+
+- [ ] **Step 2: Update assignments.astro**
+
+In `frontend/src/pages/parent/assignments.astro`, find the row rendering loop. For each assignment add:
+
+```astro
+{assignment.is_locked && (
+  <span class="inline-flex items-center gap-1 px-2 py-0.5 text-xs rounded bg-amber-100 text-amber-800" title="Finish today's mandatory tasks to unlock">
+    🔒 Locked
+  </span>
+)}
+{assignment.approval_status === "pending" && (
+  <span class="px-2 py-0.5 text-xs rounded bg-amber-100 text-amber-800">Awaiting approval</span>
+)}
+{assignment.approval_status === "approved" && (
+  <span class="px-2 py-0.5 text-xs rounded bg-green-100 text-green-800">Approved</span>
+)}
+{assignment.approval_status === "rejected" && (
+  <span class="px-2 py-0.5 text-xs rounded bg-red-100 text-red-800">Rejected</span>
+)}
+```
+
+Disable the "Complete" button when `assignment.is_locked` is true.
+
+For the gig completion flow, add a client-side modal (vanilla JS in `<script>` block) that opens when clicking complete on a row where `is_bonus=true`. The modal must collect a `proof_text` value and POST to `/api/assignments/complete` with `{ assignment_id, proof_text }`. For mandatory rows (`is_bonus=false`), submit immediately with `proof_text: null`.
+
+Modal markup (hidden by default):
+
+```html
+<dialog id="gig-proof-modal" class="rounded-lg p-6 backdrop:bg-black/40 max-w-md">
+  <h3 class="text-lg font-semibold mb-3">Tell us what you did</h3>
+  <p class="text-sm text-gray-600 mb-3">A parent will review this and approve the points.</p>
+  <textarea id="gig-proof-text" rows="5" class="w-full border rounded p-2 mb-3" placeholder="What did you learn / make / accomplish?"></textarea>
+  <div class="flex justify-end gap-2">
+    <button id="gig-proof-cancel" class="px-3 py-1.5 rounded border">Cancel</button>
+    <button id="gig-proof-submit" class="px-3 py-1.5 rounded bg-emerald-600 text-white">Submit for approval</button>
+  </div>
+</dialog>
+```
+
+`<script>` (Astro-side):
+
+```html
+<script>
+  const modal = document.getElementById("gig-proof-modal") as HTMLDialogElement;
+  const textarea = document.getElementById("gig-proof-text") as HTMLTextAreaElement;
+  let pendingAssignmentId: string | null = null;
+
+  document.querySelectorAll<HTMLButtonElement>("[data-complete-btn]").forEach((btn) => {
+    btn.addEventListener("click", async () => {
+      const id = btn.dataset.assignmentId!;
+      const isGig = btn.dataset.isBonus === "true";
+      if (isGig) {
+        pendingAssignmentId = id;
+        textarea.value = "";
+        modal.showModal();
+      } else {
+        await submitComplete(id, null);
+      }
+    });
+  });
+
+  document.getElementById("gig-proof-cancel")!.addEventListener("click", () => modal.close());
+  document.getElementById("gig-proof-submit")!.addEventListener("click", async () => {
+    if (!textarea.value.trim()) { alert("Tell us what you did"); return; }
+    await submitComplete(pendingAssignmentId!, textarea.value.trim());
+    modal.close();
+  });
+
+  async function submitComplete(assignment_id: string, proof_text: string | null) {
+    const r = await fetch("/api/assignments/complete", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ assignment_id, proof_text }),
+    });
+    if (r.ok) location.reload();
+    else alert(`Error: ${await r.text()}`);
+  }
+</script>
+```
+
+For each complete button add `data-assignment-id={assignment.id}` and `data-is-bonus={String(assignment.is_bonus)}` and `data-complete-btn`.
+
+- [ ] **Step 3: Manual smoke test in browser**
+
+Run: `docker compose up -d frontend backend` (already up — `docker compose restart frontend`)
+
+In a browser logged in as `lucas@demo.com` (TEEN with seeded mandatory + gig):
+1. Navigate to `/parent/assignments` (or the child-side equivalent).
+2. With mandatory pending, the gig row shows "🔒 Locked" and Complete button is disabled.
+3. Complete all mandatory rows — lock badge disappears.
+4. Click Complete on a gig — modal appears. Submit with text. Row gets "Awaiting approval" badge.
+
+Document any layout issues in the next task (parent approval page).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/pages/parent/assignments.astro frontend/src/pages/api/assignments/complete.ts
+git commit -m "feat(frontend): lock badge + gig proof modal on assignments list"
+```
+
+---
+
+## Task 12: Frontend — parent approvals page + nav badge
+
+**Files:**
+- Create: `frontend/src/pages/parent/approvals.astro`
+- Create: `frontend/src/pages/api/assignments/pending-approvals.ts`
+- Create: `frontend/src/pages/api/assignments/approve.ts`
+- Modify: nav header partial (search for the parent nav component)
+
+- [ ] **Step 1: Create `pending-approvals.ts` proxy**
+
+`frontend/src/pages/api/assignments/pending-approvals.ts`:
+
+```ts
+import type { APIRoute } from "astro";
+
+const API_BASE = import.meta.env.PUBLIC_API_BASE_URL || "http://backend:8000";
+
+export const GET: APIRoute = async ({ cookies }) => {
+  const token = cookies.get("access_token")?.value;
+  const r = await fetch(`${API_BASE}/api/task-assignments/pending-approvals`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return new Response(await r.text(), {
+    status: r.status,
+    headers: { "Content-Type": "application/json" },
+  });
+};
+```
+
+- [ ] **Step 2: Create `approve.ts` proxy**
+
+`frontend/src/pages/api/assignments/approve.ts`:
+
+```ts
+import type { APIRoute } from "astro";
+
+const API_BASE = import.meta.env.PUBLIC_API_BASE_URL || "http://backend:8000";
+
+export const POST: APIRoute = async ({ request, cookies }) => {
+  const body = await request.json();
+  const { assignment_id, approve, notes } = body;
+  const token = cookies.get("access_token")?.value;
+  const r = await fetch(
+    `${API_BASE}/api/task-assignments/${assignment_id}/approve`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ approve, notes }),
+    }
+  );
+  return new Response(await r.text(), {
+    status: r.status,
+    headers: { "Content-Type": "application/json" },
+  });
+};
+```
+
+- [ ] **Step 3: Create `approvals.astro`**
+
+`frontend/src/pages/parent/approvals.astro`:
+
+```astro
+---
+import Layout from "../../layouts/Layout.astro";
+import { getSessionUser } from "../../lib/session";
+
+const user = await getSessionUser(Astro);
+if (!user || user.role !== "parent") {
+  return Astro.redirect("/login");
+}
+
+const API_BASE = import.meta.env.PUBLIC_API_BASE_URL || "http://backend:8000";
+const token = Astro.cookies.get("access_token")?.value;
+const r = await fetch(`${API_BASE}/api/task-assignments/pending-approvals`, {
+  headers: { Authorization: `Bearer ${token}` },
+});
+const rows = r.ok ? await r.json() : [];
+---
+
+<Layout title="Gig approvals">
+  <main class="max-w-3xl mx-auto p-6">
+    <h1 class="text-2xl font-semibold mb-4">Pending gig approvals</h1>
+    {rows.length === 0 ? (
+      <p class="text-gray-500">No gigs waiting for approval.</p>
+    ) : (
+      <ul class="space-y-4">
+        {rows.map((row) => (
+          <li class="border rounded-lg p-4 bg-white" data-id={row.assignment_id}>
+            <div class="flex justify-between items-start mb-2">
+              <div>
+                <h3 class="font-medium">{row.template_title}</h3>
+                <p class="text-sm text-gray-600">
+                  {row.assigned_to_name} · {row.points} pts
+                </p>
+              </div>
+              <span class="text-xs text-gray-500">
+                {new Date(row.completed_at).toLocaleString()}
+              </span>
+            </div>
+            <p class="text-sm bg-gray-50 rounded p-3 mb-3 whitespace-pre-wrap">
+              {row.proof_text || "(no proof text)"}
+            </p>
+            <textarea
+              data-notes
+              rows="2"
+              class="w-full border rounded p-2 mb-2 text-sm"
+              placeholder="Notes (optional)"
+            ></textarea>
+            <div class="flex justify-end gap-2">
+              <button
+                data-action="reject"
+                class="px-3 py-1.5 rounded border text-red-700"
+              >Reject</button>
+              <button
+                data-action="approve"
+                class="px-3 py-1.5 rounded bg-emerald-600 text-white"
+              >Approve</button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    )}
+  </main>
+</Layout>
+
+<script>
+  document.querySelectorAll<HTMLLIElement>("li[data-id]").forEach((li) => {
+    const id = li.dataset.id!;
+    const notes = li.querySelector<HTMLTextAreaElement>("[data-notes]")!;
+    li.querySelectorAll<HTMLButtonElement>("button[data-action]").forEach((btn) => {
+      btn.addEventListener("click", async () => {
+        const approve = btn.dataset.action === "approve";
+        const r = await fetch("/api/assignments/approve", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            assignment_id: id,
+            approve,
+            notes: notes.value.trim() || null,
+          }),
+        });
+        if (r.ok) li.remove();
+        else alert(`Error: ${await r.text()}`);
+      });
+    });
+  });
+</script>
+```
+
+- [ ] **Step 4: Add nav badge**
+
+Locate the parent nav header (search): `grep -rln "parent/assignments\|parent/tasks" frontend/src/layouts frontend/src/components`.
+
+In the parent nav, fetch the pending count once per page render and show a small dot/number next to the "Approvals" link. Add a link to `/parent/approvals` with a dot if `count > 0`.
+
+Astro frontmatter:
+```astro
+const apprResp = await fetch(`${API_BASE}/api/task-assignments/pending-approvals`, {
+  headers: { Authorization: `Bearer ${token}` },
+});
+const pendingCount = apprResp.ok ? (await apprResp.json()).length : 0;
+```
+
+Render:
+```astro
+<a href="/parent/approvals" class="relative px-3 py-2">
+  Approvals
+  {pendingCount > 0 && (
+    <span class="absolute -top-1 -right-1 bg-red-500 text-white text-xs rounded-full w-4 h-4 flex items-center justify-center">{pendingCount}</span>
+  )}
+</a>
+```
+
+- [ ] **Step 5: Manual smoke test**
+
+In browser:
+1. As `mom@demo.com` (parent), navigate to `/parent/approvals`.
+2. Approve a pending gig — row disappears. Child's points balance increases by template points.
+3. Reject another — row disappears, no points credited.
+4. Nav badge count decrements correctly.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/pages/parent/approvals.astro frontend/src/pages/api/assignments/approve.ts frontend/src/pages/api/assignments/pending-approvals.ts frontend/src/layouts frontend/src/components
+git commit -m "feat(frontend): parent approvals page + nav badge"
+```
+
+---
+
+## Task 13: E2E Playwright test
+
+**Files:**
+- Create: `e2e-tests/tests/gigs.spec.ts`
+
+- [ ] **Step 1: Write the test**
+
+```ts
+import { test, expect } from "@playwright/test";
+
+test.describe("Gigs lifecycle", () => {
+  test("child cannot complete gig while mandatory pending, parent approves after unlock", async ({ page, context }) => {
+    // Sign in as child
+    await page.goto("/login");
+    await page.fill('input[name="email"]', "lucas@demo.com");
+    await page.fill('input[name="password"]', "password123");
+    await page.click('button[type="submit"]');
+    await page.waitForURL(/\/(parent|dashboard|child)/);
+
+    await page.goto("/parent/assignments");
+
+    // Expect a lock badge somewhere
+    await expect(page.locator("text=Locked").first()).toBeVisible();
+
+    // Complete all mandatory
+    const mandatoryButtons = page.locator('[data-complete-btn][data-is-bonus="false"]');
+    const n = await mandatoryButtons.count();
+    for (let i = 0; i < n; i++) {
+      await mandatoryButtons.nth(0).click(); // collection shrinks after reload
+      await page.waitForLoadState("networkidle");
+    }
+
+    // Click a gig complete button (modal should open)
+    await page.locator('[data-complete-btn][data-is-bonus="true"]').first().click();
+    await page.locator("#gig-proof-text").fill("read chapter on rootless podman");
+    await page.locator("#gig-proof-submit").click();
+    await page.waitForLoadState("networkidle");
+    await expect(page.locator("text=Awaiting approval").first()).toBeVisible();
+
+    // Sign out, sign in as parent
+    await context.clearCookies();
+    await page.goto("/login");
+    await page.fill('input[name="email"]', "mom@demo.com");
+    await page.fill('input[name="password"]', "password123");
+    await page.click('button[type="submit"]');
+    await page.waitForURL(/\/parent/);
+
+    await page.goto("/parent/approvals");
+    await expect(page.locator("text=read chapter on rootless podman")).toBeVisible();
+    await page.locator('button[data-action="approve"]').first().click();
+    await page.waitForLoadState("networkidle");
+
+    // Approval list shrinks
+    await expect(page.locator("text=read chapter on rootless podman")).not.toBeVisible();
+  });
+});
+```
+
+- [ ] **Step 2: Run**
+
+Run: `cd e2e-tests && npm run test -- gigs.spec.ts`
+Expected: 1 PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e-tests/tests/gigs.spec.ts
+git commit -m "test(e2e): gigs lifecycle — lock, proof modal, parent approval"
+```
+
+---
+
+## Final verification
+
+- [ ] **Step 1: Run full backend test suite**
+
+Run: `docker exec -e PYTHONPATH=/app family_app_backend pytest tests/ -v`
+Expected: all new tests PASS. Pre-existing failures (per CLAUDE.md: 51 stub failures) remain unchanged in count.
+
+- [ ] **Step 2: Manual end-to-end smoke in browser**
+
+1. Sign in as child → confirm gigs locked while mandatory pending.
+2. Complete mandatory → lock clears (no points credited for mandatory).
+3. Complete gig with proof → row goes "Awaiting approval".
+4. Sign in as parent → see pending in `/parent/approvals` and nav badge.
+5. Approve → child balance increases by template.points, badge clears.
+
+- [ ] **Step 3: Push branch + open PR**
+
+```bash
+git push -u origin HEAD
+gh pr create --title "Mandatory tasks zero points, gigs gated + parent-approved" --body "$(cat <<'EOF'
+## Summary
+- Mandatory tasks (is_bonus=false) award no points and create no point_transaction row
+- Gigs (is_bonus=true) require all of today's mandatory done first, require proof text, and enter PENDING approval
+- Parent approval credits gig points via new GIG_APPROVED transaction type
+- Default gig pack seeded per existing family and on new family creation
+- families.timezone column added for accurate "today" gating
+
+Spec: docs/superpowers/specs/2026-05-22-mandatory-vs-gigs-design.md
+
+## Test plan
+- [ ] backend pytest tests/test_gig_gating.py tests/test_gig_approval.py tests/test_migration_mandatory_zero.py
+- [ ] e2e: npm run test -- gigs.spec.ts
+- [ ] manual: child locks → complete mandatory → unlock → submit gig with proof → parent approves → balance updates
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-05-22-mandatory-vs-gigs-design.md
+++ b/docs/superpowers/specs/2026-05-22-mandatory-vs-gigs-design.md
@@ -1,0 +1,259 @@
+# Mandatory tasks vs Gigs — design
+
+**Date:** 2026-05-22
+**Author:** brainstorming session
+**Status:** Draft — pending implementation plan
+
+## Problem
+
+Current task model awards points for every completed `task_template`, regardless of whether it's a basic daily duty (brush teeth, make bed) or a higher-effort discretionary task (learn a new skill, plan meals). This dilutes the incentive system — kids treat baseline household duties as point-earning, and there's no mechanism to reward initiative beyond the baseline.
+
+## Goal
+
+Re-scope the points economy so that:
+
+1. **Mandatory tasks** (daily duties) award **zero points**. They are expected behavior, not transactions.
+2. **Gigs** (discretionary, higher-effort tasks like "learn podman + writeup", "read book + discuss", "plan next 3 days meals", "help with grocery shopping") are the **only point-earning activities**.
+3. Gigs are **gated**: a user cannot earn points from a gig until **all mandatory tasks due today are completed**.
+4. Gigs require **parent approval** before points are credited.
+
+## Non-goals
+
+- Auto-unlock notifications (push/email) when mandatory completion unlocks gigs.
+- Carry-over gating (overdue mandatory blocking future gigs). Today-only gating in v1.
+- Photo/file proof uploads. Text proof only in v1.
+- Recurring/scheduled gigs beyond what `task_templates` already supports.
+- New premium/plan limits on gigs.
+
+## Decisions (from brainstorming)
+
+| Topic | Decision |
+|-------|----------|
+| Mandatory vs gig modeling | Reuse existing `task_templates.is_bonus` flag. `is_bonus=false` → mandatory. `is_bonus=true` → gig. |
+| Gating trigger | All today's mandatory assignments for the user must be `COMPLETED` before any gig completion is accepted. Family timezone applies. |
+| Existing data | Migration forces `points=0` on every `task_template` where `is_bonus=false`. Past `point_transactions` rows untouched. |
+| Default gigs | Alembic data migration seeds a default gig pack per family. Parents can edit/disable. |
+| Approval | All gigs require parent approval. User completion sets `approval_status=PENDING`; points credit on approve. |
+| Enforcement | Service-layer guard (option A). Backend is source of truth. Frontend renders `is_locked` hint computed by API. |
+
+## Data model
+
+### `task_templates`
+
+No new columns. Add CHECK constraint:
+
+```sql
+ALTER TABLE task_templates
+  ADD CONSTRAINT chk_mandatory_zero_points
+  CHECK (is_bonus = TRUE OR points = 0);
+```
+
+Pre-constraint migration step: `UPDATE task_templates SET points = 0 WHERE is_bonus = false;`
+
+### `families` — new column
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `timezone` | VARCHAR(64), nullable, default `"UTC"` | IANA tz string (e.g. `America/Mexico_City`). Used to compute "today" for gig gating. |
+
+Backfill: `UPDATE families SET timezone = 'UTC' WHERE timezone IS NULL;` Parent settings page gains a timezone selector (frontend out of scope for this spec; backend accepts the field).
+
+### `task_assignments` — new columns
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `approval_status` | enum (`NONE`, `PENDING`, `APPROVED`, `REJECTED`) | Default `NONE`. Mandatory rows stay `NONE`. Gig rows go `PENDING` on user complete. |
+| `proof_text` | TEXT, nullable | User-submitted writeup when completing a gig. |
+| `approved_by` | UUID, FK→users.id ON DELETE SET NULL, nullable | Parent who approved/rejected. |
+| `approved_at` | TIMESTAMPTZ, nullable | When parent acted. |
+| `approval_notes` | TEXT, nullable | Parent's note (esp. for rejections). |
+
+Index: `(family_id, approval_status)` for the pending-approvals queue.
+
+### `point_transactions`
+
+Add new enum value `TransactionType.GIG_APPROVED`. Mandatory completions create **no** `point_transaction` row.
+
+### Default gig pack (seeded per family)
+
+Alembic data migration inserts ~6 starter gigs per existing family (and a post-create hook for new families):
+
+| Title | Points | Note |
+|-------|--------|------|
+| Learn topic + writeup (e.g. podman, git) | 30 | Long-form learning |
+| Read book chapter + discuss | 20 | Reading + conversation |
+| Plan next 3 days of meals | 25 | Planning task |
+| Help with grocery shopping | 15 | Errand assist |
+| Cook family dinner | 25 | Cooking |
+| Tech-help parent (15 min) | 10 | Family IT |
+
+All seeded with `is_bonus=true`, `is_active=true`, `assignment_type=AUTO`, `interval_days=7`, `allowed_roles=["teen","child","parent"]`.
+
+## Service layer
+
+### `TaskAssignmentService.complete(assignment_id, user_id, proof_text=None)`
+
+```
+load assignment + template
+verify ownership + family
+if not template.is_bonus:
+    assignment.status = COMPLETED
+    assignment.completed_at = now()
+    # no point transaction
+    commit; return
+else:  # gig
+    if await _has_pending_mandatory_today(db, user_id):
+        raise ForbiddenException("Complete today's mandatory tasks first")
+    if not proof_text or len(proof_text.strip()) < 1:
+        raise ValidationException("Proof text required for gigs")
+    assignment.status = COMPLETED
+    assignment.approval_status = PENDING
+    assignment.proof_text = proof_text
+    # no points yet
+    commit; return
+```
+
+### `_has_pending_mandatory_today(db, user_id) -> bool`
+
+```python
+user = await get_user_by_id(db, user_id)
+tz = user.family.timezone or "UTC"
+local_today_date = current_date_in_tz(tz)  # date object in family TZ
+q = (
+    select(func.count())
+    .select_from(TaskAssignment)
+    .join(TaskTemplate, TaskTemplate.id == TaskAssignment.template_id)
+    .where(
+        TaskAssignment.assigned_to == user_id,
+        TaskTemplate.is_bonus.is_(False),
+        TaskAssignment.assigned_date == local_today_date,
+        TaskAssignment.status != AssignmentStatus.COMPLETED,
+    )
+)
+return (await db.scalar(q)) > 0
+```
+
+### `TaskAssignmentService.approve_gig(assignment_id, parent_id, approve, notes=None)`
+
+```
+verify parent role + family
+load assignment
+if assignment.approval_status != PENDING: raise 409
+if approve:
+    assignment.approval_status = APPROVED
+    assignment.approved_by = parent_id
+    assignment.approved_at = now()
+    assignment.approval_notes = notes
+    await PointsService.award_gig_points(...)  # new type GIG_APPROVED
+else:
+    assignment.approval_status = REJECTED
+    assignment.approved_by = parent_id
+    assignment.approved_at = now()
+    assignment.approval_notes = notes
+commit; return
+```
+
+### `PointsService.award_gig_points(user_id, assignment_id, points)`
+
+Mirror of `award_points_for_task` but writes `TransactionType.GIG_APPROVED`.
+
+### List enrichment
+
+`TaskAssignmentService.list_assignments` adds, per row:
+- `is_locked: bool` — `True` if `template.is_bonus and _has_pending_mandatory_today(user)`. Compute once per request (cache the mandatory-pending boolean per user_id).
+- `approval_status: str` — passthrough.
+- `proof_text: str | None` — passthrough.
+
+## API surface
+
+All under `/api/task-assignments/`:
+
+| Method + path | Purpose | Auth |
+|---------------|---------|------|
+| `POST /{id}/complete` | Existing. Now accepts `proof_text?: str`. Returns 403 on locked gig, 422 on missing proof for gigs, 200 otherwise. | Assignee |
+| `GET /pending-approvals` | List gigs in family with `approval_status=PENDING`. | Parent |
+| `POST /{id}/approve` | Body: `{approve: bool, notes?: str}`. Credits points on approve. | Parent |
+| `GET /` | Existing. Response rows gain `is_locked`, `approval_status`, `proof_text`. | Family member |
+
+## Frontend
+
+### `/tasks` (assignment list)
+- Lock icon + tooltip ("Finish today's mandatory tasks to unlock gigs") on rows where `is_locked=true`. Complete button disabled.
+- Approval status badge: `PENDING` (amber), `APPROVED` (green), `REJECTED` (red). Hidden for mandatory.
+
+### Gig completion modal
+- Triggered when user clicks complete on `is_bonus=true` row.
+- Required textarea: "Tell us what you did / what you learned" → `proof_text`.
+- On submit: POST `/complete` with `proof_text`.
+
+### `/parent/approvals` (new page)
+- Parent-only. Lists pending-approval gigs across family.
+- Per row: child name, gig title, points to award, proof text (collapsible), approve button, reject button + notes input.
+
+### Nav badge
+- Parent header gains a clipboard-with-dot icon showing count of pending approvals. Same pattern as receipt-drafts.
+
+## Tests
+
+### Backend
+
+`backend/tests/test_gig_gating.py`:
+- Mandatory assignment incomplete today → completing a gig returns 403 "Complete today's mandatory tasks first".
+- All mandatory complete → completing a gig succeeds, returns `approval_status=PENDING`, no point transaction yet.
+- Completing a mandatory task creates no `point_transaction` row.
+- Mandatory tasks across timezones use family timezone for the `assigned_date` match (today in family TZ).
+
+`backend/tests/test_gig_approval.py`:
+- Approve flow: pending → approved, creates `GIG_APPROVED` transaction with `template.points`, updates user balance.
+- Reject flow: pending → rejected, no transaction, balance unchanged.
+- Non-parent attempts approve → 403.
+- Double-approve (already approved/rejected) → 409.
+- Approving a non-existent or cross-family assignment → 404.
+
+`backend/tests/test_migration_zero_mandatory.py`:
+- After migration: every `task_template` with `is_bonus=false` has `points=0`.
+- CHECK constraint blocks `INSERT INTO task_templates (is_bonus=false, points=10)`.
+- Existing `point_transactions` rows from past completions untouched.
+
+`backend/tests/test_default_gig_pack.py`:
+- After migration: every existing family has the seeded gig templates.
+- Seed is idempotent (running again does not duplicate).
+- New family creation auto-seeds the same pack.
+
+### E2E (`e2e-tests/`)
+
+`tests/gigs.spec.ts`:
+- Child user with pending mandatory tasks tries to complete a gig → sees lock icon, button disabled, attempts API → 403.
+- Child completes all mandatory tasks → lock clears, gig button enables.
+- Child completes gig with proof text → row shows PENDING badge.
+- Parent logs in, navigates to `/parent/approvals`, sees the gig, approves → child's balance increases, badge flips to APPROVED.
+- Parent rejects a different gig → no balance change, badge flips to REJECTED.
+
+## Migration plan
+
+1. Alembic revision `mandatory_zero_points_and_gigs`:
+   - Add `families.timezone VARCHAR(64) DEFAULT 'UTC'` (NOT NULL after backfill).
+   - `UPDATE task_templates SET points = 0 WHERE is_bonus = false;`
+   - Add CHECK constraint `chk_mandatory_zero_points`.
+   - Add columns to `task_assignments`: `approval_status`, `proof_text`, `approved_by`, `approved_at`, `approval_notes`.
+   - Add index `idx_assignments_family_approval (family_id, approval_status)`.
+   - Add enum value `gig_approved` to `transactiontype`.
+   - Data step: seed default gig pack for every existing family.
+2. Add post-create hook in `FamilyService.create_family` to seed the gig pack for new families.
+3. Downgrade is destructive (drops gig templates, drops approval cols, restores any points reset). Document as one-way in prod.
+
+## Risk + rollout
+
+- **Existing point balances** are not modified. Users keep what they earned. Only forward earning is constrained.
+- **Active child users** may be confused that mandatory tasks no longer award points. Add a one-time in-app banner explaining the change for the first login post-deploy.
+- **Approval bottleneck**: if a parent is slow to approve, gigs sit unrewarded. Acceptable for v1; revisit with notifications later.
+- **Gating edge case**: a family with zero mandatory tasks today (e.g. all completed before midnight, weekend with no scheduled mandatory) → `_has_pending_mandatory_today` returns false → gigs unlocked. Correct behavior.
+
+## Out of scope (future iterations)
+
+- Push/email notifications for pending approvals.
+- Photo proof upload for gigs.
+- Gig "claim" step (reserve a gig before doing it).
+- Carry-over: overdue mandatory blocking new gigs.
+- Plan-tier limits on gig count.
+- Auto-approval based on parent trust score.

--- a/e2e-tests/gigs.spec.js
+++ b/e2e-tests/gigs.spec.js
@@ -35,7 +35,7 @@ test.describe('Gigs lifecycle', () => {
     const modal = page.locator('#gig-proof-modal');
     await expect(modal).toBeVisible();
     await page.fill('#gig-proof-text', 'learned about rootless podman storage layout');
-    await page.locator('#gig-proof-form button[type="submit"]').click();
+    await page.locator('#gig-proof-submit').click();
     await page.waitForLoadState('networkidle');
 
     // After redirect, the row should show "Awaiting approval" or live in the pending section

--- a/e2e-tests/gigs.spec.js
+++ b/e2e-tests/gigs.spec.js
@@ -1,0 +1,86 @@
+const { test, expect } = require('@playwright/test');
+
+const BASE_URL = 'http://localhost:3003';
+const PARENT = { email: 'mom@demo.com', password: 'password123' };
+const CHILD = { email: 'lucas@demo.com', password: 'password123' };
+
+async function login(page, user) {
+  await page.goto(`${BASE_URL}/login`);
+  await page.waitForLoadState('networkidle');
+  await page.fill('input[name="email"]', user.email);
+  await page.fill('input[name="password"]', user.password);
+  await page.click('button[type="submit"]');
+  await page.waitForURL(/\/(dashboard|parent)/, { timeout: 10000 });
+}
+
+async function logout(page, context) {
+  await context.clearCookies();
+}
+
+test.describe('Gigs lifecycle', () => {
+  test('child submits gig with proof, parent approves, points credit', async ({ page, context }) => {
+    // ─── Child path ───
+    await login(page, CHILD);
+    await page.goto(`${BASE_URL}/dashboard`);
+    await page.waitForLoadState('networkidle');
+
+    const gigForm = page.locator('form[data-complete-form][data-is-bonus="1"]').first();
+    if ((await gigForm.count()) === 0) {
+      test.skip(true, 'No gig assignments seeded for demo child — skipping');
+      return;
+    }
+
+    // Submit triggers modal
+    await gigForm.locator('button[type="submit"]').click();
+    const modal = page.locator('#gig-proof-modal');
+    await expect(modal).toBeVisible();
+    await page.fill('#gig-proof-text', 'learned about rootless podman storage layout');
+    await page.locator('#gig-proof-form button[type="submit"]').click();
+    await page.waitForLoadState('networkidle');
+
+    // After redirect, the row should show "Awaiting approval" or live in the pending section
+    await expect(page.locator('text=Awaiting approval').first()).toBeVisible({ timeout: 5000 });
+
+    // ─── Parent path ───
+    await logout(page, context);
+    await login(page, PARENT);
+
+    await page.goto(`${BASE_URL}/parent/approvals`);
+    await page.waitForLoadState('networkidle');
+    await expect(page.locator('text=learned about rootless podman storage layout')).toBeVisible();
+
+    // Approve
+    const item = page
+      .locator('li[data-id]', { hasText: 'learned about rootless podman storage layout' })
+      .first();
+    await item.locator('button[data-action="approve"]').click();
+    await page.waitForLoadState('networkidle');
+
+    // Row should have been removed
+    await expect(
+      page.locator('text=learned about rootless podman storage layout')
+    ).not.toBeVisible();
+  });
+
+  test('child cannot complete a gig while a mandatory is pending today', async ({ page }) => {
+    await login(page, CHILD);
+    await page.goto(`${BASE_URL}/dashboard`);
+    await page.waitForLoadState('networkidle');
+
+    // If the dashboard shows the "bonus locked" state, the gig form should not be present
+    // (the existing dashboard hides complete buttons via bonusUnlocked). Verify either:
+    //   a) No bonus form exists, OR
+    //   b) The bonus form is present but is_locked badge visible.
+    const lockedBadges = page.locator('text=/locked/i');
+    const gigForms = page.locator('form[data-complete-form][data-is-bonus="1"]');
+    const lockedCount = await lockedBadges.count();
+    const gigCount = await gigForms.count();
+
+    if (lockedCount === 0 && gigCount === 0) {
+      test.skip(true, 'Seeded state has no pending mandatory + gigs — skipping');
+      return;
+    }
+
+    expect(lockedCount > 0 || gigCount === 0).toBeTruthy();
+  });
+});

--- a/frontend/src/pages/api/assignments/approve.ts
+++ b/frontend/src/pages/api/assignments/approve.ts
@@ -1,0 +1,67 @@
+import type { APIRoute } from "astro";
+
+/**
+ * POST /api/assignments/approve
+ * Body: { assignment_id: string, approve: boolean, notes?: string | null }
+ * Forwards to backend POST /api/task-assignments/{id}/approve
+ */
+export const POST: APIRoute = async ({ request, cookies }) => {
+    const token = cookies.get("access_token")?.value;
+    if (!token) {
+        return new Response(JSON.stringify({ detail: "Unauthorized" }), {
+            status: 401,
+            headers: { "Content-Type": "application/json" },
+        });
+    }
+
+    let body: any;
+    try {
+        body = await request.json();
+    } catch {
+        return new Response(JSON.stringify({ detail: "Invalid JSON" }), {
+            status: 400,
+            headers: { "Content-Type": "application/json" },
+        });
+    }
+
+    const assignmentId = body?.assignment_id;
+    if (!assignmentId || typeof assignmentId !== "string") {
+        return new Response(JSON.stringify({ detail: "assignment_id required" }), {
+            status: 400,
+            headers: { "Content-Type": "application/json" },
+        });
+    }
+
+    const apiUrl =
+        process.env.API_BASE_URL ||
+        process.env.PUBLIC_API_BASE_URL ||
+        "http://backend:8000";
+
+    try {
+        const r = await fetch(
+            `${apiUrl}/api/task-assignments/${assignmentId}/approve`,
+            {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: `Bearer ${token}`,
+                },
+                body: JSON.stringify({
+                    approve: Boolean(body.approve),
+                    notes: body.notes ?? null,
+                }),
+            }
+        );
+        const text = await r.text();
+        return new Response(text, {
+            status: r.status,
+            headers: { "Content-Type": "application/json" },
+        });
+    } catch (e) {
+        console.error("approve proxy error:", e);
+        return new Response(JSON.stringify({ detail: "Upstream error" }), {
+            status: 502,
+            headers: { "Content-Type": "application/json" },
+        });
+    }
+};

--- a/frontend/src/pages/api/assignments/complete.ts
+++ b/frontend/src/pages/api/assignments/complete.ts
@@ -14,6 +14,8 @@ export const POST: APIRoute = async ({ request, cookies, redirect }) => {
     try {
         const formData = await request.formData();
         const assignmentId = formData.get("assignment_id")?.toString();
+        const proofTextRaw = formData.get("proof_text")?.toString();
+        const proofText = proofTextRaw && proofTextRaw.trim().length > 0 ? proofTextRaw.trim() : null;
 
         if (!assignmentId) {
             const headers = new Headers({ Location: "/dashboard" });
@@ -21,13 +23,14 @@ export const POST: APIRoute = async ({ request, cookies, redirect }) => {
             return new Response(null, { status: 302, headers });
         }
 
-        const apiUrl = process.env.API_BASE_URL || process.env.PUBLIC_API_BASE_URL || "http://localhost:8002";
+        const apiUrl = process.env.API_BASE_URL || process.env.PUBLIC_API_BASE_URL || "http://backend:8000";
         const response = await fetch(`${apiUrl}/api/task-assignments/${assignmentId}/complete`, {
             method: "PATCH",
             headers: {
                 "Authorization": `Bearer ${token}`,
                 "Content-Type": "application/json",
             },
+            body: JSON.stringify({ proof_text: proofText }),
         });
 
         const headers = new Headers({ Location: "/dashboard" });

--- a/frontend/src/pages/api/assignments/pending-approvals.ts
+++ b/frontend/src/pages/api/assignments/pending-approvals.ts
@@ -1,0 +1,37 @@
+import type { APIRoute } from "astro";
+
+/**
+ * GET /api/assignments/pending-approvals
+ * Returns the parent-only queue of gigs awaiting approval.
+ * Proxies to backend with the caller's access_token cookie as Bearer auth.
+ */
+export const GET: APIRoute = async ({ cookies }) => {
+    const token = cookies.get("access_token")?.value;
+    if (!token) {
+        return new Response("[]", {
+            status: 401,
+            headers: { "Content-Type": "application/json" },
+        });
+    }
+    const apiUrl =
+        process.env.API_BASE_URL ||
+        process.env.PUBLIC_API_BASE_URL ||
+        "http://backend:8000";
+
+    try {
+        const r = await fetch(`${apiUrl}/api/task-assignments/pending-approvals`, {
+            headers: { Authorization: `Bearer ${token}` },
+        });
+        const body = await r.text();
+        return new Response(body, {
+            status: r.status,
+            headers: { "Content-Type": "application/json" },
+        });
+    } catch (e) {
+        console.error("pending-approvals proxy error:", e);
+        return new Response("[]", {
+            status: 502,
+            headers: { "Content-Type": "application/json" },
+        });
+    }
+};

--- a/frontend/src/pages/dashboard.astro
+++ b/frontend/src/pages/dashboard.astro
@@ -30,8 +30,16 @@ const bonusAssignments = assignments.filter((a: any) => a.template_is_bonus);
 
 const pendingRequired = requiredAssignments.filter((a: any) => a.status === "pending");
 const completedRequired = requiredAssignments.filter((a: any) => a.status === "completed");
+// Gigs that are completed but awaiting/already had parent decision live in
+// the "pending" bucket from a UI point of view (the assignment row is COMPLETED
+// but approval_status drives the badge). Keep "completed" as the final state.
 const pendingBonus = bonusAssignments.filter((a: any) => a.status === "pending");
-const completedBonus = bonusAssignments.filter((a: any) => a.status === "completed");
+const awaitingApprovalBonus = bonusAssignments.filter(
+    (a: any) => a.status === "completed" && a.approval_status === "pending"
+);
+const completedBonus = bonusAssignments.filter(
+    (a: any) => a.status === "completed" && a.approval_status !== "pending"
+);
 
 const allDone = requiredCompleted >= requiredTotal && bonusCompleted >= bonusTotal && (requiredTotal + bonusTotal) > 0;
 const noTasks = requiredTotal === 0 && bonusTotal === 0;
@@ -166,7 +174,7 @@ if (flashError) Astro.cookies.delete("flash_error", { path: "/" });
                                     </div>
                                 </div>
                                 {a.can_complete && (
-                                    <form method="POST" action="/api/assignments/complete">
+                                    <form method="POST" action="/api/assignments/complete" data-complete-form data-is-bonus="0">
                                         <input type="hidden" name="assignment_id" value={a.id} />
                                         <button
                                             type="submit"
@@ -264,8 +272,9 @@ if (flashError) Astro.cookies.delete("flash_error", { path: "/" });
                                             </div>
                                         </div>
                                         {a.can_complete && (
-                                            <form method="POST" action="/api/assignments/complete">
+                                            <form method="POST" action="/api/assignments/complete" data-complete-form data-is-bonus="1">
                                                 <input type="hidden" name="assignment_id" value={a.id} />
+                                                <input type="hidden" name="proof_text" value="" />
                                                 <button
                                                     type="submit"
                                                     class="h-12 w-12 rounded-full bg-brand-sun/20 text-brand-sun-deep flex items-center justify-center hover:bg-brand-sun-deep hover:text-white transition-colors active:scale-95 flex-shrink-0 shadow-[var(--shadow-card)]"
@@ -280,6 +289,35 @@ if (flashError) Astro.cookies.delete("flash_error", { path: "/" });
                                 ))}
                             </div>
 
+                            <!-- Gigs awaiting parent approval -->
+                            {awaitingApprovalBonus.length > 0 && (
+                                <div class="mt-4 space-y-2">
+                                    <p class="text-xs font-semibold text-brand-ink-soft uppercase tracking-wider px-1">
+                                        {lang === "es" ? "Pendiente de aprobación" : "Awaiting approval"}
+                                    </p>
+                                    {awaitingApprovalBonus.map((a: any) => (
+                                        <div class="bg-brand-cream/80 rounded-2xl px-5 py-3 border border-brand-sun flex items-center gap-4">
+                                            <div class="h-8 w-8 rounded-full bg-brand-sun/20 flex items-center justify-center flex-shrink-0">
+                                                <svg class="h-4 w-4 text-brand-sun-deep" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                                </svg>
+                                            </div>
+                                            <div class="flex-1 min-w-0">
+                                                <p class="font-medium text-brand-ink truncate">
+                                                    {lang === "es" && a.template_title_es ? a.template_title_es : a.template_title}
+                                                </p>
+                                                <p class="text-xs text-brand-ink-soft">
+                                                    {lang === "es" ? "Un padre la revisará pronto" : "A parent will review soon"} · +{a.template_points} pts
+                                                </p>
+                                            </div>
+                                            <span class="text-[10px] font-semibold uppercase tracking-wider px-2 py-0.5 rounded-full bg-brand-sun/20 text-brand-sun-deep">
+                                                {lang === "es" ? "Pendiente" : "Pending"}
+                                            </span>
+                                        </div>
+                                    ))}
+                                </div>
+                            )}
+
                             <!-- Completed bonus tasks -->
                             {completedBonus.length > 0 && (
                                 <details class="mt-3 group">
@@ -290,21 +328,45 @@ if (flashError) Astro.cookies.delete("flash_error", { path: "/" });
                                         </span>
                                     </summary>
                                     <div class="space-y-2">
-                                        {completedBonus.map((a: any) => (
-                                            <div class="bg-brand-cream/60 rounded-2xl px-5 py-3 border border-brand-sun flex items-center gap-4 opacity-70">
-                                                <div class="h-8 w-8 rounded-full bg-brand-mint/20 flex items-center justify-center flex-shrink-0">
-                                                    <svg class="h-4 w-4 text-brand-mint-deep" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
-                                                    </svg>
+                                        {completedBonus.map((a: any) => {
+                                            const rejected = a.approval_status === "rejected";
+                                            return (
+                                                <div class:list={[
+                                                    "rounded-2xl px-5 py-3 border flex items-center gap-4 opacity-80",
+                                                    rejected
+                                                        ? "bg-red-50 border-red-200"
+                                                        : "bg-brand-cream/60 border-brand-sun",
+                                                ]}>
+                                                    <div class:list={[
+                                                        "h-8 w-8 rounded-full flex items-center justify-center flex-shrink-0",
+                                                        rejected ? "bg-red-100" : "bg-brand-mint/20",
+                                                    ]}>
+                                                        {rejected ? (
+                                                            <svg class="h-4 w-4 text-red-700" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                                                            </svg>
+                                                        ) : (
+                                                            <svg class="h-4 w-4 text-brand-mint-deep" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+                                                            </svg>
+                                                        )}
+                                                    </div>
+                                                    <div class="flex-1 min-w-0">
+                                                        <p class:list={[
+                                                            "font-medium truncate",
+                                                            rejected ? "text-red-700" : "text-brand-ink-soft line-through",
+                                                        ]}>
+                                                            {lang === "es" && a.template_title_es ? a.template_title_es : a.template_title}
+                                                        </p>
+                                                        <p class="text-xs text-brand-ink-soft">
+                                                            {rejected
+                                                                ? (lang === "es" ? "Rechazada" : "Rejected")
+                                                                : t(lang, "dashboard_earned")(a.template_points)}
+                                                        </p>
+                                                    </div>
                                                 </div>
-                                                <div>
-                                                    <p class="font-medium text-brand-ink-soft line-through">
-                                                        {lang === "es" && a.template_title_es ? a.template_title_es : a.template_title}
-                                                    </p>
-                                                    <p class="text-xs text-brand-ink-soft">{t(lang, "dashboard_earned")(a.template_points)}</p>
-                                                </div>
-                                            </div>
-                                        ))}
+                                            );
+                                        })}
                                     </div>
                                 </details>
                             )}
@@ -316,4 +378,98 @@ if (flashError) Astro.cookies.delete("flash_error", { path: "/" });
 
         <BottomNav active="tasks" role={user.role} lang={lang} />
     </div>
+
+    <!-- Gig proof-of-work modal (only triggered for bonus tasks) -->
+    <dialog id="gig-proof-modal" class="rounded-2xl p-0 backdrop:bg-black/40 max-w-md w-full md:w-[28rem] border-2 border-brand-ink shadow-[var(--shadow-pop)] bg-brand-cream">
+        <div class="p-5 space-y-3">
+            <div>
+                <p class="text-xs font-medium text-brand-sun-deep uppercase tracking-wider">{t(lang, "dashboard_bonus_badge")}</p>
+                <h3 class="text-lg font-bold text-brand-ink">
+                    {lang === "es" ? "Cuéntanos qué hiciste" : "Tell us what you did"}
+                </h3>
+                <p class="text-sm text-brand-ink-soft mt-1">
+                    {lang === "es"
+                        ? "Un padre revisará esto y aprobará los puntos."
+                        : "A parent will review this and approve the points."}
+                </p>
+            </div>
+            <textarea
+                id="gig-proof-text"
+                rows="5"
+                class="w-full border border-brand-ink/20 rounded-lg p-3 bg-brand-cream text-sm focus:ring-2 focus:ring-sky-500 outline-none"
+                placeholder={lang === "es"
+                    ? "¿Qué aprendiste / hiciste / lograste?"
+                    : "What did you learn / make / accomplish?"}
+            ></textarea>
+            <div class="flex justify-end gap-2 pt-1">
+                <button type="button" id="gig-proof-cancel" class="px-4 py-2 rounded-lg bg-brand-cream-deep text-brand-ink font-semibold text-sm">
+                    {lang === "es" ? "Cancelar" : "Cancel"}
+                </button>
+                <button type="button" id="gig-proof-submit" class="px-4 py-2 rounded-lg bg-brand-sun-deep text-white font-semibold text-sm shadow-[var(--shadow-card)]">
+                    {lang === "es" ? "Enviar para aprobación" : "Submit for approval"}
+                </button>
+            </div>
+        </div>
+    </dialog>
+
+    <script>
+        document.addEventListener("astro:page-load", () => {
+            const modal = document.getElementById("gig-proof-modal") as HTMLDialogElement | null;
+            if (!modal) return;
+            const textarea = document.getElementById("gig-proof-text") as HTMLTextAreaElement | null;
+            const cancelBtn = document.getElementById("gig-proof-cancel");
+            const submitBtn = document.getElementById("gig-proof-submit");
+            if (!textarea || !cancelBtn || !submitBtn) return;
+
+            // Track which form opened the modal so we can submit it on confirm.
+            let pendingForm: HTMLFormElement | null = null;
+
+            document.querySelectorAll<HTMLFormElement>("form[data-complete-form]").forEach((f) => {
+                f.addEventListener("submit", (ev) => {
+                    const isBonus = f.dataset.isBonus === "1";
+                    if (!isBonus) return; // mandatory: submit normally (no proof needed)
+                    ev.preventDefault();
+                    pendingForm = f;
+                    textarea.value = "";
+                    modal.showModal();
+                    setTimeout(() => textarea.focus(), 50);
+                });
+            });
+
+            cancelBtn.addEventListener("click", () => {
+                pendingForm = null;
+                modal.close();
+            });
+
+            submitBtn.addEventListener("click", () => {
+                const text = textarea.value.trim();
+                if (!text) {
+                    textarea.focus();
+                    textarea.classList.add("ring-2", "ring-red-400");
+                    setTimeout(() => textarea.classList.remove("ring-2", "ring-red-400"), 1500);
+                    return;
+                }
+                if (!pendingForm) {
+                    modal.close();
+                    return;
+                }
+                const proofInput = pendingForm.querySelector<HTMLInputElement>('input[name="proof_text"]');
+                if (proofInput) proofInput.value = text;
+                const submittingForm = pendingForm;
+                pendingForm = null;
+                modal.close();
+                // submit() bypasses our submit listener, avoiding a re-trigger of the modal.
+                submittingForm.submit();
+            });
+
+            // Close on backdrop click
+            modal.addEventListener("click", (e) => {
+                const rect = (e.target as HTMLDialogElement).getBoundingClientRect?.();
+                if (e.target === modal) {
+                    pendingForm = null;
+                    modal.close();
+                }
+            });
+        });
+    </script>
 </Layout>

--- a/frontend/src/pages/parent/approvals.astro
+++ b/frontend/src/pages/parent/approvals.astro
@@ -1,0 +1,163 @@
+---
+import Layout from "../../layouts/Layout.astro";
+import BottomNav from "../../components/BottomNav.astro";
+import { apiFetch } from "../../lib/api";
+import { t } from "../../lib/i18n";
+
+const token = Astro.cookies.get("access_token")?.value;
+if (!token) return Astro.redirect("/login");
+const lang = Astro.cookies.get("lang")?.value ?? "en";
+
+const { data: user } = await apiFetch<any>("/api/auth/me", { token });
+if (!user) {
+    Astro.cookies.delete("access_token", { path: "/" });
+    return Astro.redirect("/login");
+}
+if (user.role !== "parent") return Astro.redirect("/dashboard");
+
+const { data: rows } = await apiFetch<any[]>(
+    "/api/task-assignments/pending-approvals",
+    { token }
+);
+const items: any[] = rows ?? [];
+
+const flash = Astro.cookies.get("flash")?.value;
+if (flash) Astro.cookies.delete("flash", { path: "/" });
+---
+
+<Layout title={`${lang === "es" ? "Aprobaciones" : "Approvals"} - Family Task Manager`}>
+    <div class="w-full max-w-md md:max-w-4xl lg:max-w-6xl mx-auto bg-brand-cream-deep flex flex-col">
+        <header class="bg-gradient-to-br from-amber-700 to-amber-600 text-white pt-12 pb-6 px-6 rounded-b-[var(--radius-tile)] shadow-[var(--shadow-card)]">
+            <div class="flex items-center gap-3 mb-4">
+                <a href="/parent" class="text-amber-100 hover:text-white transition-colors">
+                    <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+                    </svg>
+                </a>
+                <span class="text-amber-100 text-sm">{t(lang, "back_parent")}</span>
+            </div>
+            <h1 class="text-2xl font-bold">
+                {lang === "es" ? "Aprobaciones de gigs" : "Gig approvals"}
+            </h1>
+            <p class="text-amber-100 text-sm mt-1">
+                {lang === "es"
+                    ? "Revisa el trabajo enviado y aprueba o rechaza."
+                    : "Review submitted work and approve or reject."}
+            </p>
+        </header>
+
+        <main class="flex-1 px-4 py-6">
+            {items.length === 0 ? (
+                <div class="bg-brand-cream rounded-2xl p-8 text-center border border-brand-ink/10 shadow-[var(--shadow-card)]">
+                    <div class="w-16 h-16 bg-brand-mint/20 rounded-full flex items-center justify-center mx-auto mb-4">
+                        <svg class="w-8 h-8 text-brand-mint-deep" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+                        </svg>
+                    </div>
+                    <p class="text-brand-ink-soft text-sm">
+                        {lang === "es" ? "Nada por aprobar." : "Nothing waiting for approval."}
+                    </p>
+                </div>
+            ) : (
+                <ul class="space-y-3" id="approvals-list">
+                    {items.map((row: any) => (
+                        <li
+                            class="bg-brand-cream rounded-2xl p-5 border border-brand-ink/10 shadow-[var(--shadow-card)]"
+                            data-id={row.assignment_id}
+                        >
+                            <div class="flex justify-between items-start mb-3 gap-3">
+                                <div class="min-w-0">
+                                    <h3 class="font-bold text-brand-ink truncate">
+                                        {row.template_title}
+                                    </h3>
+                                    <p class="text-sm text-brand-ink-soft mt-0.5">
+                                        {row.assigned_to_name}
+                                        <span class="mx-1">·</span>
+                                        <span class="text-brand-sun-deep font-semibold">+{row.points} pts</span>
+                                    </p>
+                                </div>
+                                <span class="text-xs text-brand-ink-soft whitespace-nowrap">
+                                    {new Date(row.completed_at).toLocaleString(lang === "es" ? "es-MX" : "en-US", {
+                                        month: "short",
+                                        day: "numeric",
+                                        hour: "2-digit",
+                                        minute: "2-digit",
+                                    })}
+                                </span>
+                            </div>
+                            <p class="text-sm bg-brand-cream-deep rounded-lg p-3 mb-3 whitespace-pre-wrap text-brand-ink">
+                                {row.proof_text || (lang === "es" ? "(sin texto)" : "(no proof text)")}
+                            </p>
+                            <textarea
+                                data-notes
+                                rows="2"
+                                class="w-full border border-brand-ink/20 rounded-lg p-2 mb-3 text-sm focus:ring-2 focus:ring-amber-500 outline-none bg-brand-cream"
+                                placeholder={lang === "es" ? "Notas (opcional)" : "Notes (optional)"}
+                            ></textarea>
+                            <div class="flex justify-end gap-2">
+                                <button
+                                    type="button"
+                                    data-action="reject"
+                                    class="px-4 py-2 rounded-lg border border-red-300 text-red-700 font-semibold text-sm hover:bg-red-50 transition-colors"
+                                >
+                                    {lang === "es" ? "Rechazar" : "Reject"}
+                                </button>
+                                <button
+                                    type="button"
+                                    data-action="approve"
+                                    class="px-4 py-2 rounded-lg bg-brand-mint-deep text-white font-semibold text-sm shadow-[var(--shadow-card)] hover:opacity-90 transition-opacity"
+                                >
+                                    {lang === "es" ? "Aprobar" : "Approve"}
+                                </button>
+                            </div>
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </main>
+
+        <BottomNav active="parent" role={user.role} lang={lang} />
+    </div>
+
+    <script>
+        document.addEventListener("astro:page-load", () => {
+            const list = document.getElementById("approvals-list");
+            if (!list) return;
+            list.querySelectorAll<HTMLLIElement>("li[data-id]").forEach((li) => {
+                const id = li.dataset.id!;
+                const notes = li.querySelector<HTMLTextAreaElement>("[data-notes]");
+                li.querySelectorAll<HTMLButtonElement>("button[data-action]").forEach((btn) => {
+                    btn.addEventListener("click", async () => {
+                        const approve = btn.dataset.action === "approve";
+                        btn.disabled = true;
+                        try {
+                            const r = await fetch("/api/assignments/approve", {
+                                method: "POST",
+                                headers: { "Content-Type": "application/json" },
+                                body: JSON.stringify({
+                                    assignment_id: id,
+                                    approve,
+                                    notes: notes?.value.trim() || null,
+                                }),
+                            });
+                            if (r.ok) {
+                                li.remove();
+                                // If list is now empty, reload to show the empty state.
+                                if (list.children.length === 0) {
+                                    window.location.reload();
+                                }
+                            } else {
+                                const err = await r.text();
+                                alert(`Error: ${err}`);
+                                btn.disabled = false;
+                            }
+                        } catch (e) {
+                            alert(`Error: ${(e as Error).message}`);
+                            btn.disabled = false;
+                        }
+                    });
+                });
+            });
+        });
+    </script>
+</Layout>

--- a/frontend/src/pages/parent/assignments.astro
+++ b/frontend/src/pages/parent/assignments.astro
@@ -320,6 +320,15 @@ function isToday(d: Date): boolean {
                                                                 <path stroke-linecap="round" stroke-linejoin="round" d={statusIcon} />
                                                             </svg>
                                                         )}
+                                                        {task.is_locked && (
+                                                            <span class="text-[10px] flex-shrink-0" title={lang === "es" ? "Bloqueada" : "Locked"}>🔒</span>
+                                                        )}
+                                                        {task.approval_status === "pending" && (
+                                                            <span class="text-[10px] flex-shrink-0" title={lang === "es" ? "Por aprobar" : "Awaiting approval"}>⏳</span>
+                                                        )}
+                                                        {task.approval_status === "rejected" && (
+                                                            <span class="text-[10px] flex-shrink-0" title={lang === "es" ? "Rechazada" : "Rejected"}>✕</span>
+                                                        )}
                                                         <span class="truncate text-[10px] leading-tight">
                                                             {displayTitle.length > 6
                                                                 ? displayTitle.slice(0, 6) + ".."
@@ -386,10 +395,31 @@ function isToday(d: Date): boolean {
                                                             data-points={task.template_points}
                                                             data-is-bonus={task.template_is_bonus ? "1" : "0"}
                                                         >
-                                                            <span class="text-sm font-medium truncate">
-                                                                {displayTitle}
+                                                            <span class="text-sm font-medium truncate flex items-center gap-1.5 flex-wrap">
+                                                                <span class="truncate">{displayTitle}</span>
                                                                 {task.template_is_bonus && (
-                                                                    <span class="ml-1.5 text-[10px] font-semibold uppercase tracking-wide text-brand-sun-deep">{t(lang, "dashboard_bonus_badge")}</span>
+                                                                    <span class="text-[10px] font-semibold uppercase tracking-wide text-brand-sun-deep">{t(lang, "dashboard_bonus_badge")}</span>
+                                                                )}
+                                                                {task.is_locked && (
+                                                                    <span class="inline-flex items-center gap-0.5 px-1.5 py-0.5 text-[10px] rounded bg-amber-100 text-amber-800" title={lang === "es" ? "Termina las tareas obligatorias para desbloquear" : "Finish required tasks to unlock"}>
+                                                                        <svg class="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" /></svg>
+                                                                        {lang === "es" ? "Bloqueada" : "Locked"}
+                                                                    </span>
+                                                                )}
+                                                                {task.approval_status === "pending" && (
+                                                                    <span class="px-1.5 py-0.5 text-[10px] rounded bg-amber-100 text-amber-800">
+                                                                        {lang === "es" ? "Por aprobar" : "Awaiting"}
+                                                                    </span>
+                                                                )}
+                                                                {task.approval_status === "approved" && (
+                                                                    <span class="px-1.5 py-0.5 text-[10px] rounded bg-green-100 text-green-800">
+                                                                        {lang === "es" ? "Aprobada" : "Approved"}
+                                                                    </span>
+                                                                )}
+                                                                {task.approval_status === "rejected" && (
+                                                                    <span class="px-1.5 py-0.5 text-[10px] rounded bg-red-100 text-red-800">
+                                                                        {lang === "es" ? "Rechazada" : "Rejected"}
+                                                                    </span>
                                                                 )}
                                                             </span>
                                                             <span class="text-xs font-semibold whitespace-nowrap">+{task.template_points}</span>

--- a/frontend/src/pages/parent/index.astro
+++ b/frontend/src/pages/parent/index.astro
@@ -16,6 +16,13 @@ if (!user) {
 if (user.role !== "parent") return Astro.redirect("/dashboard");
 
 const { data: family } = await apiFetch<any>("/api/families/me", { token });
+
+// Pending gig approvals count for the badge on the Approvals tile.
+const { data: pending } = await apiFetch<any[]>(
+    "/api/task-assignments/pending-approvals",
+    { token }
+);
+const pendingApprovals = Array.isArray(pending) ? pending.length : 0;
 ---
 
 <Layout title={`${t(lang, "parent_dashboard")} - Family Task Manager`}>
@@ -151,6 +158,29 @@ const { data: family } = await apiFetch<any>("/api/families/me", { token });
                         </p>
                         <p class="text-xs text-brand-ink-soft">
                             {t(lang, "parent_consequences_desc")}
+                        </p>
+                    </div>
+                </a>
+                <a
+                    href="/parent/approvals"
+                    class="relative bg-brand-cream rounded-2xl p-5 shadow-[var(--shadow-card)] border border-brand-ink/10 hover:shadow-[var(--shadow-card)] hover:border-amber-200 transition-all flex flex-col items-center text-center gap-3"
+                >
+                    {pendingApprovals > 0 && (
+                        <span class="absolute top-2 right-2 min-w-[1.25rem] h-5 px-1.5 rounded-full bg-red-600 text-white text-[10px] font-bold flex items-center justify-center shadow-sm">
+                            {pendingApprovals > 9 ? "9+" : pendingApprovals}
+                        </span>
+                    )}
+                    <div class="w-12 h-12 rounded-xl bg-amber-50 flex items-center justify-center">
+                        <svg class="h-6 w-6 text-amber-700" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+                        </svg>
+                    </div>
+                    <div>
+                        <p class="font-bold text-brand-ink">
+                            {lang === "es" ? "Aprobaciones" : "Approvals"}
+                        </p>
+                        <p class="text-xs text-brand-ink-soft">
+                            {lang === "es" ? "Revisar gigs pendientes" : "Review pending gigs"}
                         </p>
                     </div>
                 </a>


### PR DESCRIPTION
## Summary
- Mandatory tasks (`is_bonus=false`) now award **zero points** and complete silently (no `point_transaction` row).
- Gigs (`is_bonus=true`) are gated by today's mandatory completion, require a text proof, and enter a `PENDING` approval state. Points are credited only when a parent approves via the new `/parent/approvals` page (new `GIG_APPROVED` transaction type).
- Adds `families.timezone` (`varchar(64) DEFAULT 'UTC'`) so gating uses the family's local "today".
- Adds a default 6-gig starter pack — seeded per existing family by the migration and per new family by `FamilyService._seed_default_gigs`.

Spec: `docs/superpowers/specs/2026-05-22-mandatory-vs-gigs-design.md`
Plan: `docs/superpowers/plans/2026-05-22-mandatory-vs-gigs.md`

## Migration safety
- New CHECK constraint `chk_mandatory_zero_points`. Migration force-zeroes any existing non-bonus templates' `points`. **Take a `pg_dump` before running in prod** — any non-zero mandatory point values are wiped.
- Seed step is idempotent (skips titles already present per family).
- `approval_status` column has `server_default 'none'` for back-fill safety.
- `transactiontype` enum gains `'GIG_APPROVED'` (uppercase to match existing SQLAlchemy NAME convention).

## Test plan
- [ ] Backend: `podman exec -e PYTHONPATH=/app family_app_backend pytest tests/test_gig_gating.py tests/test_gig_approval.py tests/test_migration_mandatory_zero.py tests/test_task_assignment_service.py -v` — currently 39 pass, 1 xpass.
- [ ] Apply migration on staging: `alembic upgrade head` → verify `families.timezone`, new approval columns, CHECK constraint, default gigs.
- [ ] Manual: child logs in, sees lock badge on gigs while a mandatory is pending, completes mandatory, submits gig with proof, parent approves on `/parent/approvals`, child's balance increases.
- [ ] Fix and run e2e: `cd e2e-tests && npx playwright test gigs.spec.js` (test currently skips gracefully without seeded child + gig combination).

## Follow-ups
- Wire `_user_local_today` into the live `/today`, `/progress`, `/week`, overdue sweep (column is in place, helper exists, but routes still use server `date.today()`).
- Schema-level validation for "mandatory points must be 0" so API hits return 422 instead of DB IntegrityError 500.
- Lift `DEFAULT_GIGS` to a shared seed module (currently duplicated in migration + `FamilyService` by design for migration self-containment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)