### PR TITLE
Gig spec tail: claim/reserve, trust-score auto-approval, Web Push

### DIFF
--- a/backend/app/api/routes/push.py
+++ b/backend/app/api/routes/push.py
@@ -1,0 +1,69 @@
+"""Web Push subscription endpoints."""
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.core.database import get_db
+from app.core.dependencies import get_current_user
+from app.core.type_utils import to_uuid_required
+from app.models import User
+from app.services.push_service import PushService
+
+router = APIRouter()
+
+
+class PushSubscriptionKeys(BaseModel):
+    p256dh: str = Field(..., min_length=1, max_length=255)
+    auth: str = Field(..., min_length=1, max_length=255)
+
+
+class PushSubscribeRequest(BaseModel):
+    endpoint: str = Field(..., min_length=1, max_length=2048)
+    keys: PushSubscriptionKeys
+
+
+class PushUnsubscribeRequest(BaseModel):
+    endpoint: str = Field(..., min_length=1, max_length=2048)
+
+
+@router.get("/public-key")
+async def get_vapid_public_key():
+    """Public VAPID key for the browser PushManager.subscribe() call."""
+    if not settings.VAPID_PUBLIC_KEY:
+        raise HTTPException(
+            status_code=503,
+            detail="Web Push is not configured on this server",
+        )
+    return {"public_key": settings.VAPID_PUBLIC_KEY}
+
+
+@router.post("/subscribe")
+async def subscribe(
+    body: PushSubscribeRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Register a browser push endpoint for the current user."""
+    sub = await PushService.subscribe(
+        db,
+        user_id=to_uuid_required(current_user.id),
+        endpoint=body.endpoint,
+        p256dh=body.keys.p256dh,
+        auth=body.keys.auth,
+    )
+    return {"id": str(sub.id), "endpoint": sub.endpoint}
+
+
+@router.post("/unsubscribe")
+async def unsubscribe(
+    body: PushUnsubscribeRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    removed = await PushService.unsubscribe(
+        db,
+        user_id=to_uuid_required(current_user.id),
+        endpoint=body.endpoint,
+    )
+    return {"removed": removed}

--- a/backend/app/api/routes/task_assignments.py
+++ b/backend/app/api/routes/task_assignments.py
@@ -321,6 +321,47 @@ async def complete_assignment(
     return _assignment_to_detail(assignment)
 
 
+@router.post("/{assignment_id}/claim", response_model=TaskAssignmentWithDetails)
+async def claim_assignment(
+    assignment_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Reserve a gig before working on it. Transitions PENDING → CLAIMED.
+    Mandatory rows reject; gating still applies."""
+    family_id = to_uuid_required(current_user.family_id)
+    await TaskAssignmentService.claim_gig(
+        db,
+        assignment_id,
+        family_id=family_id,
+        user_id=to_uuid_required(current_user.id),
+    )
+    assignment = await TaskAssignmentService.get_assignment(
+        db, assignment_id, family_id
+    )
+    return _assignment_to_detail(assignment)
+
+
+@router.post("/{assignment_id}/unclaim", response_model=TaskAssignmentWithDetails)
+async def unclaim_assignment(
+    assignment_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Release a claim. Transitions CLAIMED → PENDING."""
+    family_id = to_uuid_required(current_user.family_id)
+    await TaskAssignmentService.unclaim_gig(
+        db,
+        assignment_id,
+        family_id=family_id,
+        user_id=to_uuid_required(current_user.id),
+    )
+    assignment = await TaskAssignmentService.get_assignment(
+        db, assignment_id, family_id
+    )
+    return _assignment_to_detail(assignment)
+
+
 @router.post("/{assignment_id}/approve", response_model=TaskAssignmentWithDetails)
 async def approve_assignment(
     assignment_id: UUID,

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -33,6 +33,14 @@ class Settings(BaseSettings):
     # approved gigs, subsequent gig completions auto-approve and credit
     # points immediately. A parent rejection resets the streak to 0.
     GIG_AUTO_APPROVE_STREAK: int = 3
+
+    # Web Push (VAPID). Generate keys with:
+    #   python -c "from py_vapid import Vapid; v=Vapid(); v.generate_keys(); print(v.private_pem(), v.public_key.to_string())"
+    # If unset, PushService.send no-ops with a warning log; the app
+    # otherwise runs normally (email still fires).
+    VAPID_PUBLIC_KEY: str = ""
+    VAPID_PRIVATE_KEY: str = ""
+    VAPID_CLAIM_EMAIL: str = "admin@agent-ia.mx"
     
     # Google OAuth
     # GOOGLE_CLIENT_ID is the primary Web client (legacy single-value field,

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -28,6 +28,11 @@ class Settings(BaseSettings):
     SECRET_KEY: str = "your-secret-key-change-this-in-production"
     ALGORITHM: str = "HS256"
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 10080  # 7 days
+
+    # Trust-score auto-approval: once a user has this many consecutive
+    # approved gigs, subsequent gig completions auto-approve and credit
+    # points immediately. A parent rejection resets the streak to 0.
+    GIG_AUTO_APPROVE_STREAK: int = 3
     
     # Google OAuth
     # GOOGLE_CLIENT_ID is the primary Web client (legacy single-value field,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,7 +12,7 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from app.core.config import settings
 from app.core.database import engine, Base, AsyncSessionLocal
 from app.core.exception_handlers import register_exception_handlers
-from app.api.routes import auth, users, rewards, consequences, families, task_templates, task_assignments, sync, oauth, payment, points_conversion, invitations, subscriptions
+from app.api.routes import auth, users, rewards, consequences, families, task_templates, task_assignments, sync, oauth, payment, points_conversion, invitations, subscriptions, push
 from app.api.routes.budget import router as budget_router
 from app.jobs.subscription_sweep import run_sweep
 from app.services.task_assignment_service import TaskAssignmentService
@@ -134,6 +134,7 @@ app.include_router(
     tags=["Subscriptions"],
 )
 app.include_router(sync.router, tags=["Sync"])
+app.include_router(push.router, prefix="/api/push", tags=["Push"])
 
 
 @app.get("/")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -19,6 +19,7 @@ from app.models.consequence import Consequence, ConsequenceSeverity, Restriction
 from app.models.point_transaction import PointTransaction, TransactionType
 from app.models.password_reset import PasswordResetToken
 from app.models.email_verification import EmailVerificationToken
+from app.models.push_subscription import PushSubscription
 from app.models.invitation import FamilyInvitation, InvitationStatus
 from app.models.budget import (
     BudgetCategoryGroup,

--- a/backend/app/models/push_subscription.py
+++ b/backend/app/models/push_subscription.py
@@ -1,0 +1,43 @@
+"""PushSubscription model — stores Web Push (VAPID) endpoints per user."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Column, String, DateTime, ForeignKey, UniqueConstraint
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+
+from app.core.database import Base
+
+
+class PushSubscription(Base):
+    """One row per (user, browser endpoint). Multiple devices per user OK."""
+
+    __tablename__ = "push_subscriptions"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    endpoint = Column(String(2048), nullable=False)
+    p256dh = Column(String(255), nullable=False)
+    auth = Column(String(255), nullable=False)
+    created_at = Column(
+        DateTime(timezone=True), default=datetime.utcnow, nullable=False
+    )
+    last_seen_at = Column(
+        DateTime(timezone=True),
+        default=datetime.utcnow,
+        onupdate=datetime.utcnow,
+        nullable=False,
+    )
+
+    user = relationship("User")
+
+    __table_args__ = (
+        UniqueConstraint("user_id", "endpoint", name="uq_push_subscriptions_user_endpoint"),
+    )

--- a/backend/app/models/task_assignment.py
+++ b/backend/app/models/task_assignment.py
@@ -30,6 +30,7 @@ class AssignmentStatus(str, enum.Enum):
     """Assignment completion status"""
 
     PENDING = "pending"
+    CLAIMED = "claimed"
     COMPLETED = "completed"
     OVERDUE = "overdue"
     CANCELLED = "cancelled"
@@ -115,6 +116,7 @@ class TaskAssignment(Base):
 
     # Completion
     completed_at = Column(DateTime(timezone=True), nullable=True)
+    claimed_at = Column(DateTime(timezone=True), nullable=True)
 
     # Metadata
     created_at = Column(
@@ -156,4 +158,13 @@ class TaskAssignment(Base):
     @property
     def can_complete(self) -> bool:
         """Check if assignment can be marked as completed"""
-        return self.status in [AssignmentStatus.PENDING, AssignmentStatus.OVERDUE]
+        return self.status in [
+            AssignmentStatus.PENDING,
+            AssignmentStatus.CLAIMED,
+            AssignmentStatus.OVERDUE,
+        ]
+
+    @property
+    def can_claim(self) -> bool:
+        """Only PENDING gigs are claimable (mandatory has no claim semantic)."""
+        return self.status == AssignmentStatus.PENDING

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -46,6 +46,13 @@ class User(Base):
         Boolean, default=False, nullable=False, server_default="false"
     )
 
+    # Consecutive approved-gig count. Hits the GIG_AUTO_APPROVE_STREAK
+    # threshold (default 3) and subsequent gigs auto-approve on completion.
+    # A parent rejection resets to 0.
+    gig_trust_streak = Column(
+        Integer, default=0, nullable=False, server_default="0"
+    )
+
     oauth_provider = Column(String(50), nullable=True)
     oauth_id = Column(String(255), nullable=True)
     

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -59,6 +59,7 @@ class UserResponse(EntityResponse):
     preferred_lang: str = "en"
     email_verified: bool = False
     acknowledged_gigs_intro: bool = False
+    gig_trust_streak: int = 0
 
 
 class UserWithStats(UserResponse):

--- a/backend/app/services/push_service.py
+++ b/backend/app/services/push_service.py
@@ -1,0 +1,175 @@
+"""Web Push (VAPID) fan-out for parent notifications.
+
+pywebpush is synchronous; wrap each send in asyncio.to_thread so the
+gig-submission request path never blocks on Apple/Google push gateway
+latency. Dead endpoints (HTTP 410 Gone) are pruned automatically.
+
+If VAPID keys are not configured, sends are skipped with a warning so
+local/dev environments work without push setup.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any
+from uuid import UUID
+
+from pywebpush import WebPushException, webpush
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.models.push_subscription import PushSubscription
+
+log = logging.getLogger(__name__)
+
+
+class PushService:
+    @staticmethod
+    def _vapid_configured() -> bool:
+        return bool(settings.VAPID_PRIVATE_KEY and settings.VAPID_PUBLIC_KEY)
+
+    @staticmethod
+    async def subscribe(
+        db: AsyncSession,
+        user_id: UUID,
+        endpoint: str,
+        p256dh: str,
+        auth: str,
+    ) -> PushSubscription:
+        """Upsert a (user, endpoint) subscription. Same endpoint posted
+        twice just refreshes the keys + last_seen_at."""
+        existing = await db.scalar(
+            select(PushSubscription).where(
+                PushSubscription.user_id == user_id,
+                PushSubscription.endpoint == endpoint,
+            )
+        )
+        if existing:
+            existing.p256dh = p256dh
+            existing.auth = auth
+            await db.commit()
+            await db.refresh(existing)
+            return existing
+
+        sub = PushSubscription(
+            user_id=user_id,
+            endpoint=endpoint,
+            p256dh=p256dh,
+            auth=auth,
+        )
+        db.add(sub)
+        await db.commit()
+        await db.refresh(sub)
+        return sub
+
+    @staticmethod
+    async def unsubscribe(db: AsyncSession, user_id: UUID, endpoint: str) -> int:
+        result = await db.execute(
+            delete(PushSubscription).where(
+                PushSubscription.user_id == user_id,
+                PushSubscription.endpoint == endpoint,
+            )
+        )
+        await db.commit()
+        return result.rowcount or 0
+
+    @staticmethod
+    async def send_to_user(
+        db: AsyncSession, user_id: UUID, payload: dict[str, Any]
+    ) -> int:
+        """Fan out a JSON payload to every subscription owned by user_id.
+
+        Returns the count of successful sends. Best-effort: failures
+        per endpoint are logged and (if 404/410) drop the row.
+        """
+        if not PushService._vapid_configured():
+            log.warning("VAPID not configured; skipping push to user %s", user_id)
+            return 0
+
+        rows = (
+            await db.scalars(
+                select(PushSubscription).where(PushSubscription.user_id == user_id)
+            )
+        ).all()
+        if not rows:
+            return 0
+
+        vapid_claims = {"sub": f"mailto:{settings.VAPID_CLAIM_EMAIL}"}
+        body = json.dumps(payload)
+        sent = 0
+        dead_endpoints: list[str] = []
+
+        for sub in rows:
+            try:
+                await asyncio.to_thread(
+                    webpush,
+                    subscription_info={
+                        "endpoint": sub.endpoint,
+                        "keys": {"p256dh": sub.p256dh, "auth": sub.auth},
+                    },
+                    data=body,
+                    vapid_private_key=settings.VAPID_PRIVATE_KEY,
+                    vapid_claims=vapid_claims,
+                )
+                sent += 1
+            except WebPushException as exc:
+                status = getattr(exc.response, "status_code", None)
+                if status in (404, 410):
+                    dead_endpoints.append(sub.endpoint)
+                else:
+                    log.warning(
+                        "push send to %s failed (status=%s): %s",
+                        sub.endpoint[:60],
+                        status,
+                        exc,
+                    )
+            except Exception:
+                log.exception("unexpected push send failure for %s", sub.endpoint[:60])
+
+        if dead_endpoints:
+            await db.execute(
+                delete(PushSubscription).where(
+                    PushSubscription.user_id == user_id,
+                    PushSubscription.endpoint.in_(dead_endpoints),
+                )
+            )
+            await db.commit()
+            log.info("pruned %d dead push endpoints for user %s", len(dead_endpoints), user_id)
+
+        return sent
+
+    @staticmethod
+    async def fan_out_pending_gig(
+        db: AsyncSession,
+        family_id: UUID,
+        child_name: str,
+        gig_title: str,
+        points: int,
+    ) -> int:
+        """Notify every PARENT in the family that a gig is awaiting review."""
+        from app.models.user import User, UserRole
+
+        parents = (
+            await db.scalars(
+                select(User).where(
+                    User.family_id == family_id,
+                    User.role == UserRole.PARENT,
+                    User.is_active.is_(True),
+                )
+            )
+        ).all()
+        if not parents:
+            return 0
+
+        payload = {
+            "title": "Gig awaiting approval",
+            "body": f"{child_name} submitted: {gig_title} ({points} pts)",
+            "url": "/parent/approvals",
+            "tag": "gig-pending",
+        }
+        total = 0
+        for parent in parents:
+            total += await PushService.send_to_user(db, parent.id, payload)
+        return total

--- a/backend/app/services/task_assignment_service.py
+++ b/backend/app/services/task_assignment_service.py
@@ -643,14 +643,14 @@ class TaskAssignmentService(BaseFamilyService[TaskAssignment]):
         await db.commit()
         await db.refresh(assignment)
 
-        # Fire-and-forget notification on gig submission. Failures are
-        # swallowed inside the email helper so the API response is never
-        # blocked by an upstream issue. Skip for auto-approved gigs —
-        # parents don't need a heads-up on something already credited.
+        # Fire-and-forget notifications on gig submission. Failures are
+        # swallowed so the API response is never blocked by an upstream
+        # issue. Skip for auto-approved gigs — parents don't need a
+        # heads-up on something already credited.
         if template.is_bonus and assignment.approval_status == ApprovalStatus.PENDING:
+            child = await get_user_by_id(db, user_id)
             try:
                 from app.services.email_service import EmailService
-                child = await get_user_by_id(db, user_id)
                 await EmailService.notify_parents_gig_pending(
                     db,
                     family_id=family_id,
@@ -662,6 +662,18 @@ class TaskAssignmentService(BaseFamilyService[TaskAssignment]):
             except Exception:
                 import logging
                 logging.getLogger(__name__).exception("notify_parents_gig_pending failed")
+            try:
+                from app.services.push_service import PushService
+                await PushService.fan_out_pending_gig(
+                    db,
+                    family_id=family_id,
+                    child_name=child.name,
+                    gig_title=template.title,
+                    points=template.points,
+                )
+            except Exception:
+                import logging
+                logging.getLogger(__name__).exception("fan_out_pending_gig push failed")
 
         return assignment
 

--- a/backend/app/services/task_assignment_service.py
+++ b/backend/app/services/task_assignment_service.py
@@ -613,10 +613,27 @@ class TaskAssignmentService(BaseFamilyService[TaskAssignment]):
 
             assignment.status = AssignmentStatus.COMPLETED
             assignment.completed_at = datetime.now(timezone.utc)
-            assignment.approval_status = ApprovalStatus.PENDING
             assignment.proof_text = proof_text.strip()
             if proof_image_url:
                 assignment.proof_image_url = proof_image_url
+
+            # Trust-score auto-approval: a user who has earned enough
+            # consecutive parent approvals graduates to auto-approval.
+            # Credit points immediately and skip the parent queue.
+            from app.core.config import settings
+            from app.services.points_service import PointsService
+            child = await get_user_by_id(db, user_id)
+            threshold = max(1, settings.GIG_AUTO_APPROVE_STREAK)
+            if child.gig_trust_streak >= threshold:
+                assignment.approval_status = ApprovalStatus.APPROVED
+                assignment.approved_at = datetime.now(timezone.utc)
+                assignment.approval_notes = "Auto-approved via trust streak"
+                await PointsService.award_gig_points(
+                    db, user_id, assignment.id, template.points
+                )
+                child.gig_trust_streak += 1
+            else:
+                assignment.approval_status = ApprovalStatus.PENDING
         else:
             # Mandatory path — silent, no points, no approval
             assignment.status = AssignmentStatus.COMPLETED
@@ -628,8 +645,9 @@ class TaskAssignmentService(BaseFamilyService[TaskAssignment]):
 
         # Fire-and-forget notification on gig submission. Failures are
         # swallowed inside the email helper so the API response is never
-        # blocked by an upstream issue.
-        if template.is_bonus:
+        # blocked by an upstream issue. Skip for auto-approved gigs —
+        # parents don't need a heads-up on something already credited.
+        if template.is_bonus and assignment.approval_status == ApprovalStatus.PENDING:
             try:
                 from app.services.email_service import EmailService
                 child = await get_user_by_id(db, user_id)
@@ -645,6 +663,73 @@ class TaskAssignmentService(BaseFamilyService[TaskAssignment]):
                 import logging
                 logging.getLogger(__name__).exception("notify_parents_gig_pending failed")
 
+        return assignment
+
+    # ─── Gig claim (reserve before doing) ────────────────────────────
+
+    @staticmethod
+    async def claim_gig(
+        db: AsyncSession,
+        assignment_id: UUID,
+        family_id: UUID,
+        user_id: UUID,
+    ) -> TaskAssignment:
+        """
+        Reserve a gig before working on it. Transitions PENDING → CLAIMED.
+
+        Only the assignee can claim. Mandatory rows reject (no claim
+        semantic). Gating still applies — must finish open mandatory
+        first.
+        """
+        assignment = await TaskAssignmentService.get_assignment(
+            db, assignment_id, family_id
+        )
+
+        if not assignment.template.is_bonus:
+            raise ValidationException("Only gigs can be claimed")
+
+        if assignment.assigned_to != user_id:
+            raise ForbiddenException("Only the assigned user can claim this gig")
+
+        if not assignment.can_claim:
+            raise ValidationException(
+                f"Gig cannot be claimed in status {assignment.status.value}"
+            )
+
+        if await TaskAssignmentService.has_open_mandatory_through(
+            db, user_id, family_id, assignment.assigned_date
+        ):
+            raise ForbiddenException(
+                "Finish any open mandatory tasks (today + overdue) before claiming a gig"
+            )
+
+        assignment.status = AssignmentStatus.CLAIMED
+        assignment.claimed_at = datetime.utcnow()
+        await db.commit()
+        await db.refresh(assignment)
+        return assignment
+
+    @staticmethod
+    async def unclaim_gig(
+        db: AsyncSession,
+        assignment_id: UUID,
+        family_id: UUID,
+        user_id: UUID,
+    ) -> TaskAssignment:
+        """Release a claim and return the gig to PENDING."""
+        assignment = await TaskAssignmentService.get_assignment(
+            db, assignment_id, family_id
+        )
+        if assignment.assigned_to != user_id:
+            raise ForbiddenException("Only the assignee can release a claim")
+        if assignment.status != AssignmentStatus.CLAIMED:
+            raise ValidationException(
+                f"Only CLAIMED gigs can be unclaimed (current: {assignment.status.value})"
+            )
+        assignment.status = AssignmentStatus.PENDING
+        assignment.claimed_at = None
+        await db.commit()
+        await db.refresh(assignment)
         return assignment
 
     # ─── Gig approval (parent-only) ──────────────────────────────────
@@ -695,8 +780,16 @@ class TaskAssignmentService(BaseFamilyService[TaskAssignment]):
             await PointsService.award_gig_points(
                 db, assignment.assigned_to, assignment.id, assignment.template.points
             )
+            # Increment trust streak so the child graduates to
+            # auto-approval after enough consecutive approvals.
+            child = await get_user_by_id(db, assignment.assigned_to)
+            child.gig_trust_streak += 1
         else:
             assignment.approval_status = ApprovalStatus.REJECTED
+            # Reset trust streak — a rejection signals the child still
+            # needs review on subsequent gigs.
+            child = await get_user_by_id(db, assignment.assigned_to)
+            child.gig_trust_streak = 0
 
         await db.commit()
         await db.refresh(assignment)

--- a/backend/migrations/versions/2026_05_24_gig_claim_state.py
+++ b/backend/migrations/versions/2026_05_24_gig_claim_state.py
@@ -1,0 +1,37 @@
+"""gig claim state + claimed_at column
+
+Revision ID: gig_claim_v1
+Revises: gigs_intro_ack
+Create Date: 2026-05-24
+
+Adds CLAIMED to the assignment status enum and a claimed_at timestamp.
+Lets children reserve a gig before doing it. Per-user assignments
+already exist, so claim is a workflow gate rather than collision
+avoidance — once claimed the row is committed to delivering proof.
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "gig_claim_v1"
+down_revision = "gigs_intro_ack"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Postgres-side: add the enum value.
+    op.execute("ALTER TYPE assignmentstatus ADD VALUE IF NOT EXISTS 'claimed'")
+    op.add_column(
+        "task_assignments",
+        sa.Column("claimed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("task_assignments", "claimed_at")
+    # NOTE: Postgres has no DROP VALUE for enums. Downgrade leaves the
+    # 'claimed' value in place; it becomes orphan but harmless. A full
+    # downgrade would require recreating the enum type.

--- a/backend/migrations/versions/2026_05_24_gig_trust_streak.py
+++ b/backend/migrations/versions/2026_05_24_gig_trust_streak.py
@@ -1,0 +1,37 @@
+"""user gig_trust_streak counter for auto-approval
+
+Revision ID: gig_trust_v1
+Revises: gig_claim_v1
+Create Date: 2026-05-24
+
+Adds an integer counter tracking consecutive approved gigs per user.
+Once the counter hits the configured threshold (GIG_AUTO_APPROVE_STREAK,
+default 3), subsequent gigs auto-approve on completion. A parent
+rejection resets the counter to zero.
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "gig_trust_v1"
+down_revision = "gig_claim_v1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column(
+            "gig_trust_streak",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "gig_trust_streak")

--- a/backend/migrations/versions/2026_05_24_push_subscriptions.py
+++ b/backend/migrations/versions/2026_05_24_push_subscriptions.py
@@ -1,0 +1,63 @@
+"""push_subscriptions table for Web Push (VAPID)
+
+Revision ID: push_subs_v1
+Revises: gig_trust_v1
+Create Date: 2026-05-24
+
+Stores PushSubscription rows produced by the browser's PushManager so
+the backend can fan out gig-pending notifications to a parent's devices.
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+
+revision = "push_subs_v1"
+down_revision = "gig_trust_v1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "push_subscriptions",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "user_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("endpoint", sa.String(length=2048), nullable=False),
+        sa.Column("p256dh", sa.String(length=255), nullable=False),
+        sa.Column("auth", sa.String(length=255), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "last_seen_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_unique_constraint(
+        "uq_push_subscriptions_user_endpoint",
+        "push_subscriptions",
+        ["user_id", "endpoint"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "uq_push_subscriptions_user_endpoint",
+        "push_subscriptions",
+        type_="unique",
+    )
+    op.drop_table("push_subscriptions")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -66,6 +66,11 @@ pymupdf>=1.24.0
 # Scheduler
 apscheduler==3.10.4
 
+# Web Push (VAPID) for parent gig-approval notifications. pywebpush is
+# sync — call via asyncio.to_thread() to keep the gig submission path
+# non-blocking.
+pywebpush==1.14.0
+
 # Utilities
 python-dotenv==1.0.1
 email-validator==2.1.0.post1

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -74,7 +74,7 @@ async def test_engine_session():
             ("taskfrequency", ["DAILY", "WEEKLY", "MONTHLY", "ONE_TIME"]),
             ("transactiontype", ["TASK_COMPLETED", "REWARD_REDEEMED", "PARENT_ADJUSTMENT", "BONUS", "PENALTY", "TRANSFER", "GIG_APPROVED"]),
             ("rewardcategory", ["SCREEN_TIME", "TREATS", "ACTIVITIES", "PRIVILEGES", "MONEY", "TOYS"]),
-            ("assignmentstatus", ["pending", "completed", "overdue", "cancelled"]),
+            ("assignmentstatus", ["pending", "claimed", "completed", "overdue", "cancelled"]),
             ("approval_status", ["none", "pending", "approved", "rejected"]),
             ("invitationstatus", ["PENDING", "ACCEPTED", "REJECTED", "EXPIRED"]),
             ("restrictiontype", ["SCREEN_TIME", "REWARDS", "EXTRA_TASKS", "ALLOWANCE", "ACTIVITIES", "CUSTOM"]),

--- a/backend/tests/test_gig_claim.py
+++ b/backend/tests/test_gig_claim.py
@@ -1,0 +1,139 @@
+"""Tests for the gig claim/unclaim workflow."""
+from datetime import date, timedelta
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.exceptions import ForbiddenException, ValidationException
+from app.models.task_assignment import (
+    TaskAssignment,
+    AssignmentStatus,
+    ApprovalStatus,
+)
+from app.services.task_assignment_service import TaskAssignmentService
+
+
+def _week_of(d: date) -> date:
+    return d - timedelta(days=d.weekday())
+
+
+async def _make_pending(db, family, user, template, when: date | None = None):
+    when = when or date.today()
+    a = TaskAssignment(
+        id=uuid4(), template_id=template.id, assigned_to=user.id,
+        family_id=family.id, assigned_date=when, week_of=_week_of(when),
+        status=AssignmentStatus.PENDING,
+    )
+    db.add(a)
+    await db.commit()
+    await db.refresh(a)
+    return a
+
+
+@pytest.mark.asyncio
+async def test_claim_happy_path(
+    db_session: AsyncSession, test_family, test_child_user, gig_template_factory,
+):
+    gig = await gig_template_factory(family=test_family, points=20)
+    a = await _make_pending(db_session, test_family, test_child_user, gig)
+
+    result = await TaskAssignmentService.claim_gig(
+        db_session, a.id, test_family.id, test_child_user.id,
+    )
+    assert result.status == AssignmentStatus.CLAIMED
+    assert result.claimed_at is not None
+
+
+@pytest.mark.asyncio
+async def test_claim_mandatory_rejected(
+    db_session, test_family, test_child_user, mandatory_template_factory,
+):
+    mand = await mandatory_template_factory(family=test_family)
+    a = await _make_pending(db_session, test_family, test_child_user, mand)
+
+    with pytest.raises(ValidationException, match="gigs"):
+        await TaskAssignmentService.claim_gig(
+            db_session, a.id, test_family.id, test_child_user.id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_claim_blocked_by_open_mandatory(
+    db_session, test_family, test_child_user,
+    mandatory_template_factory, gig_template_factory,
+):
+    mand = await mandatory_template_factory(family=test_family)
+    gig = await gig_template_factory(family=test_family, points=20)
+    await _make_pending(db_session, test_family, test_child_user, mand)
+    gig_a = await _make_pending(db_session, test_family, test_child_user, gig)
+
+    with pytest.raises(ForbiddenException, match="mandatory"):
+        await TaskAssignmentService.claim_gig(
+            db_session, gig_a.id, test_family.id, test_child_user.id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_claim_by_non_assignee_rejected(
+    db_session, test_family, test_child_user, test_teen_user, gig_template_factory,
+):
+    gig = await gig_template_factory(family=test_family, points=20)
+    a = await _make_pending(db_session, test_family, test_child_user, gig)
+
+    with pytest.raises(ForbiddenException, match="assigned"):
+        await TaskAssignmentService.claim_gig(
+            db_session, a.id, test_family.id, test_teen_user.id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_double_claim_rejected(
+    db_session, test_family, test_child_user, gig_template_factory,
+):
+    gig = await gig_template_factory(family=test_family, points=20)
+    a = await _make_pending(db_session, test_family, test_child_user, gig)
+
+    await TaskAssignmentService.claim_gig(
+        db_session, a.id, test_family.id, test_child_user.id,
+    )
+    with pytest.raises(ValidationException, match="status"):
+        await TaskAssignmentService.claim_gig(
+            db_session, a.id, test_family.id, test_child_user.id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_unclaim_returns_to_pending(
+    db_session, test_family, test_child_user, gig_template_factory,
+):
+    gig = await gig_template_factory(family=test_family, points=20)
+    a = await _make_pending(db_session, test_family, test_child_user, gig)
+    await TaskAssignmentService.claim_gig(
+        db_session, a.id, test_family.id, test_child_user.id,
+    )
+
+    result = await TaskAssignmentService.unclaim_gig(
+        db_session, a.id, test_family.id, test_child_user.id,
+    )
+    assert result.status == AssignmentStatus.PENDING
+    assert result.claimed_at is None
+
+
+@pytest.mark.asyncio
+async def test_complete_works_from_claimed_state(
+    db_session, test_family, test_child_user, gig_template_factory,
+):
+    """can_complete must accept CLAIMED, not just PENDING/OVERDUE."""
+    gig = await gig_template_factory(family=test_family, points=20)
+    a = await _make_pending(db_session, test_family, test_child_user, gig)
+    await TaskAssignmentService.claim_gig(
+        db_session, a.id, test_family.id, test_child_user.id,
+    )
+
+    result = await TaskAssignmentService.complete_assignment(
+        db_session, a.id, test_family.id, test_child_user.id,
+        proof_text="finished the claimed gig",
+    )
+    assert result.status == AssignmentStatus.COMPLETED
+    assert result.approval_status == ApprovalStatus.PENDING

--- a/backend/tests/test_gig_trust_streak.py
+++ b/backend/tests/test_gig_trust_streak.py
@@ -1,0 +1,159 @@
+"""Tests for trust-score auto-approval of gigs."""
+from datetime import date, timedelta
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select, func
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.models.point_transaction import PointTransaction, TransactionType
+from app.models.task_assignment import (
+    TaskAssignment,
+    AssignmentStatus,
+    ApprovalStatus,
+)
+from app.services.task_assignment_service import TaskAssignmentService
+
+
+def _week_of(d: date) -> date:
+    return d - timedelta(days=d.weekday())
+
+
+async def _new_gig_assignment(db, family, user, template):
+    today = date.today()
+    a = TaskAssignment(
+        id=uuid4(), template_id=template.id, assigned_to=user.id,
+        family_id=family.id, assigned_date=today, week_of=_week_of(today),
+        status=AssignmentStatus.PENDING,
+    )
+    db.add(a)
+    await db.commit()
+    await db.refresh(a)
+    return a
+
+
+@pytest.mark.asyncio
+async def test_below_threshold_enters_pending(
+    db_session: AsyncSession, test_family, test_child_user, gig_template_factory,
+):
+    """A user with streak < threshold still requires parent approval."""
+    assert test_child_user.gig_trust_streak == 0  # default
+    gig = await gig_template_factory(family=test_family, points=25)
+    a = await _new_gig_assignment(db_session, test_family, test_child_user, gig)
+    before = test_child_user.points
+
+    result = await TaskAssignmentService.complete_assignment(
+        db_session, a.id, test_family.id, test_child_user.id,
+        proof_text="first gig",
+    )
+    await db_session.refresh(test_child_user)
+
+    assert result.approval_status == ApprovalStatus.PENDING
+    assert test_child_user.points == before  # not yet credited
+    assert test_child_user.gig_trust_streak == 0
+
+
+@pytest.mark.asyncio
+async def test_at_threshold_auto_approves(
+    db_session, test_family, test_child_user, gig_template_factory,
+):
+    """Once streak hits threshold, completion auto-approves and credits."""
+    test_child_user.gig_trust_streak = settings.GIG_AUTO_APPROVE_STREAK
+    await db_session.commit()
+
+    gig = await gig_template_factory(family=test_family, points=30)
+    a = await _new_gig_assignment(db_session, test_family, test_child_user, gig)
+    before = test_child_user.points
+
+    result = await TaskAssignmentService.complete_assignment(
+        db_session, a.id, test_family.id, test_child_user.id,
+        proof_text="auto-approved gig",
+    )
+    await db_session.refresh(test_child_user)
+
+    assert result.approval_status == ApprovalStatus.APPROVED
+    assert result.approval_notes == "Auto-approved via trust streak"
+    assert test_child_user.points == before + 30
+    assert test_child_user.gig_trust_streak == settings.GIG_AUTO_APPROVE_STREAK + 1
+
+    txn = await db_session.scalar(
+        select(PointTransaction).where(PointTransaction.user_id == test_child_user.id)
+    )
+    assert txn.type == TransactionType.GIG_APPROVED
+    assert txn.points == 30
+
+
+@pytest.mark.asyncio
+async def test_manual_approve_increments_streak(
+    db_session, test_family, test_parent_user, test_child_user, gig_template_factory,
+):
+    """Parent approval bumps the streak so the child graduates toward auto-approve."""
+    gig = await gig_template_factory(family=test_family, points=20)
+    a = await _new_gig_assignment(db_session, test_family, test_child_user, gig)
+    # Submit
+    await TaskAssignmentService.complete_assignment(
+        db_session, a.id, test_family.id, test_child_user.id,
+        proof_text="need a parent decision",
+    )
+
+    await TaskAssignmentService.approve_gig(
+        db_session, a.id, test_family.id, test_parent_user.id,
+        approve=True, notes=None,
+    )
+    await db_session.refresh(test_child_user)
+
+    assert test_child_user.gig_trust_streak == 1
+
+
+@pytest.mark.asyncio
+async def test_reject_resets_streak(
+    db_session, test_family, test_parent_user, test_child_user, gig_template_factory,
+):
+    """A parent rejection sends the streak back to zero."""
+    test_child_user.gig_trust_streak = 5
+    await db_session.commit()
+
+    gig = await gig_template_factory(family=test_family, points=20)
+    a = await _new_gig_assignment(db_session, test_family, test_child_user, gig)
+
+    # Force PENDING (otherwise streak=5 auto-approves on completion)
+    a.status = AssignmentStatus.COMPLETED
+    a.approval_status = ApprovalStatus.PENDING
+    a.proof_text = "needs review"
+    await db_session.commit()
+
+    await TaskAssignmentService.approve_gig(
+        db_session, a.id, test_family.id, test_parent_user.id,
+        approve=False, notes="not good enough",
+    )
+    await db_session.refresh(test_child_user)
+
+    assert test_child_user.gig_trust_streak == 0
+
+
+@pytest.mark.asyncio
+async def test_auto_approve_skips_pending_email(
+    db_session, test_family, test_child_user, gig_template_factory, monkeypatch,
+):
+    """Auto-approved gigs must not fire the parent-pending email."""
+    test_child_user.gig_trust_streak = settings.GIG_AUTO_APPROVE_STREAK
+    await db_session.commit()
+
+    called = []
+
+    async def fake_notify(db, **kwargs):
+        called.append(kwargs)
+
+    from app.services.email_service import EmailService
+    monkeypatch.setattr(EmailService, "notify_parents_gig_pending", fake_notify)
+
+    gig = await gig_template_factory(family=test_family, points=25)
+    a = await _new_gig_assignment(db_session, test_family, test_child_user, gig)
+
+    await TaskAssignmentService.complete_assignment(
+        db_session, a.id, test_family.id, test_child_user.id,
+        proof_text="silent auto-approve",
+    )
+
+    assert called == []

--- a/backend/tests/test_push_subscriptions.py
+++ b/backend/tests/test_push_subscriptions.py
@@ -1,0 +1,167 @@
+"""Tests for Web Push subscription endpoints + fan-out helper."""
+from datetime import date, timedelta
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.push_subscription import PushSubscription
+from app.models.task_assignment import (
+    TaskAssignment,
+    AssignmentStatus,
+    ApprovalStatus,
+)
+from app.services.push_service import PushService
+from app.services.task_assignment_service import TaskAssignmentService
+
+
+SUBSCRIBE_BODY = {
+    "endpoint": "https://fcm.googleapis.com/fcm/send/AAAA",
+    "keys": {"p256dh": "BAAA-fake-p256dh", "auth": "AAAA-fake-auth"},
+}
+
+
+@pytest.mark.asyncio
+async def test_subscribe_requires_auth(client: AsyncClient):
+    r = await client.post("/api/push/subscribe", json=SUBSCRIBE_BODY)
+    assert r.status_code in (401, 403)
+
+
+@pytest.mark.asyncio
+async def test_subscribe_stores_row(
+    client: AsyncClient, auth_headers, db_session: AsyncSession, test_parent_user,
+):
+    r = await client.post("/api/push/subscribe", json=SUBSCRIBE_BODY, headers=auth_headers)
+    assert r.status_code == 200
+    body = r.json()
+    assert body["endpoint"] == SUBSCRIBE_BODY["endpoint"]
+
+    rows = (
+        await db_session.scalars(
+            select(PushSubscription).where(
+                PushSubscription.user_id == test_parent_user.id
+            )
+        )
+    ).all()
+    assert len(rows) == 1
+    assert rows[0].endpoint == SUBSCRIBE_BODY["endpoint"]
+    assert rows[0].p256dh == SUBSCRIBE_BODY["keys"]["p256dh"]
+
+
+@pytest.mark.asyncio
+async def test_subscribe_is_idempotent(client: AsyncClient, auth_headers, db_session, test_parent_user):
+    """Same (user, endpoint) just updates keys; no duplicate row."""
+    await client.post("/api/push/subscribe", json=SUBSCRIBE_BODY, headers=auth_headers)
+    updated = {
+        "endpoint": SUBSCRIBE_BODY["endpoint"],
+        "keys": {"p256dh": "rotated-p256", "auth": "rotated-auth"},
+    }
+    r = await client.post("/api/push/subscribe", json=updated, headers=auth_headers)
+    assert r.status_code == 200
+
+    rows = (
+        await db_session.scalars(
+            select(PushSubscription).where(
+                PushSubscription.user_id == test_parent_user.id
+            )
+        )
+    ).all()
+    assert len(rows) == 1
+    assert rows[0].p256dh == "rotated-p256"
+
+
+@pytest.mark.asyncio
+async def test_unsubscribe_removes_row(client: AsyncClient, auth_headers, db_session, test_parent_user):
+    await client.post("/api/push/subscribe", json=SUBSCRIBE_BODY, headers=auth_headers)
+    r = await client.post(
+        "/api/push/unsubscribe",
+        json={"endpoint": SUBSCRIBE_BODY["endpoint"]},
+        headers=auth_headers,
+    )
+    assert r.status_code == 200
+    assert r.json()["removed"] == 1
+    count = await db_session.scalar(
+        select(PushSubscription).where(PushSubscription.user_id == test_parent_user.id)
+    )
+    assert count is None
+
+
+@pytest.mark.asyncio
+async def test_public_key_503_when_unconfigured(client: AsyncClient, auth_headers):
+    """When VAPID_PUBLIC_KEY is empty the endpoint returns 503."""
+    from app.core.config import settings
+    settings.VAPID_PUBLIC_KEY = ""
+    r = await client.get("/api/push/public-key", headers=auth_headers)
+    assert r.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_public_key_returns_when_configured(client: AsyncClient, auth_headers):
+    from app.core.config import settings
+    settings.VAPID_PUBLIC_KEY = "BTest-VAPID-public-key"
+    try:
+        r = await client.get("/api/push/public-key", headers=auth_headers)
+        assert r.status_code == 200
+        assert r.json()["public_key"] == "BTest-VAPID-public-key"
+    finally:
+        settings.VAPID_PUBLIC_KEY = ""
+
+
+@pytest.mark.asyncio
+async def test_send_to_user_noop_without_vapid(db_session, test_parent_user):
+    from app.core.config import settings
+    settings.VAPID_PRIVATE_KEY = ""
+    settings.VAPID_PUBLIC_KEY = ""
+    sent = await PushService.send_to_user(
+        db_session, test_parent_user.id, {"title": "x", "body": "y"}
+    )
+    assert sent == 0
+
+
+@pytest.mark.asyncio
+async def test_fan_out_calls_webpush_per_parent(
+    db_session, test_family, test_parent_user, test_child_user, gig_template_factory,
+):
+    """Submitting a gig should trigger PushService.fan_out_pending_gig."""
+    # Configure VAPID so send_to_user goes through the real path,
+    # but stub webpush to count calls.
+    from app.core.config import settings
+    settings.VAPID_PRIVATE_KEY = "fake-private-pem"
+    settings.VAPID_PUBLIC_KEY = "fake-public"
+
+    # Subscribe the parent
+    sub = PushSubscription(
+        user_id=test_parent_user.id,
+        endpoint="https://fcm.googleapis.com/fcm/send/PARENT-AAA",
+        p256dh="p", auth="a",
+    )
+    db_session.add(sub)
+    await db_session.commit()
+
+    today = date.today()
+    gig = await gig_template_factory(family=test_family, points=20)
+    a = TaskAssignment(
+        id=uuid4(), template_id=gig.id, assigned_to=test_child_user.id,
+        family_id=test_family.id, assigned_date=today,
+        week_of=today - timedelta(days=today.weekday()),
+        status=AssignmentStatus.PENDING,
+    )
+    db_session.add(a)
+    await db_session.commit()
+
+    with patch("app.services.push_service.webpush") as mock_webpush:
+        await TaskAssignmentService.complete_assignment(
+            db_session, a.id, test_family.id, test_child_user.id,
+            proof_text="ship it",
+        )
+        # webpush called at least once (via asyncio.to_thread)
+        assert mock_webpush.call_count >= 1
+        call_kwargs = mock_webpush.call_args.kwargs
+        assert call_kwargs["subscription_info"]["endpoint"].endswith("PARENT-AAA")
+        assert "Gig awaiting approval" in call_kwargs["data"]
+
+    settings.VAPID_PRIVATE_KEY = ""
+    settings.VAPID_PUBLIC_KEY = ""

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,0 +1,48 @@
+// Family Task Manager — service worker for Web Push.
+// Receives a payload from PushService.fan_out_pending_gig and shows a
+// notification. Clicking the notification focuses (or opens) the
+// approvals queue.
+
+self.addEventListener("install", (event) => {
+    self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+    event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener("push", (event) => {
+    let payload = { title: "Family Task Manager", body: "", url: "/parent/approvals" };
+    try {
+        if (event.data) payload = { ...payload, ...event.data.json() };
+    } catch (e) {
+        // Non-JSON payload; fall back to defaults.
+    }
+
+    const opts = {
+        body: payload.body,
+        icon: "/icon-192.png",
+        badge: "/icon-192.png",
+        tag: payload.tag || "ftm-push",
+        data: { url: payload.url },
+        // Re-notify even if a notification with the same tag exists.
+        renotify: true,
+    };
+    event.waitUntil(self.registration.showNotification(payload.title, opts));
+});
+
+self.addEventListener("notificationclick", (event) => {
+    event.notification.close();
+    const url = (event.notification.data && event.notification.data.url) || "/parent/approvals";
+    event.waitUntil(
+        self.clients.matchAll({ type: "window", includeUncontrolled: true }).then((clients) => {
+            for (const client of clients) {
+                if ("focus" in client) {
+                    client.navigate(url);
+                    return client.focus();
+                }
+            }
+            if (self.clients.openWindow) return self.clients.openWindow(url);
+        })
+    );
+});

--- a/frontend/src/components/EnablePushButton.astro
+++ b/frontend/src/components/EnablePushButton.astro
@@ -1,0 +1,86 @@
+---
+interface Props {
+    lang: string;
+}
+const { lang } = Astro.props;
+
+const L = lang === "es"
+    ? { enable: "Activar notificaciones", enabled: "Notificaciones activas", unsupported: "Notificaciones no soportadas", denied: "Permiso denegado", err: "Error" }
+    : { enable: "Enable push notifications", enabled: "Notifications enabled", unsupported: "Push not supported", denied: "Permission denied", err: "Error" };
+---
+
+<button
+    id="enable-push-btn"
+    type="button"
+    class="px-3 py-2 rounded-lg border border-brand-sky text-brand-sky-deep text-sm font-medium hover:bg-brand-sky/10 transition-colors disabled:opacity-60"
+    data-state="idle"
+>
+    {L.enable}
+</button>
+<span id="push-status" class="text-xs text-brand-ink-soft ml-2" aria-live="polite"></span>
+
+<script define:vars={{ L }}>
+    const btn = document.getElementById("enable-push-btn");
+    const status = document.getElementById("push-status");
+
+    function setStatus(msg, color = "text-brand-ink-soft") {
+        status.textContent = msg;
+        status.className = `text-xs ${color} ml-2`;
+    }
+
+    if (!("serviceWorker" in navigator) || !("PushManager" in window)) {
+        btn.disabled = true;
+        setStatus(L.unsupported, "text-red-700");
+    }
+
+    function urlBase64ToUint8Array(b64) {
+        const padding = "=".repeat((4 - (b64.length % 4)) % 4);
+        const padded = (b64 + padding).replace(/-/g, "+").replace(/_/g, "/");
+        const raw = atob(padded);
+        const arr = new Uint8Array(raw.length);
+        for (let i = 0; i < raw.length; i++) arr[i] = raw.charCodeAt(i);
+        return arr;
+    }
+
+    btn.addEventListener("click", async () => {
+        btn.disabled = true;
+        setStatus("…");
+        try {
+            const keyResp = await fetch("/api/push/public-key");
+            if (!keyResp.ok) {
+                setStatus(L.err, "text-red-700");
+                btn.disabled = false;
+                return;
+            }
+            const { public_key } = await keyResp.json();
+            const reg = await navigator.serviceWorker.register("/sw.js");
+            await navigator.serviceWorker.ready;
+            const sub = await reg.pushManager.subscribe({
+                userVisibleOnly: true,
+                applicationServerKey: urlBase64ToUint8Array(public_key),
+            });
+
+            const json = sub.toJSON();
+            const r = await fetch("/api/push/subscribe", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    endpoint: json.endpoint,
+                    keys: { p256dh: json.keys.p256dh, auth: json.keys.auth },
+                }),
+            });
+            if (r.ok) {
+                setStatus(L.enabled, "text-green-700");
+                btn.setAttribute("data-state", "enabled");
+            } else {
+                setStatus(L.err, "text-red-700");
+                btn.disabled = false;
+            }
+        } catch (e) {
+            console.error(e);
+            const msg = e?.name === "NotAllowedError" ? L.denied : L.err;
+            setStatus(msg, "text-red-700");
+            btn.disabled = false;
+        }
+    });
+</script>

--- a/frontend/src/pages/api/push/public-key.ts
+++ b/frontend/src/pages/api/push/public-key.ts
@@ -1,0 +1,31 @@
+import type { APIRoute } from "astro";
+
+const apiUrl = () =>
+    process.env.API_BASE_URL ||
+    process.env.PUBLIC_API_BASE_URL ||
+    "http://backend:8000";
+
+export const GET: APIRoute = async ({ cookies }) => {
+    const token = cookies.get("access_token")?.value;
+    if (!token) {
+        return new Response(JSON.stringify({ detail: "Unauthorized" }), {
+            status: 401,
+            headers: { "Content-Type": "application/json" },
+        });
+    }
+    try {
+        const r = await fetch(`${apiUrl()}/api/push/public-key`, {
+            headers: { Authorization: `Bearer ${token}` },
+        });
+        return new Response(await r.text(), {
+            status: r.status,
+            headers: { "Content-Type": "application/json" },
+        });
+    } catch (e) {
+        console.error("push/public-key proxy:", e);
+        return new Response(JSON.stringify({ detail: "Upstream error" }), {
+            status: 502,
+            headers: { "Content-Type": "application/json" },
+        });
+    }
+};

--- a/frontend/src/pages/api/push/subscribe.ts
+++ b/frontend/src/pages/api/push/subscribe.ts
@@ -1,0 +1,45 @@
+import type { APIRoute } from "astro";
+
+const apiUrl = () =>
+    process.env.API_BASE_URL ||
+    process.env.PUBLIC_API_BASE_URL ||
+    "http://backend:8000";
+
+export const POST: APIRoute = async ({ request, cookies }) => {
+    const token = cookies.get("access_token")?.value;
+    if (!token) {
+        return new Response(JSON.stringify({ detail: "Unauthorized" }), {
+            status: 401,
+            headers: { "Content-Type": "application/json" },
+        });
+    }
+    let body: any;
+    try {
+        body = await request.json();
+    } catch {
+        return new Response(JSON.stringify({ detail: "Invalid JSON" }), {
+            status: 400,
+            headers: { "Content-Type": "application/json" },
+        });
+    }
+    try {
+        const r = await fetch(`${apiUrl()}/api/push/subscribe`, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${token}`,
+            },
+            body: JSON.stringify(body),
+        });
+        return new Response(await r.text(), {
+            status: r.status,
+            headers: { "Content-Type": "application/json" },
+        });
+    } catch (e) {
+        console.error("push/subscribe proxy:", e);
+        return new Response(JSON.stringify({ detail: "Upstream error" }), {
+            status: 502,
+            headers: { "Content-Type": "application/json" },
+        });
+    }
+};

--- a/frontend/src/pages/parent/index.astro
+++ b/frontend/src/pages/parent/index.astro
@@ -2,6 +2,7 @@
 import Layout from "../../layouts/Layout.astro";
 import BottomNav from "../../components/BottomNav.astro";
 import GigsIntroBanner from "../../components/GigsIntroBanner.astro";
+import EnablePushButton from "../../components/EnablePushButton.astro";
 import { apiFetch } from "../../lib/api";
 import { t } from "../../lib/i18n";
 
@@ -41,6 +42,10 @@ const pendingApprovals = Array.isArray(pending) ? pending.length : 0;
         </header>
 
         <GigsIntroBanner lang={lang} show={!user.acknowledged_gigs_intro} />
+
+        <div class="px-4 mt-4 flex items-center">
+            <EnablePushButton lang={lang} />
+        </div>
 
         <main class="flex-1 px-4 py-6">
             <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">

--- a/scripts/generate-vapid-keys.py
+++ b/scripts/generate-vapid-keys.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Generate a VAPID key pair for Web Push.
+
+Usage:
+    python3 scripts/generate-vapid-keys.py
+
+Prints lines suitable for pasting into .env:
+    VAPID_PUBLIC_KEY=...
+    VAPID_PRIVATE_KEY=...
+
+The public key is also base64-url encoded (raw) for the browser
+PushManager.subscribe({applicationServerKey: ...}) call. py-vapid emits
+the private key as PEM and the public key as uncompressed point bytes;
+we re-encode to base64url as the spec demands.
+"""
+from __future__ import annotations
+
+import base64
+import sys
+
+
+def main() -> int:
+    try:
+        from py_vapid import Vapid
+    except ImportError:
+        print("py-vapid is not installed. Install with: pip install pywebpush", file=sys.stderr)
+        return 1
+
+    v = Vapid()
+    v.generate_keys()
+
+    private_pem = v.private_pem().decode("utf-8")
+    public_raw = v.public_key.public_bytes(
+        encoding=__import__("cryptography").hazmat.primitives.serialization.Encoding.X962,
+        format=__import__("cryptography").hazmat.primitives.serialization.PublicFormat.UncompressedPoint,
+    )
+    public_b64url = base64.urlsafe_b64encode(public_raw).rstrip(b"=").decode("ascii")
+
+    print("# VAPID key pair generated. Paste into .env (and keep VAPID_PRIVATE_KEY secret):")
+    print()
+    print(f"VAPID_PUBLIC_KEY={public_b64url}")
+    print()
+    print("VAPID_PRIVATE_KEY<<EOF")
+    print(private_pem.strip())
+    print("EOF")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Closes the last three "out of scope" items from `docs/superpowers/specs/2026-05-22-mandatory-vs-gigs-design.md`. Two commits:

### 1d12467 — claim/reserve + trust-score
- **Gig claim** (`POST /api/task-assignments/{id}/claim` + `/unclaim`). New `CLAIMED` value on `AssignmentStatus` + `claimed_at` column (migration `gig_claim_v1`). Flow `PENDING → CLAIMED → COMPLETED`. Mandatory rows reject claim attempts; gating still applies.
- **Trust-score auto-approval**. New `users.gig_trust_streak` int (migration `gig_trust_v1`) + `settings.GIG_AUTO_APPROVE_STREAK` (default 3). Once streak ≥ threshold, gig completion bypasses the parent queue: sets `APPROVED`, credits points, increments streak. Manual approve also bumps streak; reject resets to 0. Auto-approved gigs skip the pending email.

### 138cc13 — Web Push
- New `push_subscriptions` table + `pywebpush` dep.
- `POST /api/push/subscribe` / `unsubscribe` + `GET /api/push/public-key`.
- `PushService.fan_out_pending_gig` called from `complete_assignment` next to the existing email, guarded by `approval_status == PENDING` (silent for auto-approved).
- 410/404 endpoints pruned automatically. No-ops with a warning when `VAPID_*` env is unset (so local dev runs without setup).
- `frontend/public/sw.js` + `EnablePushButton.astro` on the parent hub.
- `scripts/generate-vapid-keys.py` one-shot helper for env setup.

## Test plan

- [x] `pytest tests/test_gig_gating.py tests/test_gig_approval.py tests/test_gig_claim.py tests/test_gig_trust_streak.py tests/test_gigs_intro_ack.py tests/test_family_timezone_update.py tests/test_push_subscriptions.py tests/test_migration_mandatory_zero.py` — 48/48 passing.
- [ ] Manual: as a child with streak=0, submit two gigs → both PENDING. Parent approves both (streak now 2). Submit a third → still PENDING. Parent approves (streak=3). Submit a fourth → auto-APPROVED, points credited, no email.
- [ ] Manual: `python3 scripts/generate-vapid-keys.py` → paste into `.env` → restart backend. As parent in Chrome, hit the new "Enable push notifications" button on `/parent` → grant permission → submit a gig from a child account → parent device pings with notification.
- [ ] Manual: reject a gig → streak resets to 0. Next gig back to PENDING.

## Out of scope (intentional)

- iOS/Safari Web Push: works on iOS 16.4+ Safari but requires the app to be installed to home screen first. Documented as a follow-up note for the deployment runbook.
- Push notifications on approve/reject: only PENDING fan-out for v1. Email already covers the parent-to-child loop.

## Operational notes for the deploy runbook

1. Generate VAPID keys once: `python3 scripts/generate-vapid-keys.py`.
2. Add `VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_CLAIM_EMAIL` to the GCP VM `.env`.
3. `./scripts/deploy-gcp.sh` (alembic runs the two new migrations + rebuilds backend with `pywebpush`).
4. Parents need to click "Enable push" once per browser/device — same UX as any browser-permission flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)