### PR TITLE
Post-deploy gap fixes: tz-aware overdue sweep + datetime cleanup

### DIFF
--- a/backend/app/services/task_assignment_service.py
+++ b/backend/app/services/task_assignment_service.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, and_, func, delete as sql_delete
 from sqlalchemy.orm import selectinload
 from typing import List, Optional
-from datetime import datetime, date, timedelta
+from datetime import datetime, date, timedelta, timezone
 from uuid import UUID
 
 from app.models.task_template import TaskTemplate, AssignmentType
@@ -630,13 +630,13 @@ class TaskAssignmentService(BaseFamilyService[TaskAssignment]):
                 raise ValidationException("Gigs require proof text describing what you did")
 
             assignment.status = AssignmentStatus.COMPLETED
-            assignment.completed_at = datetime.utcnow()
+            assignment.completed_at = datetime.now(timezone.utc)
             assignment.approval_status = ApprovalStatus.PENDING
             assignment.proof_text = proof_text.strip()
         else:
             # Mandatory path — silent, no points, no approval
             assignment.status = AssignmentStatus.COMPLETED
-            assignment.completed_at = datetime.utcnow()
+            assignment.completed_at = datetime.now(timezone.utc)
             # approval_status stays NONE; no PointTransaction row
 
         await db.commit()
@@ -669,7 +669,7 @@ class TaskAssignmentService(BaseFamilyService[TaskAssignment]):
             )
 
         assignment.approved_by = parent_id
-        assignment.approved_at = datetime.utcnow()
+        assignment.approved_at = datetime.now(timezone.utc)
         assignment.approval_notes = notes
 
         if approve:
@@ -841,11 +841,24 @@ class TaskAssignmentService(BaseFamilyService[TaskAssignment]):
     # ─── Overdue Check ───────────────────────────────────────────────
 
     @staticmethod
+    async def _family_local_today(db: AsyncSession, family_id: UUID) -> date:
+        """Today's date in the family's timezone (fallback UTC)."""
+        from zoneinfo import ZoneInfo
+        from app.models.family import Family
+        family = await db.get(Family, family_id)
+        tz_name = (family.timezone if family and family.timezone else None) or "UTC"
+        try:
+            tz = ZoneInfo(tz_name)
+        except Exception:
+            tz = ZoneInfo("UTC")
+        return datetime.now(tz).date()
+
+    @staticmethod
     async def check_overdue_assignments(
         db: AsyncSession, family_id: UUID
     ) -> List[TaskAssignment]:
-        """Check for overdue assignments and update their status"""
-        today = date.today()
+        """Check for overdue assignments and update their status (family-tz aware)."""
+        today = await TaskAssignmentService._family_local_today(db, family_id)
 
         query = select(TaskAssignment).where(
             and_(
@@ -869,21 +882,29 @@ class TaskAssignmentService(BaseFamilyService[TaskAssignment]):
     async def mark_overdue_all(db: AsyncSession) -> int:
         """
         Sweep across ALL families: flip PENDING rows with assigned_date < today
-        to OVERDUE. Returns row count. Intended for the background scheduler.
+        to OVERDUE, where "today" is each family's local date. Intended for the
+        background scheduler.
         """
-        today = date.today()
         from sqlalchemy import update as sql_update
+        from app.models.family import Family
 
-        stmt = (
-            sql_update(TaskAssignment)
-            .where(
-                and_(
-                    TaskAssignment.status == AssignmentStatus.PENDING,
-                    TaskAssignment.assigned_date < today,
+        family_rows = (await db.execute(select(Family.id))).scalars().all()
+        now_utc = datetime.now(timezone.utc)
+        total = 0
+        for family_id in family_rows:
+            today = await TaskAssignmentService._family_local_today(db, family_id)
+            stmt = (
+                sql_update(TaskAssignment)
+                .where(
+                    and_(
+                        TaskAssignment.family_id == family_id,
+                        TaskAssignment.status == AssignmentStatus.PENDING,
+                        TaskAssignment.assigned_date < today,
+                    )
                 )
+                .values(status=AssignmentStatus.OVERDUE, updated_at=now_utc)
             )
-            .values(status=AssignmentStatus.OVERDUE, updated_at=datetime.utcnow())
-        )
-        result = await db.execute(stmt)
+            result = await db.execute(stmt)
+            total += result.rowcount or 0
         await db.commit()
-        return result.rowcount or 0
+        return total

--- a/backend/tests/test_task_assignment_service.py
+++ b/backend/tests/test_task_assignment_service.py
@@ -330,52 +330,10 @@ class TestCompletion:
 
 
 class TestBonusGating:
-    async def test_bonus_blocked_when_required_incomplete(
-        self, db_session, test_family, test_parent_user, test_child_user
-    ):
-        # Create a regular daily + bonus daily
-        await _create_template(
-            db_session, test_family.id, test_parent_user.id,
-            title="Required", interval_days=7, is_bonus=False
-        )
-        await _create_template(
-            db_session, test_family.id, test_parent_user.id,
-            title="Bonus", interval_days=7, is_bonus=True
-        )
-        assignments = await TaskAssignmentService.shuffle_tasks(
-            db_session, test_family.id
-        )
-
-        # Find the bonus assignment for the child
-        bonus_assignments = [
-            a for a in assignments
-            if a.assigned_to == test_child_user.id
-        ]
-        # Find bonus assignment
-        bonus_a = None
-        for a in bonus_assignments:
-            await db_session.refresh(a)
-            tmpl = await TaskTemplateService.get_template(
-                db_session, a.template_id, test_family.id
-            )
-            if tmpl.is_bonus:
-                bonus_a = a
-                break
-
-        if bonus_a:
-            # Check if there are required assignments for the child on the same date
-            required_for_child = [
-                a for a in assignments
-                if a.assigned_to == test_child_user.id
-                and a.id != bonus_a.id
-            ]
-
-            if required_for_child:
-                # Try to complete bonus without completing required first
-                with pytest.raises(ForbiddenException):
-                    await TaskAssignmentService.complete_assignment(
-                        db_session, bonus_a.id, test_family.id, test_child_user.id
-                    )
+    # NOTE: deterministic "gig locked while mandatory pending" assertion lives in
+    # tests/test_gig_gating.py::test_gig_locked_when_mandatory_pending. The
+    # shuffle-based legacy version of that test was non-deterministic (load
+    # balancing could put all required tasks on the parent) and was removed.
 
     async def test_bonus_allowed_when_all_required_done(
         self, db_session, test_family, test_parent_user, test_child_user


### PR DESCRIPTION
## Summary
Follow-ups identified in #9's post-merge review.

- **Overdue sweep timezone-aware.** `check_overdue_assignments` + `mark_overdue_all` were still using server `date.today()` (UTC). Added `_family_local_today` helper and made the global sweep loop per-family so each tenant's "today" is correct.
- **datetime.utcnow → datetime.now(timezone.utc)** at the 4 new call sites in `task_assignment_service.py` (silences Python 3.13 deprecation; tz-aware datetimes match the `DateTime(timezone=True)` columns).
- **Removed brittle legacy gating test.** `TestBonusGating::test_bonus_blocked_when_required_incomplete` depended on `shuffle_tasks` putting at least one required task on the child, which the load balancer could legitimately skip. The deterministic equivalent lives in `test_gig_gating.py::test_gig_locked_when_mandatory_pending`.

## Test plan
- Backend: 39 pass, 1 xpass across gig_gating + gig_approval + migration_mandatory_zero + task_assignment_service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)