### PR TITLE
Mandatory-vs-gigs scope-change follow-ups: banner, timezone UI, carry-over gating

### DIFF
--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -239,6 +239,19 @@ async def update_current_user_profile(
     return user
 
 
+@router.post("/ack-gigs-intro", response_model=UserResponse)
+async def ack_gigs_intro(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Permanently dismiss the mandatory=0 / gigs=points intro banner."""
+    if not current_user.acknowledged_gigs_intro:
+        current_user.acknowledged_gigs_intro = True
+        await db.commit()
+        await db.refresh(current_user)
+    return current_user
+
+
 @router.put("/password", response_model=UserResponse)
 async def update_password(
     password_data: UserPasswordUpdate,

--- a/backend/app/api/routes/families.py
+++ b/backend/app/api/routes/families.py
@@ -70,9 +70,11 @@ async def get_family(
 async def update_family(
     family_data: FamilyUpdate,
     family_id: UUID = Depends(verify_family_id),
+    current_user: User = Depends(require_parent_role),
     db: AsyncSession = Depends(get_db),
 ):
-    """Update family information"""
+    """Update family information (parent only — non-parents can shift
+    family-wide settings like timezone otherwise, bypassing gig gating)."""
     family = await FamilyService.update_family(db, family_id, family_data)
     return family
 

--- a/backend/app/api/routes/families.py
+++ b/backend/app/api/routes/families.py
@@ -77,6 +77,19 @@ async def update_family(
     return family
 
 
+@router.patch("/me", response_model=FamilyResponse)
+async def update_my_family(
+    family_data: FamilyUpdate,
+    current_user: User = Depends(require_parent_role),
+    db: AsyncSession = Depends(get_db),
+):
+    """Parent-only update of the caller's own family (name, timezone, etc.)."""
+    family = await FamilyService.update_family(
+        db, to_uuid_required(current_user.family_id), family_data
+    )
+    return family
+
+
 @router.get("/{family_id}/members", response_model=List[UserResponse])
 async def get_family_members(
     family_id: UUID = Depends(verify_family_id),

--- a/backend/app/api/routes/task_assignments.py
+++ b/backend/app/api/routes/task_assignments.py
@@ -111,10 +111,9 @@ async def list_week_assignments(
         if is_bonus and a.assigned_date == today and a.status != AssignmentStatus.COMPLETED:
             key = (a.assigned_to, a.assigned_date)
             if key not in lock_cache:
-                all_done = await TaskAssignmentService.check_all_required_done_today(
+                lock_cache[key] = await TaskAssignmentService.has_open_mandatory_through(
                     db, a.assigned_to, family_id, a.assigned_date
                 )
-                lock_cache[key] = not all_done
             a._is_locked = lock_cache[key]
         else:
             a._is_locked = False
@@ -147,10 +146,9 @@ async def list_today_assignments(
         if is_bonus and a.status != AssignmentStatus.COMPLETED:
             key = (a.assigned_to, a.assigned_date)
             if key not in lock_cache:
-                all_done = await TaskAssignmentService.check_all_required_done_today(
+                lock_cache[key] = await TaskAssignmentService.has_open_mandatory_through(
                     db, a.assigned_to, family_id, a.assigned_date
                 )
-                lock_cache[key] = not all_done
             a._is_locked = lock_cache[key]
         else:
             a._is_locked = False

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -27,7 +27,7 @@ class Settings(BaseSettings):
     # Security
     SECRET_KEY: str = "your-secret-key-change-this-in-production"
     ALGORITHM: str = "HS256"
-    ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = 10080  # 7 days
     
     # Google OAuth
     # GOOGLE_CLIENT_ID is the primary Web client (legacy single-value field,

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -42,6 +42,10 @@ class User(Base):
         Boolean, default=False, nullable=False, server_default="false"
     )
 
+    acknowledged_gigs_intro = Column(
+        Boolean, default=False, nullable=False, server_default="false"
+    )
+
     oauth_provider = Column(String(50), nullable=True)
     oauth_id = Column(String(255), nullable=True)
     

--- a/backend/app/schemas/family.py
+++ b/backend/app/schemas/family.py
@@ -4,12 +4,24 @@ Family Pydantic schemas
 Request and response models for family-related operations.
 """
 
-from pydantic import BaseModel, Field
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from pydantic import BaseModel, Field, field_validator
 from typing import Optional, List
 from uuid import UUID
 
 from app.schemas.user import UserResponse
 from app.schemas.base import EntityResponse
+
+
+def _validate_iana_tz(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return value
+    try:
+        ZoneInfo(value)
+    except ZoneInfoNotFoundError as exc:
+        raise ValueError(f"Unknown IANA timezone: {value}") from exc
+    return value
 
 
 # Base schemas
@@ -31,6 +43,12 @@ class FamilyUpdate(BaseModel):
 
     name: Optional[str] = Field(None, min_length=1, max_length=100)
     is_active: Optional[bool] = None
+    timezone: Optional[str] = Field(None, max_length=64)
+
+    @field_validator("timezone")
+    @classmethod
+    def _check_tz(cls, v: Optional[str]) -> Optional[str]:
+        return _validate_iana_tz(v)
 
 
 # Response schemas
@@ -40,6 +58,7 @@ class FamilyResponse(EntityResponse):
     name: str = Field(..., min_length=1, max_length=100)
     created_by: Optional[UUID] = None  # Optional for legacy data
     is_active: bool
+    timezone: str = "UTC"
 
 
 class FamilyWithMembers(FamilyResponse):

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -58,6 +58,7 @@ class UserResponse(EntityResponse):
     is_active: bool
     preferred_lang: str = "en"
     email_verified: bool = False
+    acknowledged_gigs_intro: bool = False
 
 
 class UserWithStats(UserResponse):

--- a/backend/app/services/task_assignment_service.py
+++ b/backend/app/services/task_assignment_service.py
@@ -533,6 +533,39 @@ class TaskAssignmentService(BaseFamilyService[TaskAssignment]):
     # ─── Completion + Gating ─────────────────────────────────────────
 
     @staticmethod
+    async def has_open_mandatory_through(
+        db: AsyncSession,
+        user_id: UUID,
+        family_id: UUID,
+        through_date: date,
+    ) -> bool:
+        """
+        True if any mandatory (non-bonus) assignment with assigned_date
+        on or before ``through_date`` is still open (PENDING or OVERDUE).
+
+        Carry-over semantics: an unfinished mandatory from yesterday
+        blocks today's gigs. CANCELLED counts as resolved (parent waived).
+        Future-dated mandatory rows are intentionally ignored.
+        """
+        q = (
+            select(func.count())
+            .select_from(TaskAssignment)
+            .join(TaskTemplate, TaskAssignment.template_id == TaskTemplate.id)
+            .where(
+                and_(
+                    TaskAssignment.assigned_to == user_id,
+                    TaskAssignment.family_id == family_id,
+                    TaskAssignment.assigned_date <= through_date,
+                    TaskTemplate.is_bonus == False,  # noqa: E712 — SQL boolean
+                    TaskAssignment.status.in_(
+                        [AssignmentStatus.PENDING, AssignmentStatus.OVERDUE]
+                    ),
+                )
+            )
+        )
+        return (await db.execute(q)).scalar_one() > 0
+
+    @staticmethod
     async def check_all_required_done_today(
         db: AsyncSession,
         user_id: UUID,
@@ -619,12 +652,12 @@ class TaskAssignmentService(BaseFamilyService[TaskAssignment]):
 
         if template.is_bonus:
             # Gig path
-            all_required_done = await TaskAssignmentService.check_all_required_done_today(
+            has_open_mandatory = await TaskAssignmentService.has_open_mandatory_through(
                 db, user_id, family_id, assignment.assigned_date
             )
-            if not all_required_done:
+            if has_open_mandatory:
                 raise ForbiddenException(
-                    "Complete today's mandatory tasks before claiming a gig"
+                    "Finish any open mandatory tasks (today + overdue) before claiming a gig"
                 )
 
             if not proof_text or not proof_text.strip():
@@ -729,7 +762,7 @@ class TaskAssignmentService(BaseFamilyService[TaskAssignment]):
     ) -> list[dict]:
         """Return today's assignments for a user with is_locked + approval fields."""
         today = await TaskAssignmentService._user_local_today(db, user_id)
-        all_done = await TaskAssignmentService.check_all_required_done_today(
+        has_open = await TaskAssignmentService.has_open_mandatory_through(
             db, user_id, family_id, today
         )
         q = (
@@ -755,7 +788,7 @@ class TaskAssignmentService(BaseFamilyService[TaskAssignment]):
                 "status": r.status.value,
                 "approval_status": r.approval_status.value if r.approval_status else "none",
                 "proof_text": r.proof_text,
-                "is_locked": is_bonus and not all_done and r.status != AssignmentStatus.COMPLETED,
+                "is_locked": is_bonus and has_open and r.status != AssignmentStatus.COMPLETED,
                 "assigned_date": r.assigned_date,
                 "completed_at": r.completed_at,
             })
@@ -863,7 +896,13 @@ class TaskAssignmentService(BaseFamilyService[TaskAssignment]):
             1 for a in bonus_assignments if a.status == AssignmentStatus.COMPLETED
         )
 
-        bonus_unlocked = required_completed >= len(required_assignments)
+        # Carry-over: also block bonus when any prior-day mandatory is
+        # still PENDING/OVERDUE. has_open_mandatory_through covers both
+        # same-day and historical opens.
+        has_open_mandatory = await TaskAssignmentService.has_open_mandatory_through(
+            db, user_id, family_id, check_date
+        )
+        bonus_unlocked = not has_open_mandatory
 
         return {
             "date": check_date,

--- a/backend/app/services/task_assignment_service.py
+++ b/backend/app/services/task_assignment_service.py
@@ -556,7 +556,7 @@ class TaskAssignmentService(BaseFamilyService[TaskAssignment]):
                     TaskAssignment.assigned_to == user_id,
                     TaskAssignment.family_id == family_id,
                     TaskAssignment.assigned_date <= through_date,
-                    TaskTemplate.is_bonus == False,  # noqa: E712 — SQL boolean
+                    TaskTemplate.is_bonus.is_(False),
                     TaskAssignment.status.in_(
                         [AssignmentStatus.PENDING, AssignmentStatus.OVERDUE]
                     ),
@@ -564,58 +564,6 @@ class TaskAssignmentService(BaseFamilyService[TaskAssignment]):
             )
         )
         return (await db.execute(q)).scalar_one() > 0
-
-    @staticmethod
-    async def check_all_required_done_today(
-        db: AsyncSession,
-        user_id: UUID,
-        family_id: UUID,
-        target_date: Optional[date] = None,
-    ) -> bool:
-        """
-        Check if a user has completed all non-bonus assignments for today.
-        This is the gating check for bonus task access.
-        """
-        check_date = target_date or date.today()
-
-        # Count required (non-bonus) assignments for today
-        total_query = (
-            select(func.count())
-            .select_from(TaskAssignment)
-            .join(TaskTemplate, TaskAssignment.template_id == TaskTemplate.id)
-            .where(
-                and_(
-                    TaskAssignment.assigned_to == user_id,
-                    TaskAssignment.family_id == family_id,
-                    TaskAssignment.assigned_date == check_date,
-                    TaskTemplate.is_bonus == False,
-                )
-            )
-        )
-        total = (await db.execute(total_query)).scalar_one()
-
-        if total == 0:
-            # No required tasks today — bonus unlocked
-            return True
-
-        # Count completed required assignments for today
-        completed_query = (
-            select(func.count())
-            .select_from(TaskAssignment)
-            .join(TaskTemplate, TaskAssignment.template_id == TaskTemplate.id)
-            .where(
-                and_(
-                    TaskAssignment.assigned_to == user_id,
-                    TaskAssignment.family_id == family_id,
-                    TaskAssignment.assigned_date == check_date,
-                    TaskTemplate.is_bonus == False,
-                    TaskAssignment.status == AssignmentStatus.COMPLETED,
-                )
-            )
-        )
-        completed = (await db.execute(completed_query)).scalar_one()
-
-        return completed >= total
 
     @staticmethod
     async def complete_assignment(

--- a/backend/migrations/versions/2026_05_24_gigs_intro_ack.py
+++ b/backend/migrations/versions/2026_05_24_gigs_intro_ack.py
@@ -1,0 +1,36 @@
+"""acknowledged_gigs_intro flag on users
+
+Revision ID: gigs_intro_ack
+Revises: gig_photo_v1
+Create Date: 2026-05-24
+
+Adds a one-time-banner ack flag for the mandatory=0 / gigs=points
+scope change. Banner shows on first login post-deploy and is dismissed
+permanently by hitting POST /api/auth/ack-gigs-intro.
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "gigs_intro_ack"
+down_revision = "gig_photo_v1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column(
+            "acknowledged_gigs_intro",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "acknowledged_gigs_intro")

--- a/backend/tests/test_family_timezone_update.py
+++ b/backend/tests/test_family_timezone_update.py
@@ -49,6 +49,28 @@ async def test_child_cannot_update_family(client: AsyncClient, test_child_user):
 
 
 @pytest.mark.asyncio
+async def test_child_cannot_update_family_via_legacy_put(
+    client: AsyncClient, test_child_user, test_family,
+):
+    """Regression: legacy PUT /{family_id} must reject non-parents.
+    Otherwise a child can shift the family's timezone via the older
+    route and bypass carry-over gig gating."""
+    login = await client.post(
+        "/api/auth/login",
+        json={"email": "child@test.com", "password": "password123"},
+    )
+    assert login.status_code == 200
+    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+
+    r = await client.put(
+        f"/api/families/{test_family.id}",
+        json={"timezone": "Pacific/Kiritimati"},
+        headers=headers,
+    )
+    assert r.status_code == 403
+
+
+@pytest.mark.asyncio
 async def test_get_my_family_exposes_timezone(client: AsyncClient, auth_headers):
     r = await client.get("/api/families/me", headers=auth_headers)
     assert r.status_code == 200

--- a/backend/tests/test_family_timezone_update.py
+++ b/backend/tests/test_family_timezone_update.py
@@ -1,0 +1,56 @@
+"""Tests for parent-only family timezone update endpoint."""
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_parent_updates_timezone(client: AsyncClient, auth_headers, test_family):
+    r = await client.patch(
+        "/api/families/me",
+        json={"timezone": "America/Mexico_City"},
+        headers=auth_headers,
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["timezone"] == "America/Mexico_City"
+
+    # GET should now return the new tz
+    me = await client.get("/api/families/me", headers=auth_headers)
+    assert me.status_code == 200
+    assert me.json()["timezone"] == "America/Mexico_City"
+
+
+@pytest.mark.asyncio
+async def test_invalid_timezone_rejected(client: AsyncClient, auth_headers):
+    r = await client.patch(
+        "/api/families/me",
+        json={"timezone": "Mars/Olympus_Mons"},
+        headers=auth_headers,
+    )
+    assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_child_cannot_update_family(client: AsyncClient, test_child_user):
+    # Login as child
+    login = await client.post(
+        "/api/auth/login",
+        json={"email": "child@test.com", "password": "password123"},
+    )
+    assert login.status_code == 200
+    token = login.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    r = await client.patch(
+        "/api/families/me",
+        json={"timezone": "America/Mexico_City"},
+        headers=headers,
+    )
+    assert r.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_get_my_family_exposes_timezone(client: AsyncClient, auth_headers):
+    r = await client.get("/api/families/me", headers=auth_headers)
+    assert r.status_code == 200
+    # Default seed value
+    assert "timezone" in r.json()

--- a/backend/tests/test_gig_gating.py
+++ b/backend/tests/test_gig_gating.py
@@ -149,3 +149,149 @@ async def test_list_marks_gigs_locked_when_mandatory_pending(
     locked = [r for r in rows if r["is_locked"]]
     assert len(locked) == 1
     assert locked[0]["is_bonus"] is True
+
+
+@pytest.mark.asyncio
+async def test_carry_over_overdue_mandatory_blocks_today_gig(
+    db_session, test_family, test_child_user,
+    mandatory_template_factory, gig_template_factory,
+):
+    """An OVERDUE mandatory from yesterday should block today's gigs."""
+    mand = await mandatory_template_factory(family=test_family)
+    gig = await gig_template_factory(family=test_family, points=20)
+    today = date.today()
+    yesterday = today - timedelta(days=1)
+    week_of = today - timedelta(days=today.weekday())
+
+    db_session.add_all([
+        # Yesterday's mandatory left OVERDUE
+        TaskAssignment(
+            id=uuid4(), template_id=mand.id, assigned_to=test_child_user.id,
+            family_id=test_family.id, assigned_date=yesterday, week_of=week_of,
+            status=AssignmentStatus.OVERDUE,
+        ),
+        # Today's gig (no pending mandatory today)
+        gig_assignment := TaskAssignment(
+            id=uuid4(), template_id=gig.id, assigned_to=test_child_user.id,
+            family_id=test_family.id, assigned_date=today, week_of=week_of,
+            status=AssignmentStatus.PENDING,
+        ),
+    ])
+    await db_session.commit()
+
+    with pytest.raises(ForbiddenException, match="mandatory"):
+        await TaskAssignmentService.complete_assignment(
+            db_session, gig_assignment.id, test_family.id, test_child_user.id,
+            proof_text="trying to skip",
+        )
+
+
+@pytest.mark.asyncio
+async def test_carry_over_pending_from_yesterday_blocks_today_gig(
+    db_session, test_family, test_child_user,
+    mandatory_template_factory, gig_template_factory,
+):
+    """A still-PENDING mandatory from yesterday should also block."""
+    mand = await mandatory_template_factory(family=test_family)
+    gig = await gig_template_factory(family=test_family, points=20)
+    today = date.today()
+    yesterday = today - timedelta(days=1)
+    week_of = today - timedelta(days=today.weekday())
+
+    db_session.add_all([
+        TaskAssignment(
+            id=uuid4(), template_id=mand.id, assigned_to=test_child_user.id,
+            family_id=test_family.id, assigned_date=yesterday, week_of=week_of,
+            status=AssignmentStatus.PENDING,
+        ),
+        gig_assignment := TaskAssignment(
+            id=uuid4(), template_id=gig.id, assigned_to=test_child_user.id,
+            family_id=test_family.id, assigned_date=today, week_of=week_of,
+            status=AssignmentStatus.PENDING,
+        ),
+    ])
+    await db_session.commit()
+
+    has_open = await TaskAssignmentService.has_open_mandatory_through(
+        db_session, test_child_user.id, test_family.id, today
+    )
+    assert has_open is True
+
+    with pytest.raises(ForbiddenException):
+        await TaskAssignmentService.complete_assignment(
+            db_session, gig_assignment.id, test_family.id, test_child_user.id,
+            proof_text="trying again",
+        )
+
+
+@pytest.mark.asyncio
+async def test_cancelled_mandatory_does_not_block(
+    db_session, test_family, test_child_user,
+    mandatory_template_factory, gig_template_factory,
+):
+    """CANCELLED mandatory (parent waived) does not block gigs."""
+    mand = await mandatory_template_factory(family=test_family)
+    gig = await gig_template_factory(family=test_family, points=20)
+    today = date.today()
+    yesterday = today - timedelta(days=1)
+    week_of = today - timedelta(days=today.weekday())
+
+    db_session.add_all([
+        TaskAssignment(
+            id=uuid4(), template_id=mand.id, assigned_to=test_child_user.id,
+            family_id=test_family.id, assigned_date=yesterday, week_of=week_of,
+            status=AssignmentStatus.CANCELLED,
+        ),
+        gig_assignment := TaskAssignment(
+            id=uuid4(), template_id=gig.id, assigned_to=test_child_user.id,
+            family_id=test_family.id, assigned_date=today, week_of=week_of,
+            status=AssignmentStatus.PENDING,
+        ),
+    ])
+    await db_session.commit()
+
+    has_open = await TaskAssignmentService.has_open_mandatory_through(
+        db_session, test_child_user.id, test_family.id, today
+    )
+    assert has_open is False
+
+    result = await TaskAssignmentService.complete_assignment(
+        db_session, gig_assignment.id, test_family.id, test_child_user.id,
+        proof_text="cancelled mandatory didn't block",
+    )
+    assert result.approval_status == ApprovalStatus.PENDING
+
+
+@pytest.mark.asyncio
+async def test_progress_bonus_unlocked_respects_carry_over(
+    db_session, test_family, test_child_user,
+    mandatory_template_factory, gig_template_factory,
+):
+    """get_daily_progress.bonus_unlocked must be False when overdue mandatory exists."""
+    mand = await mandatory_template_factory(family=test_family)
+    gig = await gig_template_factory(family=test_family, points=20)
+    today = date.today()
+    yesterday = today - timedelta(days=1)
+    week_of = today - timedelta(days=today.weekday())
+
+    db_session.add_all([
+        TaskAssignment(
+            id=uuid4(), template_id=mand.id, assigned_to=test_child_user.id,
+            family_id=test_family.id, assigned_date=yesterday, week_of=week_of,
+            status=AssignmentStatus.OVERDUE,
+        ),
+        TaskAssignment(
+            id=uuid4(), template_id=gig.id, assigned_to=test_child_user.id,
+            family_id=test_family.id, assigned_date=today, week_of=week_of,
+            status=AssignmentStatus.PENDING,
+        ),
+    ])
+    await db_session.commit()
+
+    progress = await TaskAssignmentService.get_daily_progress(
+        db_session, test_child_user.id, test_family.id, today,
+    )
+    assert progress["bonus_unlocked"] is False
+    # No mandatory on `today` itself
+    assert progress["required_total"] == 0
+    assert progress["bonus_total"] == 1

--- a/backend/tests/test_gigs_intro_ack.py
+++ b/backend/tests/test_gigs_intro_ack.py
@@ -1,0 +1,35 @@
+"""Tests for the one-time gigs-intro banner ack endpoint."""
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_new_user_default_false(client: AsyncClient, auth_headers):
+    r = await client.get("/api/auth/me", headers=auth_headers)
+    assert r.status_code == 200
+    assert r.json()["acknowledged_gigs_intro"] is False
+
+
+@pytest.mark.asyncio
+async def test_ack_sets_flag_true(client: AsyncClient, auth_headers):
+    r = await client.post("/api/auth/ack-gigs-intro", headers=auth_headers)
+    assert r.status_code == 200
+    assert r.json()["acknowledged_gigs_intro"] is True
+
+    me = await client.get("/api/auth/me", headers=auth_headers)
+    assert me.json()["acknowledged_gigs_intro"] is True
+
+
+@pytest.mark.asyncio
+async def test_ack_idempotent(client: AsyncClient, auth_headers):
+    r1 = await client.post("/api/auth/ack-gigs-intro", headers=auth_headers)
+    r2 = await client.post("/api/auth/ack-gigs-intro", headers=auth_headers)
+    assert r1.status_code == 200
+    assert r2.status_code == 200
+    assert r2.json()["acknowledged_gigs_intro"] is True
+
+
+@pytest.mark.asyncio
+async def test_ack_requires_auth(client: AsyncClient):
+    r = await client.post("/api/auth/ack-gigs-intro")
+    assert r.status_code in (401, 403)

--- a/backend/tests/test_task_assignment_service.py
+++ b/backend/tests/test_task_assignment_service.py
@@ -357,13 +357,14 @@ class TestBonusGating:
             )
             assert completed.status == AssignmentStatus.COMPLETED
 
-    async def test_check_all_required_done_true_when_no_required(
+    async def test_no_open_mandatory_when_none_exist(
         self, db_session, test_family, test_child_user
     ):
-        result = await TaskAssignmentService.check_all_required_done_today(
-            db_session, test_child_user.id, test_family.id
+        from datetime import date
+        result = await TaskAssignmentService.has_open_mandatory_through(
+            db_session, test_child_user.id, test_family.id, date.today()
         )
-        assert result is True  # No required tasks = unlocked
+        assert result is False  # No required tasks = nothing open = unlocked
 
 
 # ─── Daily Progress ──────────────────────────────────────────────────

--- a/frontend/src/components/GigsIntroBanner.astro
+++ b/frontend/src/components/GigsIntroBanner.astro
@@ -1,0 +1,59 @@
+---
+import { t } from "../lib/i18n";
+
+interface Props {
+    lang: string;
+    show: boolean;
+}
+
+const { lang, show } = Astro.props;
+---
+
+{show && (
+    <div
+        id="gigs-intro-banner"
+        class="mx-4 mt-4 rounded-2xl border border-brand-sun bg-brand-cream p-4 shadow-[var(--shadow-card)]"
+        role="region"
+        aria-label="Scope change explanation"
+    >
+        <div class="flex items-start gap-3">
+            <div class="flex-shrink-0 mt-0.5">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-brand-ink" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+            </div>
+            <div class="flex-1">
+                <h3 class="font-semibold text-brand-ink mb-1">{t(lang, "intro_banner_title")}</h3>
+                <p class="text-sm text-brand-ink/80 mb-3">{t(lang, "intro_banner_body")}</p>
+                <button
+                    id="gigs-intro-dismiss"
+                    class="px-4 py-2 bg-brand-sky-deep text-white rounded-lg text-sm font-medium hover:bg-brand-sky transition-colors"
+                    type="button"
+                >
+                    {t(lang, "intro_banner_dismiss")}
+                </button>
+            </div>
+        </div>
+    </div>
+)}
+
+<script>
+    const btn = document.getElementById("gigs-intro-dismiss");
+    if (btn) {
+        btn.addEventListener("click", async () => {
+            btn.setAttribute("disabled", "true");
+            try {
+                const r = await fetch("/api/auth/ack-gigs-intro", { method: "POST" });
+                if (r.ok) {
+                    document.getElementById("gigs-intro-banner")?.remove();
+                } else {
+                    btn.removeAttribute("disabled");
+                    console.error("ack-gigs-intro failed:", await r.text());
+                }
+            } catch (e) {
+                btn.removeAttribute("disabled");
+                console.error("ack-gigs-intro error:", e);
+            }
+        });
+    }
+</script>

--- a/frontend/src/lib/i18n.ts
+++ b/frontend/src/lib/i18n.ts
@@ -432,6 +432,11 @@ export const translations = {
         fab_another: "+ Another",
         fab_close: "Close",
         fab_auto_rule: "rule ✓",
+
+        // Gigs intro banner (one-time after scope change)
+        intro_banner_title: "What changed",
+        intro_banner_body: "Daily mandatory tasks now award 0 points — they're expected. Gigs (bonus tasks) are the only way to earn points, and a parent reviews your proof before points are credited.",
+        intro_banner_dismiss: "Got it",
     },
     es: {
         // Common / Nav
@@ -860,6 +865,11 @@ export const translations = {
         fab_another: "+ Otro gasto",
         fab_close: "Cerrar",
         fab_auto_rule: "regla ✓",
+
+        // Gigs intro banner (one-time after scope change)
+        intro_banner_title: "Qué cambió",
+        intro_banner_body: "Las tareas obligatorias diarias ahora dan 0 puntos — son lo esperado. Los gigs (tareas bonus) son la única forma de ganar puntos, y un padre revisa tu evidencia antes de acreditarlos.",
+        intro_banner_dismiss: "Entendido",
     },
 } as const;
 

--- a/frontend/src/lib/i18n.ts
+++ b/frontend/src/lib/i18n.ts
@@ -435,7 +435,7 @@ export const translations = {
 
         // Gigs intro banner (one-time after scope change)
         intro_banner_title: "What changed",
-        intro_banner_body: "Daily mandatory tasks now award 0 points — they're expected. Gigs (bonus tasks) are the only way to earn points, and a parent reviews your proof before points are credited.",
+        intro_banner_body: "Daily mandatory tasks now award 0 points — they're expected. Gigs (bonus tasks) are the only way to earn points, stay locked until every mandatory task (today and any overdue) is finished, and a parent reviews your proof before points are credited.",
         intro_banner_dismiss: "Got it",
     },
     es: {
@@ -868,7 +868,7 @@ export const translations = {
 
         // Gigs intro banner (one-time after scope change)
         intro_banner_title: "Qué cambió",
-        intro_banner_body: "Las tareas obligatorias diarias ahora dan 0 puntos — son lo esperado. Los gigs (tareas bonus) son la única forma de ganar puntos, y un padre revisa tu evidencia antes de acreditarlos.",
+        intro_banner_body: "Las tareas obligatorias diarias ahora dan 0 puntos — son lo esperado. Los gigs (tareas bonus) son la única forma de ganar puntos, quedan bloqueados hasta terminar todas las obligatorias (de hoy y atrasadas), y un padre revisa tu evidencia antes de acreditarlos.",
         intro_banner_dismiss: "Entendido",
     },
 } as const;

--- a/frontend/src/pages/api/auth/ack-gigs-intro.ts
+++ b/frontend/src/pages/api/auth/ack-gigs-intro.ts
@@ -1,0 +1,39 @@
+import type { APIRoute } from "astro";
+
+/**
+ * POST /api/auth/ack-gigs-intro
+ * Forwards to backend POST /api/auth/ack-gigs-intro to dismiss the
+ * mandatory=0 / gigs=points scope-change banner.
+ */
+export const POST: APIRoute = async ({ cookies }) => {
+    const token = cookies.get("access_token")?.value;
+    if (!token) {
+        return new Response(JSON.stringify({ detail: "Unauthorized" }), {
+            status: 401,
+            headers: { "Content-Type": "application/json" },
+        });
+    }
+
+    const apiUrl =
+        process.env.API_BASE_URL ||
+        process.env.PUBLIC_API_BASE_URL ||
+        "http://backend:8000";
+
+    try {
+        const r = await fetch(`${apiUrl}/api/auth/ack-gigs-intro`, {
+            method: "POST",
+            headers: { Authorization: `Bearer ${token}` },
+        });
+        const text = await r.text();
+        return new Response(text, {
+            status: r.status,
+            headers: { "Content-Type": "application/json" },
+        });
+    } catch (e) {
+        console.error("ack-gigs-intro proxy error:", e);
+        return new Response(JSON.stringify({ detail: "Upstream error" }), {
+            status: 502,
+            headers: { "Content-Type": "application/json" },
+        });
+    }
+};

--- a/frontend/src/pages/api/families/me.ts
+++ b/frontend/src/pages/api/families/me.ts
@@ -1,0 +1,72 @@
+import type { APIRoute } from "astro";
+
+/**
+ * Proxy for /api/families/me.
+ * GET  → backend GET /api/families/me
+ * PATCH → backend PATCH /api/families/me  (parent only; updates name/timezone)
+ */
+const apiUrl = () =>
+    process.env.API_BASE_URL ||
+    process.env.PUBLIC_API_BASE_URL ||
+    "http://backend:8000";
+
+function unauthorized() {
+    return new Response(JSON.stringify({ detail: "Unauthorized" }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+    });
+}
+
+export const GET: APIRoute = async ({ cookies }) => {
+    const token = cookies.get("access_token")?.value;
+    if (!token) return unauthorized();
+    try {
+        const r = await fetch(`${apiUrl()}/api/families/me`, {
+            headers: { Authorization: `Bearer ${token}` },
+        });
+        return new Response(await r.text(), {
+            status: r.status,
+            headers: { "Content-Type": "application/json" },
+        });
+    } catch (e) {
+        console.error("families/me GET proxy error:", e);
+        return new Response(JSON.stringify({ detail: "Upstream error" }), {
+            status: 502,
+            headers: { "Content-Type": "application/json" },
+        });
+    }
+};
+
+export const PATCH: APIRoute = async ({ request, cookies }) => {
+    const token = cookies.get("access_token")?.value;
+    if (!token) return unauthorized();
+    let body: any;
+    try {
+        body = await request.json();
+    } catch {
+        return new Response(JSON.stringify({ detail: "Invalid JSON" }), {
+            status: 400,
+            headers: { "Content-Type": "application/json" },
+        });
+    }
+    try {
+        const r = await fetch(`${apiUrl()}/api/families/me`, {
+            method: "PATCH",
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${token}`,
+            },
+            body: JSON.stringify(body),
+        });
+        return new Response(await r.text(), {
+            status: r.status,
+            headers: { "Content-Type": "application/json" },
+        });
+    } catch (e) {
+        console.error("families/me PATCH proxy error:", e);
+        return new Response(JSON.stringify({ detail: "Upstream error" }), {
+            status: 502,
+            headers: { "Content-Type": "application/json" },
+        });
+    }
+};

--- a/frontend/src/pages/dashboard.astro
+++ b/frontend/src/pages/dashboard.astro
@@ -2,6 +2,7 @@
 import Layout from "../layouts/Layout.astro";
 import BottomNav from "../components/BottomNav.astro";
 import PointsConverter from "../components/PointsConverter.astro";
+import GigsIntroBanner from "../components/GigsIntroBanner.astro";
 import { apiFetch } from "../lib/api";
 import { t } from "../lib/i18n";
 
@@ -78,6 +79,8 @@ if (flashError) Astro.cookies.delete("flash_error", { path: "/" });
                 </div>
             </div>
         </header>
+
+        <GigsIntroBanner lang={lang} show={!user.acknowledged_gigs_intro} />
 
         <!-- Points Converter (only for TEEN/CHILD users) -->
         {(user.role === "TEEN" || user.role === "CHILD") && (

--- a/frontend/src/pages/parent/index.astro
+++ b/frontend/src/pages/parent/index.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from "../../layouts/Layout.astro";
 import BottomNav from "../../components/BottomNav.astro";
+import GigsIntroBanner from "../../components/GigsIntroBanner.astro";
 import { apiFetch } from "../../lib/api";
 import { t } from "../../lib/i18n";
 
@@ -38,6 +39,8 @@ const pendingApprovals = Array.isArray(pending) ? pending.length : 0;
                 {t(lang, "parent_members_count")(family?.members?.length ?? 0)}
             </p>
         </header>
+
+        <GigsIntroBanner lang={lang} show={!user.acknowledged_gigs_intro} />
 
         <main class="flex-1 px-4 py-6">
             <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">

--- a/frontend/src/pages/parent/settings/family.astro
+++ b/frontend/src/pages/parent/settings/family.astro
@@ -1,0 +1,159 @@
+---
+import Layout from "../../../layouts/Layout.astro";
+import BottomNav from "../../../components/BottomNav.astro";
+import { apiFetch } from "../../../lib/api";
+
+const token = Astro.cookies.get("access_token")?.value;
+if (!token) return Astro.redirect("/login");
+const lang = Astro.cookies.get("lang")?.value ?? "en";
+
+const { data: user } = await apiFetch<any>("/api/auth/me", { token });
+if (!user) {
+    Astro.cookies.delete("access_token", { path: "/" });
+    return Astro.redirect("/login");
+}
+if (user.role !== "parent") return Astro.redirect("/dashboard");
+
+const { data: family } = await apiFetch<any>("/api/families/me", { token });
+
+// Common North-American + Latin-American zones bubbled to the top, then everything else.
+const PRIORITY_TZ = [
+    "UTC",
+    "America/Mexico_City",
+    "America/Monterrey",
+    "America/Tijuana",
+    "America/Los_Angeles",
+    "America/Denver",
+    "America/Chicago",
+    "America/New_York",
+    "America/Bogota",
+    "America/Lima",
+    "America/Buenos_Aires",
+    "America/Santiago",
+    "Europe/Madrid",
+    "Europe/London",
+];
+// Intl.supportedValuesOf is available on Node 18+ and modern browsers.
+const allZones: string[] =
+    typeof (Intl as any).supportedValuesOf === "function"
+        ? (Intl as any).supportedValuesOf("timeZone")
+        : [];
+const remaining = allZones.filter((z) => !PRIORITY_TZ.includes(z));
+const tzOptions = [...PRIORITY_TZ, ...remaining];
+
+const currentTz = family?.timezone || "UTC";
+
+const labels = {
+    en: {
+        title: "Family settings",
+        back: "Back",
+        tz_label: "Timezone",
+        tz_hint: "Used to determine 'today' for gig gating. Pick the timezone your family lives in.",
+        save: "Save",
+        saved: "Saved.",
+        error: "Could not save. Try again.",
+    },
+    es: {
+        title: "Ajustes de la familia",
+        back: "Volver",
+        tz_label: "Zona horaria",
+        tz_hint: "Se usa para determinar 'hoy' en el bloqueo de gigs. Elige la zona en la que vive tu familia.",
+        save: "Guardar",
+        saved: "Guardado.",
+        error: "No se pudo guardar. Inténtalo de nuevo.",
+    },
+}[lang] ?? null;
+const L = labels ?? {
+    title: "Family settings",
+    back: "Back",
+    tz_label: "Timezone",
+    tz_hint: "Used to determine 'today' for gig gating.",
+    save: "Save",
+    saved: "Saved.",
+    error: "Could not save. Try again.",
+};
+---
+
+<Layout title={`${L.title} - Family Task Manager`}>
+    <div class="w-full max-w-md md:max-w-4xl lg:max-w-6xl mx-auto bg-brand-cream-deep flex flex-col min-h-screen">
+        <header class="bg-gradient-to-br from-slate-800 to-slate-700 text-white pt-12 pb-8 px-6 rounded-b-[var(--radius-tile)] shadow-[var(--shadow-card)]">
+            <div class="flex items-center gap-3 mb-2">
+                <a href="/parent/settings" class="text-brand-ink-soft hover:text-white transition-colors">
+                    <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+                    </svg>
+                </a>
+                <p class="text-brand-ink-soft text-sm">{L.back}</p>
+            </div>
+            <h1 class="text-2xl font-bold">{L.title}</h1>
+        </header>
+
+        <main class="flex-1 px-4 py-6">
+            <form id="family-form" class="bg-brand-cream rounded-2xl p-5 shadow-[var(--shadow-card)] border border-brand-ink/10 space-y-4">
+                <div>
+                    <label for="timezone" class="block text-sm font-semibold text-brand-ink mb-1">{L.tz_label}</label>
+                    <select
+                        id="timezone"
+                        name="timezone"
+                        class="w-full rounded-lg border border-brand-ink/20 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-sky"
+                    >
+                        {tzOptions.map((tz) => (
+                            <option value={tz} selected={tz === currentTz}>{tz}</option>
+                        ))}
+                    </select>
+                    <p class="text-xs text-brand-ink-soft mt-1">{L.tz_hint}</p>
+                </div>
+
+                <div class="flex items-center gap-3">
+                    <button
+                        type="submit"
+                        id="save-btn"
+                        class="px-4 py-2 bg-brand-sky-deep text-white rounded-lg text-sm font-medium hover:bg-brand-sky transition-colors disabled:opacity-60"
+                    >
+                        {L.save}
+                    </button>
+                    <span id="status-msg" class="text-sm" aria-live="polite"></span>
+                </div>
+            </form>
+        </main>
+
+        <BottomNav active="parent" role={user.role} lang={lang} />
+    </div>
+</Layout>
+
+<script define:vars={{ savedLabel: L.saved, errorLabel: L.error }}>
+    const form = document.getElementById("family-form");
+    const btn = document.getElementById("save-btn");
+    const status = document.getElementById("status-msg");
+    const tzInput = document.getElementById("timezone");
+
+    form?.addEventListener("submit", async (e) => {
+        e.preventDefault();
+        if (!btn || !status || !tzInput) return;
+        btn.setAttribute("disabled", "true");
+        status.textContent = "";
+        status.className = "text-sm";
+
+        try {
+            const r = await fetch("/api/families/me", {
+                method: "PATCH",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ timezone: tzInput.value }),
+            });
+            if (r.ok) {
+                status.textContent = savedLabel;
+                status.className = "text-sm text-green-700";
+            } else {
+                status.textContent = errorLabel;
+                status.className = "text-sm text-red-700";
+                console.error("family update failed:", await r.text());
+            }
+        } catch (err) {
+            status.textContent = errorLabel;
+            status.className = "text-sm text-red-700";
+            console.error(err);
+        } finally {
+            btn.removeAttribute("disabled");
+        }
+    });
+</script>

--- a/frontend/src/pages/parent/settings/index.astro
+++ b/frontend/src/pages/parent/settings/index.astro
@@ -20,18 +20,24 @@ const labels = {
         title: "Settings",
         subscription: "Subscription",
         subscription_desc: "Manage your plan and billing",
+        family: "Family",
+        family_desc: "Timezone and family-wide preferences",
         back: "Back",
     },
     es: {
         title: "Configuraci\u00f3n",
         subscription: "Suscripci\u00f3n",
         subscription_desc: "Administra tu plan y facturaci\u00f3n",
+        family: "Familia",
+        family_desc: "Zona horaria y preferencias de la familia",
         back: "Volver",
     },
 }[lang] ?? {
     title: "Settings",
     subscription: "Subscription",
     subscription_desc: "Manage your plan and billing",
+    family: "Family",
+    family_desc: "Timezone and family-wide preferences",
     back: "Back",
 };
 ---
@@ -66,6 +72,26 @@ const labels = {
                     <div>
                         <p class="font-bold text-brand-ink">{labels.subscription}</p>
                         <p class="text-xs text-brand-ink-soft">{labels.subscription_desc}</p>
+                    </div>
+                    <svg class="w-5 h-5 text-brand-ink-soft ml-auto flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                    </svg>
+                </a>
+
+                <a
+                    href="/parent/settings/family"
+                    class="bg-brand-cream rounded-2xl p-5 shadow-[var(--shadow-card)] border border-brand-ink/10 hover:shadow-[var(--shadow-card)] hover:border-brand-sky transition-all flex items-center gap-4"
+                >
+                    <div class="w-12 h-12 rounded-xl bg-brand-sky/20 flex items-center justify-center flex-shrink-0">
+                        <svg class="h-6 w-6 text-brand-sky-deep" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+                            />
+                        </svg>
+                    </div>
+                    <div>
+                        <p class="font-bold text-brand-ink">{labels.family}</p>
+                        <p class="text-xs text-brand-ink-soft">{labels.family_desc}</p>
                     </div>
                     <svg class="w-5 h-5 text-brand-ink-soft ml-auto flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />


### PR DESCRIPTION
## Summary

Closes remaining "out of scope" + "Risk + rollout" items from `docs/superpowers/specs/2026-05-22-mandatory-vs-gigs-design.md` that PRs #9, #10, #11 deferred.

- **Intro banner** (`e32f80e`) — One-time post-deploy banner on dashboard + parent hub explaining mandatory=0 / gigs=points. New `users.acknowledged_gigs_intro` flag, migration `gigs_intro_ack`, `POST /api/auth/ack-gigs-intro`, EN/ES copy.
- **Parent timezone selector** (`bf94611`) — Parent-only `PATCH /api/families/me` with IANA-validated `timezone` field. New `/parent/settings/family` page with dropdown sourced from `Intl.supportedValuesOf('timeZone')` and a Latin-America/US priority list. Fixes the deferred frontend half of `families.timezone`.
- **Carry-over gating** (`b57c93a`) — Overdue / yesterday-pending mandatory now blocks today's gigs. New `TaskAssignmentService.has_open_mandatory_through(user, family, through_date)` covers same-day + carry-over in one query. Wired through `complete_assignment`, `list_for_user_today_with_locks`, `get_daily_progress.bonus_unlocked`, and the two route lock caches. CANCELLED mandatory treated as resolved.
- **Config drift** (`9026a46`) — In-code `ACCESS_TOKEN_EXPIRE_MINUTES` default 30→10080 (companion to 6414af8 which only updated `.env.gcp.example`).

Spec: `docs/superpowers/specs/2026-05-22-mandatory-vs-gigs-design.md`

## Test plan

- [x] `pytest tests/test_gig_gating.py tests/test_gig_approval.py tests/test_gigs_intro_ack.py tests/test_family_timezone_update.py tests/test_migration_mandatory_zero.py` — 27/27 passing
- [ ] Manual: login as `lucas@demo.com` (TEEN). Mandatory pending → gig locked. Yesterday's mandatory left OVERDUE → today's gig still locked. Cancel yesterday's → unlock.
- [ ] Manual: login as `mom@demo.com` (PARENT). `/parent/settings/family` → change tz to `America/Mexico_City` → save. Verify `progress["bonus_unlocked"]` honors new "today" boundary.
- [ ] Manual: fresh user sees banner on dashboard, dismiss persists across page reloads.

## Out of scope (deferred)

- Push notifications for pending approvals (email-only today, shipped in #11)
- Gig claim/reserve step
- Auto-approval based on parent trust score

🤖 Generated with [Claude Code](https://claude.com/claude-code)