### PR TITLE
feat: Receipt Scanner v2 — one-tap UX, structured items, FX, dup-guard, a2a webhook

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -7,7 +7,13 @@
       "Bash(ssh -o BatchMode=yes 10.1.0.99 'curl -sS -o /dev/null -w \"%{http_code}\" http://localhost:3003/')",
       "Bash(nc -z -w 3 136.114.187.138 22)",
       "Bash(gcloud compute *)",
-      "Skill(code-review:code-review)"
+      "Skill(code-review:code-review)",
+      "mcp__plugin_playwright_playwright__browser_navigate",
+      "mcp__plugin_playwright_playwright__browser_fill_form",
+      "mcp__plugin_playwright_playwright__browser_snapshot",
+      "mcp__plugin_playwright_playwright__browser_evaluate",
+      "mcp__plugin_playwright_playwright__browser_network_request",
+      "mcp__plugin_playwright_playwright__browser_click"
     ],
     "deny": [
       "Bash(rm -rf /)",

--- a/.deploy.gcp.env
+++ b/.deploy.gcp.env
@@ -1,7 +1,7 @@
 GCP_ACCOUNT=info@agent-ia.mx
-GCP_PROJECT=agentia-prod-497016
+GCP_PROJECT=family-prod
 GCP_ZONE=us-central1-a
-GCP_VM=agentia-family-hub
+GCP_VM=family-app
 REMOTE_USER=jc
 REMOTE_PATH=/home/jc/family-task-manager
 COMPOSE_FILE=docker-compose.gcp.yml

--- a/.playwright-mcp/page-2026-05-26T15-45-49-195Z.yml
+++ b/.playwright-mcp/page-2026-05-26T15-45-49-195Z.yml
@@ -1,0 +1,52 @@
+- main [ref=e3]:
+  - generic [ref=e6]:
+    - generic [ref=e7]:
+      - generic [ref=e8]:
+        - heading "Manage your family" [level=2] [ref=e9]
+        - paragraph [ref=e10]: Tasks, rewards, and parental control in one place
+      - generic [ref=e11]:
+        - generic [ref=e12]:
+          - img [ref=e14]
+          - generic [ref=e16]:
+            - paragraph [ref=e17]: Task assignment
+            - paragraph [ref=e18]: Create and assign tasks with points
+        - generic [ref=e19]:
+          - img [ref=e21]
+          - generic [ref=e23]:
+            - paragraph [ref=e24]: Reward system
+            - paragraph [ref=e25]: Motivate with attractive rewards
+        - generic [ref=e26]:
+          - img [ref=e28]
+          - generic [ref=e30]:
+            - paragraph [ref=e31]: Family finances
+            - paragraph [ref=e32]: Budget and expense tracking
+    - generic [ref=e33]:
+      - generic [ref=e34]:
+        - heading "Welcome Back" [level=1] [ref=e35]
+        - paragraph [ref=e36]: Sign in to Family Task Manager
+      - generic [ref=e39]:
+        - button "Acceder con Google. Se abre en una pestaña nueva" [ref=e41] [cursor=pointer]:
+          - generic [ref=e43]:
+            - img [ref=e45]
+            - generic [ref=e52]: Acceder con Google
+        - iframe
+      - generic [ref=e57]: Or continue with email
+      - generic [ref=e58]:
+        - generic [ref=e59]:
+          - generic [ref=e60]: Email Address
+          - textbox "Email Address" [ref=e61]:
+            - /placeholder: parent@demo.com
+        - generic [ref=e62]:
+          - generic [ref=e63]: Password
+          - textbox "Password" [ref=e64]:
+            - /placeholder: ••••••••
+        - link "Forgot password?" [ref=e66] [cursor=pointer]:
+          - /url: /forgot-password
+        - button "Sign In" [ref=e67]
+      - paragraph [ref=e68]:
+        - text: Don't have an account?
+        - link "Create one" [ref=e69] [cursor=pointer]:
+          - /url: /register
+      - button "Español" [ref=e71]:
+        - img [ref=e72]
+        - text: Español

--- a/.playwright-mcp/page-2026-05-26T15-46-20-946Z.yml
+++ b/.playwright-mcp/page-2026-05-26T15-46-20-946Z.yml
@@ -1,0 +1,54 @@
+- generic [active] [ref=e74]:
+  - generic [ref=e132]:
+    - img [ref=e133]
+    - paragraph [ref=e135]: Invalid email or password
+    - button "×" [ref=e136]
+  - main [ref=e76]:
+    - generic [ref=e79]:
+      - generic [ref=e80]:
+        - generic [ref=e81]:
+          - heading "Gestiona tu familia" [level=2] [ref=e82]
+          - paragraph [ref=e83]: Tareas, recompensas y control parental en un solo lugar
+        - generic [ref=e84]:
+          - generic [ref=e85]:
+            - img [ref=e87]
+            - generic [ref=e89]:
+              - paragraph [ref=e90]: Asignación de tareas
+              - paragraph [ref=e91]: Crea y asigna tareas con puntos
+          - generic [ref=e92]:
+            - img [ref=e94]
+            - generic [ref=e96]:
+              - paragraph [ref=e97]: Sistema de recompensas
+              - paragraph [ref=e98]: Motiva con recompensas atractivas
+          - generic [ref=e99]:
+            - img [ref=e101]
+            - generic [ref=e103]:
+              - paragraph [ref=e104]: Finanzas familiares
+              - paragraph [ref=e105]: Presupuesto y control de gastos
+      - generic [ref=e106]:
+        - generic [ref=e107]:
+          - heading "Bienvenido" [level=1] [ref=e108]
+          - paragraph [ref=e109]: Iniciar sesión en Family Task Manager
+        - generic [ref=e114]: O continúa con correo
+        - generic [ref=e115]:
+          - generic [ref=e116]:
+            - generic [ref=e117]: Correo Electrónico
+            - textbox "Correo Electrónico" [ref=e118]:
+              - /placeholder: parent@demo.com
+              - text: mom@demo.com
+          - generic [ref=e119]:
+            - generic [ref=e120]: Contraseña
+            - textbox "Contraseña" [ref=e121]:
+              - /placeholder: ••••••••
+              - text: password123
+          - link "¿Olvidaste tu contraseña?" [ref=e123] [cursor=pointer]:
+            - /url: /forgot-password
+          - button "Iniciar Sesión" [ref=e124]
+        - paragraph [ref=e125]:
+          - text: ¿No tienes cuenta?
+          - link "Crear cuenta" [ref=e126] [cursor=pointer]:
+            - /url: /register
+        - button "English" [ref=e128]:
+          - img [ref=e129]
+          - text: English
+  - generic [ref=e131]: Iniciar Sesión - Family Task Manager

--- a/.playwright-mcp/page-2026-05-26T15-46-26-636Z.yml
+++ b/.playwright-mcp/page-2026-05-26T15-46-26-636Z.yml
@@ -1,0 +1,50 @@
+- generic [active] [ref=e74]:
+  - main [ref=e76]:
+    - generic [ref=e79]:
+      - generic [ref=e80]:
+        - generic [ref=e81]:
+          - heading "Gestiona tu familia" [level=2] [ref=e82]
+          - paragraph [ref=e83]: Tareas, recompensas y control parental en un solo lugar
+        - generic [ref=e84]:
+          - generic [ref=e85]:
+            - img [ref=e87]
+            - generic [ref=e89]:
+              - paragraph [ref=e90]: Asignación de tareas
+              - paragraph [ref=e91]: Crea y asigna tareas con puntos
+          - generic [ref=e92]:
+            - img [ref=e94]
+            - generic [ref=e96]:
+              - paragraph [ref=e97]: Sistema de recompensas
+              - paragraph [ref=e98]: Motiva con recompensas atractivas
+          - generic [ref=e99]:
+            - img [ref=e101]
+            - generic [ref=e103]:
+              - paragraph [ref=e104]: Finanzas familiares
+              - paragraph [ref=e105]: Presupuesto y control de gastos
+      - generic [ref=e106]:
+        - generic [ref=e107]:
+          - heading "Bienvenido" [level=1] [ref=e108]
+          - paragraph [ref=e109]: Iniciar sesión en Family Task Manager
+        - generic [ref=e114]: O continúa con correo
+        - generic [ref=e115]:
+          - generic [ref=e116]:
+            - generic [ref=e117]: Correo Electrónico
+            - textbox "Correo Electrónico" [ref=e118]:
+              - /placeholder: parent@demo.com
+              - text: mom@demo.com
+          - generic [ref=e119]:
+            - generic [ref=e120]: Contraseña
+            - textbox "Contraseña" [ref=e121]:
+              - /placeholder: ••••••••
+              - text: password123
+          - link "¿Olvidaste tu contraseña?" [ref=e123] [cursor=pointer]:
+            - /url: /forgot-password
+          - button "Iniciar Sesión" [ref=e124]
+        - paragraph [ref=e125]:
+          - text: ¿No tienes cuenta?
+          - link "Crear cuenta" [ref=e126] [cursor=pointer]:
+            - /url: /register
+        - button "English" [ref=e128]:
+          - img [ref=e129]
+          - text: English
+  - generic [ref=e131]: Iniciar Sesión - Family Task Manager

--- a/.playwright-mcp/page-2026-05-26T15-46-43-607Z.yml
+++ b/.playwright-mcp/page-2026-05-26T15-46-43-607Z.yml
@@ -1,0 +1,52 @@
+- main [ref=e3]:
+  - generic [ref=e6]:
+    - generic [ref=e7]:
+      - generic [ref=e8]:
+        - heading "Gestiona tu familia" [level=2] [ref=e9]
+        - paragraph [ref=e10]: Tareas, recompensas y control parental en un solo lugar
+      - generic [ref=e11]:
+        - generic [ref=e12]:
+          - img [ref=e14]
+          - generic [ref=e16]:
+            - paragraph [ref=e17]: Asignación de tareas
+            - paragraph [ref=e18]: Crea y asigna tareas con puntos
+        - generic [ref=e19]:
+          - img [ref=e21]
+          - generic [ref=e23]:
+            - paragraph [ref=e24]: Sistema de recompensas
+            - paragraph [ref=e25]: Motiva con recompensas atractivas
+        - generic [ref=e26]:
+          - img [ref=e28]
+          - generic [ref=e30]:
+            - paragraph [ref=e31]: Finanzas familiares
+            - paragraph [ref=e32]: Presupuesto y control de gastos
+    - generic [ref=e33]:
+      - generic [ref=e34]:
+        - heading "Bienvenido" [level=1] [ref=e35]
+        - paragraph [ref=e36]: Iniciar sesión en Family Task Manager
+      - generic [ref=e39]:
+        - button "Acceder con Google. Se abre en una pestaña nueva" [ref=e41] [cursor=pointer]:
+          - generic [ref=e43]:
+            - img [ref=e45]
+            - generic [ref=e52]: Acceder con Google
+        - iframe
+      - generic [ref=e57]: O continúa con correo
+      - generic [ref=e58]:
+        - generic [ref=e59]:
+          - generic [ref=e60]: Correo Electrónico
+          - textbox "Correo Electrónico" [ref=e61]:
+            - /placeholder: parent@demo.com
+        - generic [ref=e62]:
+          - generic [ref=e63]: Contraseña
+          - textbox "Contraseña" [ref=e64]:
+            - /placeholder: ••••••••
+        - link "¿Olvidaste tu contraseña?" [ref=e66] [cursor=pointer]:
+          - /url: /forgot-password
+        - button "Iniciar Sesión" [ref=e67]
+      - paragraph [ref=e68]:
+        - text: ¿No tienes cuenta?
+        - link "Crear cuenta" [ref=e69] [cursor=pointer]:
+          - /url: /register
+      - button "English" [ref=e71]:
+        - img [ref=e72]
+        - text: English

--- a/.playwright-mcp/page-2026-05-26T15-46-48-803Z.yml
+++ b/.playwright-mcp/page-2026-05-26T15-46-48-803Z.yml
@@ -1,0 +1,45 @@
+- generic [ref=e3]:
+  - banner [ref=e4]:
+    - generic [ref=e5]:
+      - generic [ref=e6]:
+        - paragraph [ref=e7]: Hola,
+        - heading "Sarah Johnson" [level=1] [ref=e8]
+      - generic [ref=e9]: S
+    - generic [ref=e10]:
+      - generic [ref=e11]:
+        - paragraph [ref=e12]: Mis Puntos
+        - paragraph [ref=e13]: "500"
+      - img [ref=e15]
+  - main [ref=e17]:
+    - heading "Hoy" [level=2] [ref=e20]
+    - generic [ref=e21]:
+      - img [ref=e23]
+      - paragraph [ref=e25]: No hay tareas asignadas para hoy. Pide a un padre que haga el shuffle!
+  - navigation [ref=e26]:
+    - generic [ref=e27]:
+      - link "Tareas" [ref=e28] [cursor=pointer]:
+        - /url: /dashboard
+        - img [ref=e29]
+        - generic [ref=e31]: Tareas
+      - link "Premios" [ref=e32] [cursor=pointer]:
+        - /url: /rewards
+        - img [ref=e33]
+        - generic [ref=e35]: Premios
+      - link "Perfil" [ref=e36] [cursor=pointer]:
+        - /url: /profile
+        - img [ref=e37]
+        - generic [ref=e39]: Perfil
+      - link "Budget" [ref=e40] [cursor=pointer]:
+        - /url: /budget/month
+        - img [ref=e41]
+        - generic [ref=e43]: Budget
+      - link "Gestion" [ref=e44] [cursor=pointer]:
+        - /url: /parent
+        - img [ref=e45]
+        - generic [ref=e48]: Gestion
+      - button "EN" [ref=e50]:
+        - img [ref=e51]
+        - generic [ref=e53]: EN
+      - button "Salir" [ref=e55]:
+        - img [ref=e56]
+        - generic [ref=e58]: Salir

--- a/.playwright-mcp/page-2026-05-26T15-46-50-954Z.yml
+++ b/.playwright-mcp/page-2026-05-26T15-46-50-954Z.yml
@@ -1,0 +1,97 @@
+- generic [ref=e3]:
+  - banner [ref=e4]:
+    - link "Panel de Padres" [ref=e5] [cursor=pointer]:
+      - /url: /parent
+      - img [ref=e6]
+      - text: Panel de Padres
+    - heading "Gestionar Tareas" [level=1] [ref=e8]
+    - paragraph [ref=e9]: 0 plantillas en la familia
+  - main [ref=e10]:
+    - generic [ref=e11]:
+      - heading "Shuffle Semanal" [level=2] [ref=e13]
+      - paragraph [ref=e14]: Asignar plantillas aleatoriamente a los miembros para esta semana
+      - generic [ref=e15]:
+        - button "Vista previa" [ref=e16]:
+          - img [ref=e17]
+          - text: Vista previa
+        - button "Mezclar Tareas" [ref=e21]:
+          - img [ref=e22]
+          - text: Mezclar Tareas
+    - generic [ref=e24]:
+      - heading "Crear Nueva Plantilla" [level=2] [ref=e25]
+      - generic [ref=e26]:
+        - generic [ref=e27]:
+          - generic [ref=e28]:
+            - heading "English" [level=3] [ref=e29]
+            - textbox "Titulo de la tarea" [ref=e30]
+            - textbox "Descripcion (opcional)" [ref=e31]
+          - generic [ref=e32]:
+            - heading "Español" [level=3] [ref=e33]
+            - textbox "Titulo (Espanol)" [ref=e34]
+            - textbox "Descripcion (Espanol)" [ref=e35]
+        - generic [ref=e36]:
+          - generic [ref=e37]:
+            - generic [ref=e38]: Puntos
+            - spinbutton [ref=e39]: "10"
+          - generic [ref=e40]:
+            - generic [ref=e41]: Frecuencia
+            - combobox [ref=e42]:
+              - option "Diaria" [selected]
+              - option "Cada 3 dias"
+              - option "Semanal"
+        - generic [ref=e43]:
+          - generic [ref=e44]: Tipo de Asignacion
+          - combobox [ref=e45]:
+            - option "Auto - Balance de carga (predeterminado)" [selected]
+            - option "Fija - Siempre la(s) misma(s) persona(s)"
+            - option "Rotativa - Ciclar entre personas especificas"
+        - generic [ref=e46]:
+          - generic [ref=e47]: Quien puede hacer esta tarea
+          - generic [ref=e48]:
+            - generic [ref=e49] [cursor=pointer]:
+              - checkbox "Padre/Madre" [ref=e50]
+              - generic [ref=e51]: Padre/Madre
+            - generic [ref=e52] [cursor=pointer]:
+              - checkbox "Adolescente" [ref=e53]
+              - generic [ref=e54]: Adolescente
+            - generic [ref=e55] [cursor=pointer]:
+              - checkbox "Nino" [ref=e56]
+              - generic [ref=e57]: Nino
+          - paragraph [ref=e58]: Auto solo elige miembros con el rol marcado. Deja todo en blanco para permitir a todos.
+        - generic [ref=e59]:
+          - checkbox [ref=e61]
+          - generic [ref=e63]:
+            - text: Tarea bonus
+            - paragraph [ref=e64]: Las tareas bonus se desbloquean al completar las obligatorias del dia
+        - button "Crear Plantilla" [ref=e65]
+    - generic [ref=e66]:
+      - heading "Todas las Plantillas" [level=2] [ref=e67]
+      - paragraph [ref=e69]: Sin plantillas. Crea una arriba!
+  - navigation [ref=e70]:
+    - generic [ref=e71]:
+      - link "Tareas" [ref=e72] [cursor=pointer]:
+        - /url: /dashboard
+        - img [ref=e73]
+        - generic [ref=e75]: Tareas
+      - link "Premios" [ref=e76] [cursor=pointer]:
+        - /url: /rewards
+        - img [ref=e77]
+        - generic [ref=e79]: Premios
+      - link "Perfil" [ref=e80] [cursor=pointer]:
+        - /url: /profile
+        - img [ref=e81]
+        - generic [ref=e83]: Perfil
+      - link "Budget" [ref=e84] [cursor=pointer]:
+        - /url: /budget/month
+        - img [ref=e85]
+        - generic [ref=e87]: Budget
+      - link "Gestion" [ref=e88] [cursor=pointer]:
+        - /url: /parent
+        - img [ref=e89]
+        - generic [ref=e92]: Gestion
+      - button "EN" [ref=e94]:
+        - img [ref=e95]
+        - generic [ref=e97]: EN
+      - button "Salir" [ref=e99]:
+        - img [ref=e100]
+        - generic [ref=e102]: Salir

--- a/.playwright-mcp/page-2026-05-26T15-47-38-152Z.yml
+++ b/.playwright-mcp/page-2026-05-26T15-47-38-152Z.yml
@@ -1,0 +1,97 @@
+- generic [ref=e3]:
+  - banner [ref=e4]:
+    - link "Panel de Padres" [ref=e5] [cursor=pointer]:
+      - /url: /parent
+      - img [ref=e6]
+      - text: Panel de Padres
+    - heading "Gestionar Tareas" [level=1] [ref=e8]
+    - paragraph [ref=e9]: 0 plantillas en la familia
+  - main [ref=e10]:
+    - generic [ref=e11]:
+      - heading "Shuffle Semanal" [level=2] [ref=e13]
+      - paragraph [ref=e14]: Asignar plantillas aleatoriamente a los miembros para esta semana
+      - generic [ref=e15]:
+        - button "Vista previa" [ref=e16]:
+          - img [ref=e17]
+          - text: Vista previa
+        - button "Mezclar Tareas" [ref=e21]:
+          - img [ref=e22]
+          - text: Mezclar Tareas
+    - generic [ref=e24]:
+      - heading "Crear Nueva Plantilla" [level=2] [ref=e25]
+      - generic [ref=e26]:
+        - generic [ref=e27]:
+          - generic [ref=e28]:
+            - heading "English" [level=3] [ref=e29]
+            - textbox "Titulo de la tarea" [ref=e30]
+            - textbox "Descripcion (opcional)" [ref=e31]
+          - generic [ref=e32]:
+            - heading "Español" [level=3] [ref=e33]
+            - textbox "Titulo (Espanol)" [ref=e34]
+            - textbox "Descripcion (Espanol)" [ref=e35]
+        - generic [ref=e36]:
+          - generic [ref=e37]:
+            - generic [ref=e38]: Puntos
+            - spinbutton [ref=e39]: "10"
+          - generic [ref=e40]:
+            - generic [ref=e41]: Frecuencia
+            - combobox [ref=e42]:
+              - option "Diaria" [selected]
+              - option "Cada 3 dias"
+              - option "Semanal"
+        - generic [ref=e43]:
+          - generic [ref=e44]: Tipo de Asignacion
+          - combobox [ref=e45]:
+            - option "Auto - Balance de carga (predeterminado)" [selected]
+            - option "Fija - Siempre la(s) misma(s) persona(s)"
+            - option "Rotativa - Ciclar entre personas especificas"
+        - generic [ref=e46]:
+          - generic [ref=e47]: Quien puede hacer esta tarea
+          - generic [ref=e48]:
+            - generic [ref=e49] [cursor=pointer]:
+              - checkbox "Padre/Madre" [ref=e50]
+              - generic [ref=e51]: Padre/Madre
+            - generic [ref=e52] [cursor=pointer]:
+              - checkbox "Adolescente" [ref=e53]
+              - generic [ref=e54]: Adolescente
+            - generic [ref=e55] [cursor=pointer]:
+              - checkbox "Nino" [ref=e56]
+              - generic [ref=e57]: Nino
+          - paragraph [ref=e58]: Auto solo elige miembros con el rol marcado. Deja todo en blanco para permitir a todos.
+        - generic [ref=e59]:
+          - checkbox [ref=e61]
+          - generic [ref=e63]:
+            - text: Tarea bonus
+            - paragraph [ref=e64]: Las tareas bonus se desbloquean al completar las obligatorias del dia
+        - button "Crear Plantilla" [ref=e65]
+    - generic [ref=e66]:
+      - heading "Todas las Plantillas" [level=2] [ref=e67]
+      - paragraph [ref=e69]: Sin plantillas. Crea una arriba!
+  - navigation [ref=e70]:
+    - generic [ref=e71]:
+      - link "Tareas" [ref=e72] [cursor=pointer]:
+        - /url: /dashboard
+        - img [ref=e73]
+        - generic [ref=e75]: Tareas
+      - link "Premios" [ref=e76] [cursor=pointer]:
+        - /url: /rewards
+        - img [ref=e77]
+        - generic [ref=e79]: Premios
+      - link "Perfil" [ref=e80] [cursor=pointer]:
+        - /url: /profile
+        - img [ref=e81]
+        - generic [ref=e83]: Perfil
+      - link "Budget" [ref=e84] [cursor=pointer]:
+        - /url: /budget/month
+        - img [ref=e85]
+        - generic [ref=e87]: Budget
+      - link "Gestion" [ref=e88] [cursor=pointer]:
+        - /url: /parent
+        - img [ref=e89]
+        - generic [ref=e92]: Gestion
+      - button "EN" [ref=e94]:
+        - img [ref=e95]
+        - generic [ref=e97]: EN
+      - button "Salir" [ref=e99]:
+        - img [ref=e100]
+        - generic [ref=e102]: Salir

--- a/.playwright-mcp/page-2026-05-26T15-48-09-573Z.yml
+++ b/.playwright-mcp/page-2026-05-26T15-48-09-573Z.yml
@@ -1,0 +1,60 @@
+- generic [ref=e3]:
+  - banner [ref=e4]:
+    - link "Panel de Padres" [ref=e5] [cursor=pointer]:
+      - /url: /parent
+      - img [ref=e6]
+      - text: Panel de Padres
+    - generic [ref=e8]:
+      - heading "Gestionar Tareas" [level=1] [ref=e9]
+      - button "Nueva tarea" [ref=e10]: +
+    - paragraph [ref=e11]: 0 plantillas en la familia
+  - main [ref=e12]:
+    - generic [ref=e13]:
+      - heading "Shuffle Semanal" [level=2] [ref=e15]
+      - paragraph [ref=e16]: Asignar plantillas aleatoriamente a los miembros para esta semana
+      - generic [ref=e17]:
+        - button "Vista previa" [ref=e18]:
+          - img [ref=e19]
+          - text: Vista previa
+        - button "Mezclar Tareas" [ref=e23]:
+          - img [ref=e24]
+          - text: Mezclar Tareas
+    - generic [ref=e26]:
+      - heading "Todas las Plantillas" [level=2] [ref=e27]
+      - paragraph [ref=e29]: Sin plantillas. Crea una arriba!
+  - navigation [ref=e30]:
+    - generic [ref=e31]:
+      - link "Tareas" [ref=e32] [cursor=pointer]:
+        - /url: /dashboard
+        - img [ref=e33]
+        - generic [ref=e35]: Tareas
+      - link "Premios" [ref=e36] [cursor=pointer]:
+        - /url: /rewards
+        - img [ref=e37]
+        - generic [ref=e39]: Premios
+      - link "Avisos" [ref=e40] [cursor=pointer]:
+        - /url: /notifications
+        - img [ref=e41]
+        - generic [ref=e43]: Avisos
+      - link "Chat" [ref=e44] [cursor=pointer]:
+        - /url: /chat
+        - img [ref=e45]
+        - generic [ref=e47]: Chat
+      - link "Perfil" [ref=e48] [cursor=pointer]:
+        - /url: /profile
+        - img [ref=e49]
+        - generic [ref=e51]: Perfil
+      - link "Budget" [ref=e52] [cursor=pointer]:
+        - /url: /budget/month
+        - img [ref=e53]
+        - generic [ref=e55]: Budget
+      - link "Gestion" [ref=e56] [cursor=pointer]:
+        - /url: /parent
+        - img [ref=e57]
+        - generic [ref=e60]: Gestion
+      - button "EN" [ref=e62]:
+        - img [ref=e63]
+        - generic [ref=e65]: EN
+      - button "Salir" [ref=e67]:
+        - img [ref=e68]
+        - generic [ref=e70]: Salir

--- a/.playwright-mcp/page-2026-05-26T15-48-15-699Z.yml
+++ b/.playwright-mcp/page-2026-05-26T15-48-15-699Z.yml
@@ -1,0 +1,60 @@
+- generic [ref=e3]:
+  - banner [ref=e4]:
+    - link "Panel de Padres" [ref=e5] [cursor=pointer]:
+      - /url: /parent
+      - img [ref=e6]
+      - text: Panel de Padres
+    - generic [ref=e8]:
+      - heading "Gestionar Tareas" [level=1] [ref=e9]
+      - button "Nueva tarea" [ref=e10]: +
+    - paragraph [ref=e11]: 0 plantillas en la familia
+  - main [ref=e12]:
+    - generic [ref=e13]:
+      - heading "Shuffle Semanal" [level=2] [ref=e15]
+      - paragraph [ref=e16]: Asignar plantillas aleatoriamente a los miembros para esta semana
+      - generic [ref=e17]:
+        - button "Vista previa" [ref=e18]:
+          - img [ref=e19]
+          - text: Vista previa
+        - button "Mezclar Tareas" [ref=e23]:
+          - img [ref=e24]
+          - text: Mezclar Tareas
+    - generic [ref=e26]:
+      - heading "Todas las Plantillas" [level=2] [ref=e27]
+      - paragraph [ref=e29]: Sin plantillas. Crea una arriba!
+  - navigation [ref=e30]:
+    - generic [ref=e31]:
+      - link "Tareas" [ref=e32] [cursor=pointer]:
+        - /url: /dashboard
+        - img [ref=e33]
+        - generic [ref=e35]: Tareas
+      - link "Premios" [ref=e36] [cursor=pointer]:
+        - /url: /rewards
+        - img [ref=e37]
+        - generic [ref=e39]: Premios
+      - link "Avisos" [ref=e40] [cursor=pointer]:
+        - /url: /notifications
+        - img [ref=e41]
+        - generic [ref=e43]: Avisos
+      - link "Chat" [ref=e44] [cursor=pointer]:
+        - /url: /chat
+        - img [ref=e45]
+        - generic [ref=e47]: Chat
+      - link "Perfil" [ref=e48] [cursor=pointer]:
+        - /url: /profile
+        - img [ref=e49]
+        - generic [ref=e51]: Perfil
+      - link "Budget" [ref=e52] [cursor=pointer]:
+        - /url: /budget/month
+        - img [ref=e53]
+        - generic [ref=e55]: Budget
+      - link "Gestion" [ref=e56] [cursor=pointer]:
+        - /url: /parent
+        - img [ref=e57]
+        - generic [ref=e60]: Gestion
+      - button "EN" [ref=e62]:
+        - img [ref=e63]
+        - generic [ref=e65]: EN
+      - button "Salir" [ref=e67]:
+        - img [ref=e68]
+        - generic [ref=e70]: Salir

--- a/.playwright-mcp/page-2026-05-26T15-50-33-358Z.yml
+++ b/.playwright-mcp/page-2026-05-26T15-50-33-358Z.yml
@@ -1,0 +1,76 @@
+- generic [ref=e3]:
+  - banner [ref=e4]:
+    - link "Panel de Padres" [ref=e5] [cursor=pointer]:
+      - /url: /parent
+      - img [ref=e6]
+      - text: Panel de Padres
+    - generic [ref=e8]:
+      - heading "Gestionar Tareas" [level=1] [ref=e9]
+      - button "Nueva tarea" [ref=e10]: +
+    - paragraph [ref=e11]: 0 plantillas en la familia
+  - main [ref=e12]:
+    - generic [ref=e13]:
+      - heading "Shuffle Semanal" [level=2] [ref=e15]
+      - paragraph [ref=e16]: Asignar plantillas aleatoriamente a los miembros para esta semana
+      - generic [ref=e17]:
+        - button "Vista previa" [ref=e18]:
+          - img [ref=e19]
+          - text: Vista previa
+        - button "Mezclar Tareas" [ref=e23]:
+          - img [ref=e24]
+          - text: Mezclar Tareas
+    - generic [ref=e26]:
+      - heading "Todas las Plantillas" [level=2] [ref=e27]
+      - generic [ref=e240]:
+        - generic [ref=e241]:
+          - generic [ref=e242]:
+            - heading "Wash Dishes ES missing" [level=3] [ref=e243]:
+              - text: Wash Dishes
+              - generic "Translation missing" [ref=e244]: ES missing
+            - generic [ref=e245]: Regular
+            - generic [ref=e246]: Daily
+          - paragraph [ref=e247]: +0 pts
+        - generic [ref=e248]:
+          - button "Deactivate" [ref=e250]:
+            - img [ref=e251]
+          - link [ref=e253] [cursor=pointer]:
+            - /url: /parent/tasks/dd7ecb40-ec80-4829-84cd-55fcdee7f606/edit
+            - img [ref=e254]
+          - button [ref=e257]:
+            - img [ref=e258]
+  - navigation [ref=e30]:
+    - generic [ref=e31]:
+      - link "Tareas" [ref=e32] [cursor=pointer]:
+        - /url: /dashboard
+        - img [ref=e33]
+        - generic [ref=e35]: Tareas
+      - link "Premios" [ref=e36] [cursor=pointer]:
+        - /url: /rewards
+        - img [ref=e37]
+        - generic [ref=e39]: Premios
+      - link "Avisos" [ref=e40] [cursor=pointer]:
+        - /url: /notifications
+        - img [ref=e41]
+        - generic [ref=e43]: Avisos
+      - link "Chat" [ref=e44] [cursor=pointer]:
+        - /url: /chat
+        - img [ref=e45]
+        - generic [ref=e47]: Chat
+      - link "Perfil" [ref=e48] [cursor=pointer]:
+        - /url: /profile
+        - img [ref=e49]
+        - generic [ref=e51]: Perfil
+      - link "Budget" [ref=e52] [cursor=pointer]:
+        - /url: /budget/month
+        - img [ref=e53]
+        - generic [ref=e55]: Budget
+      - link "Gestion" [ref=e56] [cursor=pointer]:
+        - /url: /parent
+        - img [ref=e57]
+        - generic [ref=e60]: Gestion
+      - button "EN" [ref=e62]:
+        - img [ref=e63]
+        - generic [ref=e65]: EN
+      - button "Salir" [ref=e67]:
+        - img [ref=e68]
+        - generic [ref=e70]: Salir

--- a/.playwright-mcp/page-2026-05-26T20-07-39-052Z.yml
+++ b/.playwright-mcp/page-2026-05-26T20-07-39-052Z.yml
@@ -1,0 +1,52 @@
+- main [ref=e3]:
+  - generic [ref=e6]:
+    - generic [ref=e7]:
+      - generic [ref=e8]:
+        - heading "Manage your family" [level=2] [ref=e9]
+        - paragraph [ref=e10]: Tasks, rewards, and parental control in one place
+      - generic [ref=e11]:
+        - generic [ref=e12]:
+          - img [ref=e14]
+          - generic [ref=e16]:
+            - paragraph [ref=e17]: Task assignment
+            - paragraph [ref=e18]: Create and assign tasks with points
+        - generic [ref=e19]:
+          - img [ref=e21]
+          - generic [ref=e23]:
+            - paragraph [ref=e24]: Reward system
+            - paragraph [ref=e25]: Motivate with attractive rewards
+        - generic [ref=e26]:
+          - img [ref=e28]
+          - generic [ref=e30]:
+            - paragraph [ref=e31]: Family finances
+            - paragraph [ref=e32]: Budget and expense tracking
+    - generic [ref=e33]:
+      - generic [ref=e34]:
+        - heading "Welcome Back" [level=1] [ref=e35]
+        - paragraph [ref=e36]: Sign in to Family Task Manager
+      - generic [ref=e39]:
+        - button "Acceder con Google. Se abre en una pestaña nueva" [ref=e41] [cursor=pointer]:
+          - generic [ref=e43]:
+            - img [ref=e45]
+            - generic [ref=e52]: Acceder con Google
+        - iframe
+      - generic [ref=e57]: Or continue with email
+      - generic [ref=e58]:
+        - generic [ref=e59]:
+          - generic [ref=e60]: Email Address
+          - textbox "Email Address" [ref=e61]:
+            - /placeholder: parent@demo.com
+        - generic [ref=e62]:
+          - generic [ref=e63]: Password
+          - textbox "Password" [ref=e64]:
+            - /placeholder: ••••••••
+        - link "Forgot password?" [ref=e66] [cursor=pointer]:
+          - /url: /forgot-password
+        - button "Sign In" [ref=e67]
+      - paragraph [ref=e68]:
+        - text: Don't have an account?
+        - link "Create one" [ref=e69] [cursor=pointer]:
+          - /url: /register
+      - button "Español" [ref=e71]:
+        - img [ref=e72]
+        - text: Español

--- a/.playwright-mcp/page-2026-05-26T20-07-47-483Z.yml
+++ b/.playwright-mcp/page-2026-05-26T20-07-47-483Z.yml
@@ -1,0 +1,58 @@
+- generic [active] [ref=e1]:
+  - generic [ref=e75]:
+    - img [ref=e76]
+    - paragraph [ref=e78]: Invalid email or password
+    - button "×" [ref=e79]
+  - main [ref=e3]:
+    - generic [ref=e6]:
+      - generic [ref=e7]:
+        - generic [ref=e8]:
+          - heading "Manage your family" [level=2] [ref=e9]
+          - paragraph [ref=e10]: Tasks, rewards, and parental control in one place
+        - generic [ref=e11]:
+          - generic [ref=e12]:
+            - img [ref=e14]
+            - generic [ref=e16]:
+              - paragraph [ref=e17]: Task assignment
+              - paragraph [ref=e18]: Create and assign tasks with points
+          - generic [ref=e19]:
+            - img [ref=e21]
+            - generic [ref=e23]:
+              - paragraph [ref=e24]: Reward system
+              - paragraph [ref=e25]: Motivate with attractive rewards
+          - generic [ref=e26]:
+            - img [ref=e28]
+            - generic [ref=e30]:
+              - paragraph [ref=e31]: Family finances
+              - paragraph [ref=e32]: Budget and expense tracking
+      - generic [ref=e33]:
+        - generic [ref=e34]:
+          - heading "Welcome Back" [level=1] [ref=e35]
+          - paragraph [ref=e36]: Sign in to Family Task Manager
+        - iframe [ref=e74]:
+          - button "Acceder con Google. Se abre en una pestaña nueva" [ref=f3e3] [cursor=pointer]:
+            - generic [ref=f3e5]:
+              - img [ref=f3e7]
+              - generic [ref=f3e14]: Acceder con Google
+        - generic [ref=e57]: Or continue with email
+        - generic [ref=e58]:
+          - generic [ref=e59]:
+            - generic [ref=e60]: Email Address
+            - textbox "Email Address" [ref=e61]:
+              - /placeholder: parent@demo.com
+              - text: juan.mtz79@gmail.com
+          - generic [ref=e62]:
+            - generic [ref=e63]: Password
+            - textbox "Password" [ref=e64]:
+              - /placeholder: ••••••••
+              - text: password123
+          - link "Forgot password?" [ref=e66] [cursor=pointer]:
+            - /url: /forgot-password
+          - button "Sign In" [ref=e67]
+        - paragraph [ref=e68]:
+          - text: Don't have an account?
+          - link "Create one" [ref=e69] [cursor=pointer]:
+            - /url: /register
+        - button "Español" [ref=e71]:
+          - img [ref=e72]
+          - text: Español

--- a/.playwright-mcp/page-2026-05-26T20-16-56-629Z.yml
+++ b/.playwright-mcp/page-2026-05-26T20-16-56-629Z.yml
@@ -1,0 +1,52 @@
+- main [ref=e3]:
+  - generic [ref=e6]:
+    - generic [ref=e7]:
+      - generic [ref=e8]:
+        - heading "Manage your family" [level=2] [ref=e9]
+        - paragraph [ref=e10]: Tasks, rewards, and parental control in one place
+      - generic [ref=e11]:
+        - generic [ref=e12]:
+          - img [ref=e14]
+          - generic [ref=e16]:
+            - paragraph [ref=e17]: Task assignment
+            - paragraph [ref=e18]: Create and assign tasks with points
+        - generic [ref=e19]:
+          - img [ref=e21]
+          - generic [ref=e23]:
+            - paragraph [ref=e24]: Reward system
+            - paragraph [ref=e25]: Motivate with attractive rewards
+        - generic [ref=e26]:
+          - img [ref=e28]
+          - generic [ref=e30]:
+            - paragraph [ref=e31]: Family finances
+            - paragraph [ref=e32]: Budget and expense tracking
+    - generic [ref=e33]:
+      - generic [ref=e34]:
+        - heading "Welcome Back" [level=1] [ref=e35]
+        - paragraph [ref=e36]: Sign in to Family Task Manager
+      - generic [ref=e39]:
+        - button "Acceder con Google. Se abre en una pestaña nueva" [ref=e41] [cursor=pointer]:
+          - generic [ref=e43]:
+            - img [ref=e45]
+            - generic [ref=e52]: Acceder con Google
+        - iframe
+      - generic [ref=e57]: Or continue with email
+      - generic [ref=e58]:
+        - generic [ref=e59]:
+          - generic [ref=e60]: Email Address
+          - textbox "Email Address" [ref=e61]:
+            - /placeholder: parent@demo.com
+        - generic [ref=e62]:
+          - generic [ref=e63]: Password
+          - textbox "Password" [ref=e64]:
+            - /placeholder: ••••••••
+        - link "Forgot password?" [ref=e66] [cursor=pointer]:
+          - /url: /forgot-password
+        - button "Sign In" [ref=e67]
+      - paragraph [ref=e68]:
+        - text: Don't have an account?
+        - link "Create one" [ref=e69] [cursor=pointer]:
+          - /url: /register
+      - button "Español" [ref=e71]:
+        - img [ref=e72]
+        - text: Español

--- a/.playwright-mcp/page-2026-05-26T20-17-05-564Z.yml
+++ b/.playwright-mcp/page-2026-05-26T20-17-05-564Z.yml
@@ -1,0 +1,58 @@
+- generic [active] [ref=e1]:
+  - generic [ref=e75]:
+    - img [ref=e76]
+    - paragraph [ref=e78]: Invalid email or password
+    - button "×" [ref=e79]
+  - main [ref=e3]:
+    - generic [ref=e6]:
+      - generic [ref=e7]:
+        - generic [ref=e8]:
+          - heading "Manage your family" [level=2] [ref=e9]
+          - paragraph [ref=e10]: Tasks, rewards, and parental control in one place
+        - generic [ref=e11]:
+          - generic [ref=e12]:
+            - img [ref=e14]
+            - generic [ref=e16]:
+              - paragraph [ref=e17]: Task assignment
+              - paragraph [ref=e18]: Create and assign tasks with points
+          - generic [ref=e19]:
+            - img [ref=e21]
+            - generic [ref=e23]:
+              - paragraph [ref=e24]: Reward system
+              - paragraph [ref=e25]: Motivate with attractive rewards
+          - generic [ref=e26]:
+            - img [ref=e28]
+            - generic [ref=e30]:
+              - paragraph [ref=e31]: Family finances
+              - paragraph [ref=e32]: Budget and expense tracking
+      - generic [ref=e33]:
+        - generic [ref=e34]:
+          - heading "Welcome Back" [level=1] [ref=e35]
+          - paragraph [ref=e36]: Sign in to Family Task Manager
+        - iframe [ref=e74]:
+          - button "Acceder con Google. Se abre en una pestaña nueva" [ref=f4e3] [cursor=pointer]:
+            - generic [ref=f4e5]:
+              - img [ref=f4e7]
+              - generic [ref=f4e14]: Acceder con Google
+        - generic [ref=e57]: Or continue with email
+        - generic [ref=e58]:
+          - generic [ref=e59]:
+            - generic [ref=e60]: Email Address
+            - textbox "Email Address" [ref=e61]:
+              - /placeholder: parent@demo.com
+              - text: mom@demo.com
+          - generic [ref=e62]:
+            - generic [ref=e63]: Password
+            - textbox "Password" [ref=e64]:
+              - /placeholder: ••••••••
+              - text: password123
+          - link "Forgot password?" [ref=e66] [cursor=pointer]:
+            - /url: /forgot-password
+          - button "Sign In" [ref=e67]
+        - paragraph [ref=e68]:
+          - text: Don't have an account?
+          - link "Create one" [ref=e69] [cursor=pointer]:
+            - /url: /register
+        - button "Español" [ref=e71]:
+          - img [ref=e72]
+          - text: Español

--- a/.playwright-mcp/page-2026-05-26T20-17-41-954Z.yml
+++ b/.playwright-mcp/page-2026-05-26T20-17-41-954Z.yml
@@ -1,0 +1,52 @@
+- main [ref=e3]:
+  - generic [ref=e6]:
+    - generic [ref=e7]:
+      - generic [ref=e8]:
+        - heading "Gestiona tu familia" [level=2] [ref=e9]
+        - paragraph [ref=e10]: Tareas, recompensas y control parental en un solo lugar
+      - generic [ref=e11]:
+        - generic [ref=e12]:
+          - img [ref=e14]
+          - generic [ref=e16]:
+            - paragraph [ref=e17]: Asignación de tareas
+            - paragraph [ref=e18]: Crea y asigna tareas con puntos
+        - generic [ref=e19]:
+          - img [ref=e21]
+          - generic [ref=e23]:
+            - paragraph [ref=e24]: Sistema de recompensas
+            - paragraph [ref=e25]: Motiva con recompensas atractivas
+        - generic [ref=e26]:
+          - img [ref=e28]
+          - generic [ref=e30]:
+            - paragraph [ref=e31]: Finanzas familiares
+            - paragraph [ref=e32]: Presupuesto y control de gastos
+    - generic [ref=e33]:
+      - generic [ref=e34]:
+        - heading "Bienvenido" [level=1] [ref=e35]
+        - paragraph [ref=e36]: Iniciar sesión en Family Task Manager
+      - generic [ref=e39]:
+        - button "Acceder con Google. Se abre en una pestaña nueva" [ref=e41] [cursor=pointer]:
+          - generic [ref=e43]:
+            - img [ref=e45]
+            - generic [ref=e52]: Acceder con Google
+        - iframe
+      - generic [ref=e57]: O continúa con correo
+      - generic [ref=e58]:
+        - generic [ref=e59]:
+          - generic [ref=e60]: Correo Electrónico
+          - textbox "Correo Electrónico" [ref=e61]:
+            - /placeholder: parent@demo.com
+        - generic [ref=e62]:
+          - generic [ref=e63]: Contraseña
+          - textbox "Contraseña" [ref=e64]:
+            - /placeholder: ••••••••
+        - link "¿Olvidaste tu contraseña?" [ref=e66] [cursor=pointer]:
+          - /url: /forgot-password
+        - button "Iniciar Sesión" [ref=e67]
+      - paragraph [ref=e68]:
+        - text: ¿No tienes cuenta?
+        - link "Crear cuenta" [ref=e69] [cursor=pointer]:
+          - /url: /register
+      - button "English" [ref=e71]:
+        - img [ref=e72]
+        - text: English

--- a/.playwright-mcp/page-2026-05-26T20-17-47-690Z.yml
+++ b/.playwright-mcp/page-2026-05-26T20-17-47-690Z.yml
@@ -1,0 +1,60 @@
+- generic [ref=e3]:
+  - banner [ref=e4]:
+    - generic [ref=e5]:
+      - generic [ref=e6]:
+        - paragraph [ref=e7]: Hola,
+        - heading "Sarah Johnson" [level=1] [ref=e8]
+      - generic [ref=e9]: S
+    - generic [ref=e10]:
+      - generic [ref=e11]:
+        - paragraph [ref=e12]: Mis Puntos
+        - paragraph [ref=e13]: "500"
+      - img [ref=e15]
+  - region "Scope change explanation" [ref=e17]:
+    - generic [ref=e18]:
+      - img [ref=e20]
+      - generic [ref=e22]:
+        - heading "Qué cambió" [level=3] [ref=e23]
+        - paragraph [ref=e24]: Las tareas obligatorias diarias ahora dan 0 puntos — son lo esperado. Los gigs (tareas bonus) son la única forma de ganar puntos, quedan bloqueados hasta terminar todas las obligatorias (de hoy y atrasadas), y un padre revisa tu evidencia antes de acreditarlos.
+        - button "Entendido" [ref=e25]
+  - main [ref=e26]:
+    - heading "Hoy" [level=2] [ref=e29]
+    - generic [ref=e30]:
+      - img [ref=e32]
+      - paragraph [ref=e34]: No hay tareas asignadas para hoy. Pide a un padre que haga el shuffle!
+  - navigation [ref=e35]:
+    - generic [ref=e36]:
+      - link "Tareas" [ref=e37] [cursor=pointer]:
+        - /url: /dashboard
+        - img [ref=e38]
+        - generic [ref=e40]: Tareas
+      - link "Premios" [ref=e41] [cursor=pointer]:
+        - /url: /rewards
+        - img [ref=e42]
+        - generic [ref=e44]: Premios
+      - link "Avisos" [ref=e45] [cursor=pointer]:
+        - /url: /notifications
+        - img [ref=e46]
+        - generic [ref=e48]: Avisos
+      - link "Chat" [ref=e49] [cursor=pointer]:
+        - /url: /chat
+        - img [ref=e50]
+        - generic [ref=e52]: Chat
+      - link "Perfil" [ref=e53] [cursor=pointer]:
+        - /url: /profile
+        - img [ref=e54]
+        - generic [ref=e56]: Perfil
+      - link "Budget" [ref=e57] [cursor=pointer]:
+        - /url: /budget/month
+        - img [ref=e58]
+        - generic [ref=e60]: Budget
+      - link "Gestion" [ref=e61] [cursor=pointer]:
+        - /url: /parent
+        - img [ref=e62]
+        - generic [ref=e65]: Gestion
+      - button "EN" [ref=e67]:
+        - img [ref=e68]
+        - generic [ref=e70]: EN
+      - button "Salir" [ref=e72]:
+        - img [ref=e73]
+        - generic [ref=e75]: Salir

--- a/.playwright-mcp/page-2026-05-26T20-17-53-383Z.yml
+++ b/.playwright-mcp/page-2026-05-26T20-17-53-383Z.yml
@@ -1,0 +1,126 @@
+- generic [ref=e3]:
+  - banner [ref=e4]:
+    - paragraph [ref=e5]: Panel de Padres
+    - heading "Demo Family" [level=1] [ref=e6]
+    - paragraph [ref=e7]: 4 miembros
+  - region "Scope change explanation" [ref=e8]:
+    - generic [ref=e9]:
+      - img [ref=e11]
+      - generic [ref=e13]:
+        - heading "Qué cambió" [level=3] [ref=e14]
+        - paragraph [ref=e15]: Las tareas obligatorias diarias ahora dan 0 puntos — son lo esperado. Los gigs (tareas bonus) son la única forma de ganar puntos, quedan bloqueados hasta terminar todas las obligatorias (de hoy y atrasadas), y un padre revisa tu evidencia antes de acreditarlos.
+        - button "Entendido" [ref=e16]
+  - button "Activar notificaciones" [ref=e18]
+  - main [ref=e19]:
+    - generic [ref=e20]:
+      - link "Tareas Crear y gestionar tareas" [ref=e21] [cursor=pointer]:
+        - /url: /parent/tasks
+        - img [ref=e23]
+        - generic [ref=e25]:
+          - paragraph [ref=e26]: Tareas
+          - paragraph [ref=e27]: Crear y gestionar tareas
+      - link "Premios Crear y gestionar premios" [ref=e28] [cursor=pointer]:
+        - /url: /parent/rewards
+        - img [ref=e30]
+        - generic [ref=e32]:
+          - paragraph [ref=e33]: Premios
+          - paragraph [ref=e34]: Crear y gestionar premios
+      - link "Miembros Gestionar miembros de la familia" [ref=e35] [cursor=pointer]:
+        - /url: /parent/members
+        - img [ref=e37]
+        - generic [ref=e39]:
+          - paragraph [ref=e40]: Miembros
+          - paragraph [ref=e41]: Gestionar miembros de la familia
+      - link "Consecuencias Crear y resolver" [ref=e42] [cursor=pointer]:
+        - /url: /parent/consequences
+        - img [ref=e44]
+        - generic [ref=e46]:
+          - paragraph [ref=e47]: Consecuencias
+          - paragraph [ref=e48]: Crear y resolver
+      - link "Aprobaciones Revisar gigs pendientes" [ref=e49] [cursor=pointer]:
+        - /url: /parent/approvals
+        - img [ref=e51]
+        - generic [ref=e53]:
+          - paragraph [ref=e54]: Aprobaciones
+          - paragraph [ref=e55]: Revisar gigs pendientes
+      - link "Calendario Vista semanal de asignaciones" [ref=e56] [cursor=pointer]:
+        - /url: /parent/assignments
+        - img [ref=e58]
+        - generic [ref=e60]:
+          - paragraph [ref=e61]: Calendario
+          - paragraph [ref=e62]: Vista semanal de asignaciones
+      - link "Configuración Plan y suscripción" [ref=e63] [cursor=pointer]:
+        - /url: /parent/settings
+        - img [ref=e65]
+        - generic [ref=e68]:
+          - paragraph [ref=e69]: Configuración
+          - paragraph [ref=e70]: Plan y suscripción
+      - link "Finanzas Familiares Presupuesto, mandado, domingos, ahorro" [ref=e71] [cursor=pointer]:
+        - /url: /budget
+        - img [ref=e73]
+        - generic [ref=e75]:
+          - paragraph [ref=e76]: Finanzas Familiares
+          - paragraph [ref=e77]: Presupuesto, mandado, domingos, ahorro
+    - generic [ref=e78]:
+      - heading "Miembros de la Familia" [level=2] [ref=e79]
+      - generic [ref=e80]:
+        - generic [ref=e81]:
+          - generic [ref=e82]: E
+          - generic [ref=e83]:
+            - paragraph [ref=e84]: Emma Johnson
+            - paragraph [ref=e85]: child
+          - generic [ref=e86]: 150 pts
+        - generic [ref=e87]:
+          - generic [ref=e88]: L
+          - generic [ref=e89]:
+            - paragraph [ref=e90]: Lucas Johnson
+            - paragraph [ref=e91]: teen
+          - generic [ref=e92]: 280 pts
+        - generic [ref=e93]:
+          - generic [ref=e94]: M
+          - generic [ref=e95]:
+            - paragraph [ref=e96]: Mike Johnson
+            - paragraph [ref=e97]: parent
+          - generic [ref=e98]: 300 pts
+        - generic [ref=e99]:
+          - generic [ref=e100]: S
+          - generic [ref=e101]:
+            - paragraph [ref=e102]: Sarah Johnson
+            - paragraph [ref=e103]: parent
+          - generic [ref=e104]: 500 pts
+  - navigation [ref=e105]:
+    - generic [ref=e106]:
+      - link "Tareas" [ref=e107] [cursor=pointer]:
+        - /url: /dashboard
+        - img [ref=e108]
+        - generic [ref=e110]: Tareas
+      - link "Premios" [ref=e111] [cursor=pointer]:
+        - /url: /rewards
+        - img [ref=e112]
+        - generic [ref=e114]: Premios
+      - link "Avisos" [ref=e115] [cursor=pointer]:
+        - /url: /notifications
+        - img [ref=e116]
+        - generic [ref=e118]: Avisos
+      - link "Chat" [ref=e119] [cursor=pointer]:
+        - /url: /chat
+        - img [ref=e120]
+        - generic [ref=e122]: Chat
+      - link "Perfil" [ref=e123] [cursor=pointer]:
+        - /url: /profile
+        - img [ref=e124]
+        - generic [ref=e126]: Perfil
+      - link "Budget" [ref=e127] [cursor=pointer]:
+        - /url: /budget/month
+        - img [ref=e128]
+        - generic [ref=e130]: Budget
+      - link "Gestion" [ref=e131] [cursor=pointer]:
+        - /url: /parent
+        - img [ref=e132]
+        - generic [ref=e135]: Gestion
+      - button "EN" [ref=e137]:
+        - img [ref=e138]
+        - generic [ref=e140]: EN
+      - button "Salir" [ref=e142]:
+        - img [ref=e143]
+        - generic [ref=e145]: Salir

--- a/.playwright-mcp/page-2026-05-26T20-19-54-877Z.yml
+++ b/.playwright-mcp/page-2026-05-26T20-19-54-877Z.yml
@@ -1,0 +1,126 @@
+- generic [ref=e3]:
+  - banner [ref=e4]:
+    - paragraph [ref=e5]: Panel de Padres
+    - heading "Demo Family" [level=1] [ref=e6]
+    - paragraph [ref=e7]: 4 miembros
+  - region "Scope change explanation" [ref=e8]:
+    - generic [ref=e9]:
+      - img [ref=e11]
+      - generic [ref=e13]:
+        - heading "Qué cambió" [level=3] [ref=e14]
+        - paragraph [ref=e15]: Las tareas obligatorias diarias ahora dan 0 puntos — son lo esperado. Los gigs (tareas bonus) son la única forma de ganar puntos, quedan bloqueados hasta terminar todas las obligatorias (de hoy y atrasadas), y un padre revisa tu evidencia antes de acreditarlos.
+        - button "Entendido" [ref=e16]
+  - button "Activar notificaciones" [ref=e18]
+  - main [ref=e19]:
+    - generic [ref=e20]:
+      - link "Tareas Crear y gestionar tareas" [ref=e21] [cursor=pointer]:
+        - /url: /parent/tasks
+        - img [ref=e23]
+        - generic [ref=e25]:
+          - paragraph [ref=e26]: Tareas
+          - paragraph [ref=e27]: Crear y gestionar tareas
+      - link "Premios Crear y gestionar premios" [ref=e28] [cursor=pointer]:
+        - /url: /parent/rewards
+        - img [ref=e30]
+        - generic [ref=e32]:
+          - paragraph [ref=e33]: Premios
+          - paragraph [ref=e34]: Crear y gestionar premios
+      - link "Miembros Gestionar miembros de la familia" [ref=e35] [cursor=pointer]:
+        - /url: /parent/members
+        - img [ref=e37]
+        - generic [ref=e39]:
+          - paragraph [ref=e40]: Miembros
+          - paragraph [ref=e41]: Gestionar miembros de la familia
+      - link "Consecuencias Crear y resolver" [ref=e42] [cursor=pointer]:
+        - /url: /parent/consequences
+        - img [ref=e44]
+        - generic [ref=e46]:
+          - paragraph [ref=e47]: Consecuencias
+          - paragraph [ref=e48]: Crear y resolver
+      - link "Aprobaciones Revisar gigs pendientes" [ref=e49] [cursor=pointer]:
+        - /url: /parent/approvals
+        - img [ref=e51]
+        - generic [ref=e53]:
+          - paragraph [ref=e54]: Aprobaciones
+          - paragraph [ref=e55]: Revisar gigs pendientes
+      - link "Calendario Vista semanal de asignaciones" [ref=e56] [cursor=pointer]:
+        - /url: /parent/assignments
+        - img [ref=e58]
+        - generic [ref=e60]:
+          - paragraph [ref=e61]: Calendario
+          - paragraph [ref=e62]: Vista semanal de asignaciones
+      - link "Configuración Plan y suscripción" [ref=e63] [cursor=pointer]:
+        - /url: /parent/settings
+        - img [ref=e65]
+        - generic [ref=e68]:
+          - paragraph [ref=e69]: Configuración
+          - paragraph [ref=e70]: Plan y suscripción
+      - link "Finanzas Familiares Presupuesto, mandado, domingos, ahorro" [ref=e71] [cursor=pointer]:
+        - /url: /budget
+        - img [ref=e73]
+        - generic [ref=e75]:
+          - paragraph [ref=e76]: Finanzas Familiares
+          - paragraph [ref=e77]: Presupuesto, mandado, domingos, ahorro
+    - generic [ref=e78]:
+      - heading "Miembros de la Familia" [level=2] [ref=e79]
+      - generic [ref=e80]:
+        - generic [ref=e81]:
+          - generic [ref=e82]: E
+          - generic [ref=e83]:
+            - paragraph [ref=e84]: Emma Johnson
+            - paragraph [ref=e85]: child
+          - generic [ref=e86]: 150 pts
+        - generic [ref=e87]:
+          - generic [ref=e88]: L
+          - generic [ref=e89]:
+            - paragraph [ref=e90]: Lucas Johnson
+            - paragraph [ref=e91]: teen
+          - generic [ref=e92]: 280 pts
+        - generic [ref=e93]:
+          - generic [ref=e94]: M
+          - generic [ref=e95]:
+            - paragraph [ref=e96]: Mike Johnson
+            - paragraph [ref=e97]: parent
+          - generic [ref=e98]: 300 pts
+        - generic [ref=e99]:
+          - generic [ref=e100]: S
+          - generic [ref=e101]:
+            - paragraph [ref=e102]: Sarah Johnson
+            - paragraph [ref=e103]: parent
+          - generic [ref=e104]: 500 pts
+  - navigation [ref=e105]:
+    - generic [ref=e106]:
+      - link "Tareas" [ref=e107] [cursor=pointer]:
+        - /url: /dashboard
+        - img [ref=e108]
+        - generic [ref=e110]: Tareas
+      - link "Premios" [ref=e111] [cursor=pointer]:
+        - /url: /rewards
+        - img [ref=e112]
+        - generic [ref=e114]: Premios
+      - link "Avisos" [ref=e115] [cursor=pointer]:
+        - /url: /notifications
+        - img [ref=e116]
+        - generic [ref=e118]: Avisos
+      - link "Chat" [ref=e119] [cursor=pointer]:
+        - /url: /chat
+        - img [ref=e120]
+        - generic [ref=e122]: Chat
+      - link "Perfil" [ref=e123] [cursor=pointer]:
+        - /url: /profile
+        - img [ref=e124]
+        - generic [ref=e126]: Perfil
+      - link "Budget" [ref=e127] [cursor=pointer]:
+        - /url: /budget/month
+        - img [ref=e128]
+        - generic [ref=e130]: Budget
+      - link "Gestion" [ref=e131] [cursor=pointer]:
+        - /url: /parent
+        - img [ref=e132]
+        - generic [ref=e135]: Gestion
+      - button "EN" [ref=e137]:
+        - img [ref=e138]
+        - generic [ref=e140]: EN
+      - button "Salir" [ref=e142]:
+        - img [ref=e143]
+        - generic [ref=e145]: Salir

--- a/.playwright-mcp/page-2026-05-26T20-27-57-573Z.yml
+++ b/.playwright-mcp/page-2026-05-26T20-27-57-573Z.yml
@@ -1,0 +1,138 @@
+- generic [ref=e3]:
+  - banner [ref=e4]:
+    - paragraph [ref=e5]: Panel de Padres
+    - heading "Demo Family" [level=1] [ref=e6]
+    - paragraph [ref=e7]: 4 miembros
+  - region "Scope change explanation" [ref=e8]:
+    - generic [ref=e9]:
+      - img [ref=e11]
+      - generic [ref=e13]:
+        - heading "Qué cambió" [level=3] [ref=e14]
+        - paragraph [ref=e15]: Las tareas obligatorias diarias ahora dan 0 puntos — son lo esperado. Los gigs (tareas bonus) son la única forma de ganar puntos, quedan bloqueados hasta terminar todas las obligatorias (de hoy y atrasadas), y un padre revisa tu evidencia antes de acreditarlos.
+        - button "Entendido" [ref=e16]
+  - button "Activar notificaciones" [ref=e18]
+  - main [ref=e19]:
+    - generic [ref=e20]:
+      - link "Tareas Crear y gestionar tareas" [ref=e21] [cursor=pointer]:
+        - /url: /parent/tasks
+        - img [ref=e23]
+        - generic [ref=e25]:
+          - paragraph [ref=e26]: Tareas
+          - paragraph [ref=e27]: Crear y gestionar tareas
+      - link "Premios Crear y gestionar premios" [ref=e28] [cursor=pointer]:
+        - /url: /parent/rewards
+        - img [ref=e30]
+        - generic [ref=e32]:
+          - paragraph [ref=e33]: Premios
+          - paragraph [ref=e34]: Crear y gestionar premios
+      - link "Miembros Gestionar miembros de la familia" [ref=e35] [cursor=pointer]:
+        - /url: /parent/members
+        - img [ref=e37]
+        - generic [ref=e39]:
+          - paragraph [ref=e40]: Miembros
+          - paragraph [ref=e41]: Gestionar miembros de la familia
+      - link "Consecuencias Crear y resolver" [ref=e42] [cursor=pointer]:
+        - /url: /parent/consequences
+        - img [ref=e44]
+        - generic [ref=e46]:
+          - paragraph [ref=e47]: Consecuencias
+          - paragraph [ref=e48]: Crear y resolver
+      - link "Aprobaciones Revisar gigs pendientes" [ref=e49] [cursor=pointer]:
+        - /url: /parent/approvals
+        - img [ref=e51]
+        - generic [ref=e53]:
+          - paragraph [ref=e54]: Aprobaciones
+          - paragraph [ref=e55]: Revisar gigs pendientes
+      - link "Calendario Vista semanal de asignaciones" [ref=e56] [cursor=pointer]:
+        - /url: /parent/assignments
+        - img [ref=e58]
+        - generic [ref=e60]:
+          - paragraph [ref=e61]: Calendario
+          - paragraph [ref=e62]: Vista semanal de asignaciones
+      - link "Configuración Plan y suscripción" [ref=e63] [cursor=pointer]:
+        - /url: /parent/settings
+        - img [ref=e65]
+        - generic [ref=e68]:
+          - paragraph [ref=e69]: Configuración
+          - paragraph [ref=e70]: Plan y suscripción
+      - link "🤖 Jarvis Copiloto IA" [ref=e71] [cursor=pointer]:
+        - /url: /parent/frankie
+        - generic [ref=e73]: 🤖
+        - generic [ref=e74]:
+          - paragraph [ref=e75]: Jarvis
+          - paragraph [ref=e76]: Copiloto IA
+      - link "Chat Mensajes familiares" [ref=e77] [cursor=pointer]:
+        - /url: /chat
+        - img [ref=e79]
+        - generic [ref=e81]:
+          - paragraph [ref=e82]: Chat
+          - paragraph [ref=e83]: Mensajes familiares
+      - link "Finanzas Familiares Presupuesto, mandado, domingos, ahorro" [ref=e84] [cursor=pointer]:
+        - /url: /budget
+        - img [ref=e86]
+        - generic [ref=e88]:
+          - paragraph [ref=e89]: Finanzas Familiares
+          - paragraph [ref=e90]: Presupuesto, mandado, domingos, ahorro
+    - generic [ref=e91]:
+      - heading "Miembros de la Familia" [level=2] [ref=e92]
+      - generic [ref=e93]:
+        - generic [ref=e94]:
+          - generic [ref=e95]: E
+          - generic [ref=e96]:
+            - paragraph [ref=e97]: Emma Johnson
+            - paragraph [ref=e98]: child
+          - generic [ref=e99]: 150 pts
+        - generic [ref=e100]:
+          - generic [ref=e101]: L
+          - generic [ref=e102]:
+            - paragraph [ref=e103]: Lucas Johnson
+            - paragraph [ref=e104]: teen
+          - generic [ref=e105]: 280 pts
+        - generic [ref=e106]:
+          - generic [ref=e107]: M
+          - generic [ref=e108]:
+            - paragraph [ref=e109]: Mike Johnson
+            - paragraph [ref=e110]: parent
+          - generic [ref=e111]: 300 pts
+        - generic [ref=e112]:
+          - generic [ref=e113]: S
+          - generic [ref=e114]:
+            - paragraph [ref=e115]: Sarah Johnson
+            - paragraph [ref=e116]: parent
+          - generic [ref=e117]: 500 pts
+  - navigation [ref=e118]:
+    - generic [ref=e119]:
+      - link "Tareas" [ref=e120] [cursor=pointer]:
+        - /url: /dashboard
+        - img [ref=e121]
+        - generic [ref=e123]: Tareas
+      - link "Premios" [ref=e124] [cursor=pointer]:
+        - /url: /rewards
+        - img [ref=e125]
+        - generic [ref=e127]: Premios
+      - link "Avisos" [ref=e128] [cursor=pointer]:
+        - /url: /notifications
+        - img [ref=e129]
+        - generic [ref=e131]: Avisos
+      - link "Chat" [ref=e132] [cursor=pointer]:
+        - /url: /chat
+        - img [ref=e133]
+        - generic [ref=e135]: Chat
+      - link "Perfil" [ref=e136] [cursor=pointer]:
+        - /url: /profile
+        - img [ref=e137]
+        - generic [ref=e139]: Perfil
+      - link "Budget" [ref=e140] [cursor=pointer]:
+        - /url: /budget/month
+        - img [ref=e141]
+        - generic [ref=e143]: Budget
+      - link "Gestion" [ref=e144] [cursor=pointer]:
+        - /url: /parent
+        - img [ref=e145]
+        - generic [ref=e148]: Gestion
+      - button "EN" [ref=e150]:
+        - img [ref=e151]
+        - generic [ref=e153]: EN
+      - button "Salir" [ref=e155]:
+        - img [ref=e156]
+        - generic [ref=e158]: Salir

--- a/.playwright-mcp/page-2026-05-26T20-32-44-052Z.yml
+++ b/.playwright-mcp/page-2026-05-26T20-32-44-052Z.yml
@@ -1,0 +1,52 @@
+- main [ref=e3]:
+  - generic [ref=e6]:
+    - generic [ref=e7]:
+      - generic [ref=e8]:
+        - heading "Manage your family" [level=2] [ref=e9]
+        - paragraph [ref=e10]: Tasks, rewards, and parental control in one place
+      - generic [ref=e11]:
+        - generic [ref=e12]:
+          - img [ref=e14]
+          - generic [ref=e16]:
+            - paragraph [ref=e17]: Task assignment
+            - paragraph [ref=e18]: Create and assign tasks with points
+        - generic [ref=e19]:
+          - img [ref=e21]
+          - generic [ref=e23]:
+            - paragraph [ref=e24]: Reward system
+            - paragraph [ref=e25]: Motivate with attractive rewards
+        - generic [ref=e26]:
+          - img [ref=e28]
+          - generic [ref=e30]:
+            - paragraph [ref=e31]: Family finances
+            - paragraph [ref=e32]: Budget and expense tracking
+    - generic [ref=e33]:
+      - generic [ref=e34]:
+        - heading "Welcome Back" [level=1] [ref=e35]
+        - paragraph [ref=e36]: Sign in to Family Task Manager
+      - generic [ref=e39]:
+        - button "Acceder con Google. Se abre en una pestaña nueva" [ref=e41] [cursor=pointer]:
+          - generic [ref=e43]:
+            - img [ref=e45]
+            - generic [ref=e52]: Acceder con Google
+        - iframe
+      - generic [ref=e57]: Or continue with email
+      - generic [ref=e58]:
+        - generic [ref=e59]:
+          - generic [ref=e60]: Email Address
+          - textbox "Email Address" [ref=e61]:
+            - /placeholder: parent@demo.com
+        - generic [ref=e62]:
+          - generic [ref=e63]: Password
+          - textbox "Password" [ref=e64]:
+            - /placeholder: ••••••••
+        - link "Forgot password?" [ref=e66] [cursor=pointer]:
+          - /url: /forgot-password
+        - button "Sign In" [ref=e67]
+      - paragraph [ref=e68]:
+        - text: Don't have an account?
+        - link "Create one" [ref=e69] [cursor=pointer]:
+          - /url: /register
+      - button "Español" [ref=e71]:
+        - img [ref=e72]
+        - text: Español

--- a/.playwright-mcp/page-2026-05-26T21-31-27-483Z.yml
+++ b/.playwright-mcp/page-2026-05-26T21-31-27-483Z.yml
@@ -1,0 +1,54 @@
+- main [ref=e3]:
+  - generic [ref=e6]:
+    - generic [ref=e7]:
+      - generic [ref=e8]:
+        - heading "Gestiona tu familia" [level=2] [ref=e9]
+        - paragraph [ref=e10]: Tareas, recompensas y control parental en un solo lugar
+      - generic [ref=e11]:
+        - generic [ref=e12]:
+          - img [ref=e14]
+          - generic [ref=e16]:
+            - paragraph [ref=e17]: Asignación de tareas
+            - paragraph [ref=e18]: Crea y asigna tareas con puntos
+        - generic [ref=e19]:
+          - img [ref=e21]
+          - generic [ref=e23]:
+            - paragraph [ref=e24]: Sistema de recompensas
+            - paragraph [ref=e25]: Motiva con recompensas atractivas
+        - generic [ref=e26]:
+          - img [ref=e28]
+          - generic [ref=e30]:
+            - paragraph [ref=e31]: Finanzas familiares
+            - paragraph [ref=e32]: Presupuesto y control de gastos
+    - generic [ref=e33]:
+      - generic [ref=e34]:
+        - heading "Bienvenido" [level=1] [ref=e35]
+        - paragraph [ref=e36]: Iniciar sesión en Family Task Manager
+      - generic [ref=e39]:
+        - button "Acceder con Google. Se abre en una pestaña nueva" [ref=e41] [cursor=pointer]:
+          - generic [ref=e43]:
+            - img [ref=e45]
+            - generic [ref=e52]: Acceder con Google
+        - iframe
+      - generic [ref=e57]: O continúa con correo
+      - generic [ref=e58]:
+        - generic [ref=e59]:
+          - generic [ref=e60]: Correo Electrónico
+          - textbox "Correo Electrónico" [ref=e61]:
+            - /placeholder: parent@demo.com
+            - text: mom@demo.com
+        - generic [ref=e62]:
+          - generic [ref=e63]: Contraseña
+          - textbox "Contraseña" [ref=e64]:
+            - /placeholder: ••••••••
+            - text: password123
+        - link "¿Olvidaste tu contraseña?" [ref=e66] [cursor=pointer]:
+          - /url: /forgot-password
+        - button "Iniciar Sesión" [ref=e67]
+      - paragraph [ref=e68]:
+        - text: ¿No tienes cuenta?
+        - link "Crear cuenta" [ref=e69] [cursor=pointer]:
+          - /url: /register
+      - button "English" [ref=e71]:
+        - img [ref=e72]
+        - text: English

--- a/.playwright-mcp/page-2026-05-26T21-31-32-706Z.yml
+++ b/.playwright-mcp/page-2026-05-26T21-31-32-706Z.yml
@@ -1,0 +1,60 @@
+- generic [ref=e3]:
+  - banner [ref=e4]:
+    - generic [ref=e5]:
+      - generic [ref=e6]:
+        - paragraph [ref=e7]: Hola,
+        - heading "Sarah Johnson" [level=1] [ref=e8]
+      - generic [ref=e9]: S
+    - generic [ref=e10]:
+      - generic [ref=e11]:
+        - paragraph [ref=e12]: Mis Puntos
+        - paragraph [ref=e13]: "500"
+      - img [ref=e15]
+  - region "Scope change explanation" [ref=e17]:
+    - generic [ref=e18]:
+      - img [ref=e20]
+      - generic [ref=e22]:
+        - heading "Qué cambió" [level=3] [ref=e23]
+        - paragraph [ref=e24]: Las tareas obligatorias diarias ahora dan 0 puntos — son lo esperado. Los gigs (tareas bonus) son la única forma de ganar puntos, quedan bloqueados hasta terminar todas las obligatorias (de hoy y atrasadas), y un padre revisa tu evidencia antes de acreditarlos.
+        - button "Entendido" [ref=e25]
+  - main [ref=e26]:
+    - heading "Hoy" [level=2] [ref=e29]
+    - generic [ref=e30]:
+      - img [ref=e32]
+      - paragraph [ref=e34]: No hay tareas asignadas para hoy. Pide a un padre que haga el shuffle!
+  - navigation [ref=e35]:
+    - generic [ref=e36]:
+      - link "Tareas" [ref=e37] [cursor=pointer]:
+        - /url: /dashboard
+        - img [ref=e38]
+        - generic [ref=e40]: Tareas
+      - link "Premios" [ref=e41] [cursor=pointer]:
+        - /url: /rewards
+        - img [ref=e42]
+        - generic [ref=e44]: Premios
+      - link "Avisos" [ref=e45] [cursor=pointer]:
+        - /url: /notifications
+        - img [ref=e46]
+        - generic [ref=e48]: Avisos
+      - link "Chat" [ref=e49] [cursor=pointer]:
+        - /url: /chat
+        - img [ref=e50]
+        - generic [ref=e52]: Chat
+      - link "Perfil" [ref=e53] [cursor=pointer]:
+        - /url: /profile
+        - img [ref=e54]
+        - generic [ref=e56]: Perfil
+      - link "Budget" [ref=e57] [cursor=pointer]:
+        - /url: /budget/month
+        - img [ref=e58]
+        - generic [ref=e60]: Budget
+      - link "Gestion" [ref=e61] [cursor=pointer]:
+        - /url: /parent
+        - img [ref=e62]
+        - generic [ref=e65]: Gestion
+      - button "EN" [ref=e67]:
+        - img [ref=e68]
+        - generic [ref=e70]: EN
+      - button "Salir" [ref=e72]:
+        - img [ref=e73]
+        - generic [ref=e75]: Salir

--- a/.playwright-mcp/page-2026-05-26T21-31-35-397Z.yml
+++ b/.playwright-mcp/page-2026-05-26T21-31-35-397Z.yml
@@ -1,0 +1,45 @@
+- generic [ref=e3]:
+  - banner [ref=e4]:
+    - heading "💬 Chat familiar" [level=1] [ref=e5]
+    - paragraph [ref=e6]: Mensajes rápidos entre miembros
+  - main [ref=e7]:
+    - paragraph [ref=e9]: Sin mensajes aún.
+  - generic [ref=e10]:
+    - textbox "Escribe un mensaje…" [ref=e11]
+    - button "Enviar" [ref=e12]
+  - navigation [ref=e13]:
+    - generic [ref=e14]:
+      - link "Tareas" [ref=e15] [cursor=pointer]:
+        - /url: /dashboard
+        - img [ref=e16]
+        - generic [ref=e18]: Tareas
+      - link "Premios" [ref=e19] [cursor=pointer]:
+        - /url: /rewards
+        - img [ref=e20]
+        - generic [ref=e22]: Premios
+      - link "Avisos" [ref=e23] [cursor=pointer]:
+        - /url: /notifications
+        - img [ref=e24]
+        - generic [ref=e26]: Avisos
+      - link "Chat" [ref=e27] [cursor=pointer]:
+        - /url: /chat
+        - img [ref=e28]
+        - generic [ref=e30]: Chat
+      - link "Perfil" [ref=e31] [cursor=pointer]:
+        - /url: /profile
+        - img [ref=e32]
+        - generic [ref=e34]: Perfil
+      - link "Budget" [ref=e35] [cursor=pointer]:
+        - /url: /budget/month
+        - img [ref=e36]
+        - generic [ref=e38]: Budget
+      - link "Gestion" [ref=e39] [cursor=pointer]:
+        - /url: /parent
+        - img [ref=e40]
+        - generic [ref=e43]: Gestion
+      - button "EN" [ref=e45]:
+        - img [ref=e46]
+        - generic [ref=e48]: EN
+      - button "Salir" [ref=e50]:
+        - img [ref=e51]
+        - generic [ref=e53]: Salir

--- a/.playwright-mcp/page-2026-05-26T23-04-36-711Z.yml
+++ b/.playwright-mcp/page-2026-05-26T23-04-36-711Z.yml
@@ -1,0 +1,54 @@
+- main [ref=e3]:
+  - generic [ref=e6]:
+    - generic [ref=e7]:
+      - generic [ref=e8]:
+        - heading "Gestiona tu familia" [level=2] [ref=e9]
+        - paragraph [ref=e10]: Tareas, recompensas y control parental en un solo lugar
+      - generic [ref=e11]:
+        - generic [ref=e12]:
+          - img [ref=e14]
+          - generic [ref=e16]:
+            - paragraph [ref=e17]: Asignación de tareas
+            - paragraph [ref=e18]: Crea y asigna tareas con puntos
+        - generic [ref=e19]:
+          - img [ref=e21]
+          - generic [ref=e23]:
+            - paragraph [ref=e24]: Sistema de recompensas
+            - paragraph [ref=e25]: Motiva con recompensas atractivas
+        - generic [ref=e26]:
+          - img [ref=e28]
+          - generic [ref=e30]:
+            - paragraph [ref=e31]: Finanzas familiares
+            - paragraph [ref=e32]: Presupuesto y control de gastos
+    - generic [ref=e33]:
+      - generic [ref=e34]:
+        - heading "Bienvenido" [level=1] [ref=e35]
+        - paragraph [ref=e36]: Iniciar sesión en Family Task Manager
+      - generic [ref=e39]:
+        - button "Acceder con Google. Se abre en una pestaña nueva" [ref=e41] [cursor=pointer]:
+          - generic [ref=e43]:
+            - img [ref=e45]
+            - generic [ref=e52]: Acceder con Google
+        - iframe
+      - generic [ref=e57]: O continúa con correo
+      - generic [ref=e58]:
+        - generic [ref=e59]:
+          - generic [ref=e60]: Correo Electrónico
+          - textbox "Correo Electrónico" [ref=e61]:
+            - /placeholder: parent@demo.com
+            - text: mom@demo.com
+        - generic [ref=e62]:
+          - generic [ref=e63]: Contraseña
+          - textbox "Contraseña" [ref=e64]:
+            - /placeholder: ••••••••
+            - text: password123
+        - link "¿Olvidaste tu contraseña?" [ref=e66] [cursor=pointer]:
+          - /url: /forgot-password
+        - button "Iniciar Sesión" [ref=e67]
+      - paragraph [ref=e68]:
+        - text: ¿No tienes cuenta?
+        - link "Crear cuenta" [ref=e69] [cursor=pointer]:
+          - /url: /register
+      - button "English" [ref=e71]:
+        - img [ref=e72]
+        - text: English

--- a/.playwright-mcp/page-2026-05-26T23-04-43-697Z.yml
+++ b/.playwright-mcp/page-2026-05-26T23-04-43-697Z.yml
@@ -1,0 +1,60 @@
+- generic [ref=e3]:
+  - banner [ref=e4]:
+    - generic [ref=e5]:
+      - generic [ref=e6]:
+        - paragraph [ref=e7]: Hola,
+        - heading "Sarah Johnson" [level=1] [ref=e8]
+      - generic [ref=e9]: S
+    - generic [ref=e10]:
+      - generic [ref=e11]:
+        - paragraph [ref=e12]: Mis Puntos
+        - paragraph [ref=e13]: "500"
+      - img [ref=e15]
+  - region "Scope change explanation" [ref=e17]:
+    - generic [ref=e18]:
+      - img [ref=e20]
+      - generic [ref=e22]:
+        - heading "Qué cambió" [level=3] [ref=e23]
+        - paragraph [ref=e24]: Las tareas obligatorias diarias ahora dan 0 puntos — son lo esperado. Los gigs (tareas bonus) son la única forma de ganar puntos, quedan bloqueados hasta terminar todas las obligatorias (de hoy y atrasadas), y un padre revisa tu evidencia antes de acreditarlos.
+        - button "Entendido" [ref=e25]
+  - main [ref=e26]:
+    - heading "Hoy" [level=2] [ref=e29]
+    - generic [ref=e30]:
+      - img [ref=e32]
+      - paragraph [ref=e34]: No hay tareas asignadas para hoy. Pide a un padre que haga el shuffle!
+  - navigation [ref=e35]:
+    - generic [ref=e36]:
+      - link "Tareas" [ref=e37] [cursor=pointer]:
+        - /url: /dashboard
+        - img [ref=e38]
+        - generic [ref=e40]: Tareas
+      - link "Premios" [ref=e41] [cursor=pointer]:
+        - /url: /rewards
+        - img [ref=e42]
+        - generic [ref=e44]: Premios
+      - link "Avisos" [ref=e45] [cursor=pointer]:
+        - /url: /notifications
+        - img [ref=e46]
+        - generic [ref=e48]: Avisos
+      - link "Chat" [ref=e49] [cursor=pointer]:
+        - /url: /chat
+        - img [ref=e50]
+        - generic [ref=e52]: Chat
+      - link "Perfil" [ref=e53] [cursor=pointer]:
+        - /url: /profile
+        - img [ref=e54]
+        - generic [ref=e56]: Perfil
+      - link "Budget" [ref=e57] [cursor=pointer]:
+        - /url: /budget/month
+        - img [ref=e58]
+        - generic [ref=e60]: Budget
+      - link "Gestion" [ref=e61] [cursor=pointer]:
+        - /url: /parent
+        - img [ref=e62]
+        - generic [ref=e65]: Gestion
+      - button "EN" [ref=e67]:
+        - img [ref=e68]
+        - generic [ref=e70]: EN
+      - button "Salir" [ref=e72]:
+        - img [ref=e73]
+        - generic [ref=e75]: Salir

--- a/.playwright-mcp/page-2026-05-26T23-04-45-742Z.yml
+++ b/.playwright-mcp/page-2026-05-26T23-04-45-742Z.yml
@@ -1,0 +1,189 @@
+- generic [ref=e3]:
+  - generic [ref=e5]:
+    - button "Abrir menú" [ref=e6]:
+      - img [ref=e7]
+    - navigation [ref=e9]:
+      - link "Mes" [ref=e10] [cursor=pointer]:
+        - /url: /budget/
+        - img [ref=e11]
+        - text: Mes
+      - link "Movimientos" [ref=e13] [cursor=pointer]:
+        - /url: /budget/transactions
+        - img [ref=e14]
+        - text: Movimientos
+      - link "Reportes" [ref=e16] [cursor=pointer]:
+        - /url: /budget/reports
+        - img [ref=e17]
+        - text: Reportes
+    - link "Revisar recibos pendientes" [ref=e19] [cursor=pointer]:
+      - /url: /budget/receipt-drafts
+      - img [ref=e20]
+  - dialog "Navigation menu" [ref=e22]:
+    - generic [ref=e23]:
+      - generic [ref=e24]: Menú
+      - button "Cerrar menú" [ref=e25]:
+        - img [ref=e26]
+    - navigation [ref=e28]:
+      - generic [ref=e29]:
+        - heading "Principal" [level=3] [ref=e30]
+        - link "📅 Vista del mes" [ref=e31] [cursor=pointer]:
+          - /url: /budget/
+          - generic [ref=e32]: 📅
+          - text: Vista del mes
+        - link "📋 Movimientos" [ref=e33] [cursor=pointer]:
+          - /url: /budget/transactions
+          - generic [ref=e34]: 📋
+          - text: Movimientos
+        - link "📊 Reportes" [ref=e35] [cursor=pointer]:
+          - /url: /budget/reports
+          - generic [ref=e36]: 📊
+          - text: Reportes
+      - generic [ref=e37]:
+        - heading "Gestión" [level=3] [ref=e38]
+        - link "🏦 Cuentas" [ref=e39] [cursor=pointer]:
+          - /url: /budget/settings#accounts
+          - generic [ref=e40]: 🏦
+          - text: Cuentas
+        - link "🏷️ Categorías" [ref=e41] [cursor=pointer]:
+          - /url: /budget/settings#categories
+          - generic [ref=e42]: 🏷️
+          - text: Categorías
+        - link "👤 Beneficiarios" [ref=e43] [cursor=pointer]:
+          - /url: /budget/settings#payees
+          - generic [ref=e44]: 👤
+          - text: Beneficiarios
+      - generic [ref=e45]:
+        - heading "Herramientas" [level=3] [ref=e46]
+        - link "📸 Escanear ticket" [ref=e47] [cursor=pointer]:
+          - /url: /budget/scan-receipt
+          - generic [ref=e48]: 📸
+          - text: Escanear ticket
+        - link "📥 Importar CSV" [ref=e49] [cursor=pointer]:
+          - /url: /budget/import
+          - generic [ref=e50]: 📥
+          - text: Importar CSV
+        - link "🔄 Recurrentes" [ref=e51] [cursor=pointer]:
+          - /url: /budget/settings#recurring
+          - generic [ref=e52]: 🔄
+          - text: Recurrentes
+        - link "⚡ Reglas auto" [ref=e53] [cursor=pointer]:
+          - /url: /budget/settings#rules
+          - generic [ref=e54]: ⚡
+          - text: Reglas auto
+      - generic [ref=e55]:
+        - heading "Sistema" [level=3] [ref=e56]
+        - link "💾 Respaldos" [ref=e57] [cursor=pointer]:
+          - /url: /budget/settings#backups
+          - generic [ref=e58]: 💾
+          - text: Respaldos
+        - link "⚙️ Configuración" [ref=e59] [cursor=pointer]:
+          - /url: /budget/settings
+          - generic [ref=e60]: ⚙️
+          - text: Configuración
+  - banner [ref=e61]:
+    - generic [ref=e62]:
+      - generic [ref=e63]:
+        - link [ref=e64] [cursor=pointer]:
+          - /url: /budget/?year=2026&month=4
+          - img [ref=e65]
+        - generic [ref=e67]:
+          - paragraph [ref=e68]: Mayo 2026
+          - generic [ref=e69]: MES ACTUAL
+        - link [ref=e70] [cursor=pointer]:
+          - /url: /budget/?year=2026&month=6
+          - img [ref=e71]
+      - button "Listo para Asignar $0 ✓ Listo" [ref=e73] [cursor=pointer]:
+        - paragraph [ref=e74]: Listo para Asignar
+        - generic [ref=e75]:
+          - paragraph [ref=e76]: $0
+          - generic [ref=e77]: ✓ Listo
+  - generic [ref=e78]:
+    - generic [ref=e79]:
+      - generic [ref=e80]:
+        - generic [ref=e81]: Ingresos
+        - generic [ref=e82]: $0
+      - generic [ref=e83]:
+        - generic [ref=e84]: Gastado
+        - generic [ref=e85]: $0
+      - generic [ref=e86]:
+        - generic [ref=e87]: Disponible
+        - generic [ref=e88]: $0
+    - generic [ref=e90]: 0% del presupuesto usado
+  - main [ref=e91]:
+    - generic [ref=e92]:
+      - paragraph [ref=e93]: No hay categorias configuradas para este mes.
+      - link "Crear categorias" [ref=e94] [cursor=pointer]:
+        - /url: /budget/settings#categories
+  - navigation [ref=e95]:
+    - generic [ref=e96]:
+      - link "Tareas" [ref=e97] [cursor=pointer]:
+        - /url: /dashboard
+        - img [ref=e98]
+        - generic [ref=e100]: Tareas
+      - link "Premios" [ref=e101] [cursor=pointer]:
+        - /url: /rewards
+        - img [ref=e102]
+        - generic [ref=e104]: Premios
+      - link "Avisos" [ref=e105] [cursor=pointer]:
+        - /url: /notifications
+        - img [ref=e106]
+        - generic [ref=e108]: Avisos
+      - link "Chat" [ref=e109] [cursor=pointer]:
+        - /url: /chat
+        - img [ref=e110]
+        - generic [ref=e112]: Chat
+      - link "Perfil" [ref=e113] [cursor=pointer]:
+        - /url: /profile
+        - img [ref=e114]
+        - generic [ref=e116]: Perfil
+      - link "Budget" [ref=e117] [cursor=pointer]:
+        - /url: /budget/month
+        - img [ref=e118]
+        - generic [ref=e120]: Budget
+      - link "Gestion" [ref=e121] [cursor=pointer]:
+        - /url: /parent
+        - img [ref=e122]
+        - generic [ref=e125]: Gestion
+      - button "EN" [ref=e127]:
+        - img [ref=e128]
+        - generic [ref=e130]: EN
+      - button "Salir" [ref=e132]:
+        - img [ref=e133]
+        - generic [ref=e135]: Salir
+  - button "Register expense" [ref=e136]:
+    - img [ref=e137]
+  - dialog [ref=e139]:
+    - generic [ref=e143]:
+      - heading "Registrar gasto" [level=2] [ref=e144]
+      - generic [ref=e145]:
+        - generic [ref=e146]: Monto
+        - generic [ref=e147]:
+          - generic [ref=e148]: $
+          - spinbutton "Monto" [ref=e149]
+        - generic [ref=e150]:
+          - button "$50" [ref=e151]
+          - button "$100" [ref=e152]
+          - button "$200" [ref=e153]
+          - button "$500" [ref=e154]
+      - generic [ref=e155]:
+        - button "⌨️ Manual" [ref=e156]
+        - link "📸 Foto" [ref=e157] [cursor=pointer]:
+          - /url: /budget/scan-receipt
+        - link "📄 Scan" [ref=e158] [cursor=pointer]:
+          - /url: /budget/import
+      - generic [ref=e159]:
+        - generic [ref=e160]: Beneficiario
+        - textbox "Beneficiario" [ref=e162]
+      - generic [ref=e163]:
+        - generic [ref=e164]: Categoría
+        - combobox "Categoría" [ref=e165]:
+          - option "--" [selected]
+      - generic [ref=e166]:
+        - generic [ref=e167]: Cuenta
+        - combobox "Cuenta" [ref=e168]:
+          - option "--" [selected]
+      - generic [ref=e169]:
+        - generic [ref=e170]: Nota
+        - textbox "Nota" [ref=e171]:
+          - /placeholder: Nota opcional...
+      - button "Guardar gasto" [ref=e172]

--- a/.playwright-mcp/page-2026-05-26T23-04-53-715Z.yml
+++ b/.playwright-mcp/page-2026-05-26T23-04-53-715Z.yml
@@ -1,0 +1,78 @@
+- generic [ref=e173]:
+  - generic [ref=e175]:
+    - banner [ref=e176]:
+      - generic [ref=e177]:
+        - generic [ref=e178]: S
+        - generic [ref=e179]:
+          - heading "Sarah Johnson" [level=1] [ref=e180]
+          - paragraph [ref=e181]: mom@demo.com
+          - generic [ref=e182]: parent
+    - main [ref=e183]:
+      - generic [ref=e184]:
+        - heading "Resumen de Puntos" [level=2] [ref=e185]
+        - generic [ref=e186]:
+          - generic [ref=e187]:
+            - paragraph [ref=e188]: "0"
+            - paragraph [ref=e189]: Ganados
+          - generic [ref=e190]:
+            - paragraph [ref=e191]: "0"
+            - paragraph [ref=e192]: Gastados
+          - generic [ref=e193]:
+            - paragraph [ref=e194]: "500"
+            - paragraph [ref=e195]: Saldo
+      - generic [ref=e196]:
+        - heading "Idioma Preferido" [level=2] [ref=e197]
+        - generic [ref=e198]:
+          - combobox [ref=e199]:
+            - option "Ingles" [selected]
+            - option "Espanol"
+          - button "Guardar Cambios" [ref=e200]
+      - generic [ref=e201]:
+        - heading "Cambiar Contraseña" [level=2] [ref=e202]
+        - generic [ref=e203]:
+          - generic [ref=e204]:
+            - generic [ref=e205]: Contraseña Actual
+            - textbox "Contraseña Actual" [ref=e206]:
+              - /placeholder: ••••••••
+          - generic [ref=e207]:
+            - generic [ref=e208]: Nueva Contraseña
+            - textbox "Nueva Contraseña" [ref=e209]:
+              - /placeholder: ••••••••
+          - button "Actualizar Contraseña" [ref=e210]
+    - navigation [ref=e95]:
+      - generic [ref=e96]:
+        - link "Tareas" [ref=e97] [cursor=pointer]:
+          - /url: /dashboard
+          - img [ref=e98]
+          - generic [ref=e100]: Tareas
+        - link "Premios" [ref=e101] [cursor=pointer]:
+          - /url: /rewards
+          - img [ref=e102]
+          - generic [ref=e104]: Premios
+        - link "Avisos" [ref=e105] [cursor=pointer]:
+          - /url: /notifications
+          - img [ref=e106]
+          - generic [ref=e108]: Avisos
+        - link "Chat" [ref=e109] [cursor=pointer]:
+          - /url: /chat
+          - img [ref=e110]
+          - generic [ref=e112]: Chat
+        - link "Perfil" [active] [ref=e113] [cursor=pointer]:
+          - /url: /profile
+          - img [ref=e114]
+          - generic [ref=e116]: Perfil
+        - link "Budget" [ref=e117] [cursor=pointer]:
+          - /url: /budget/month
+          - img [ref=e118]
+          - generic [ref=e120]: Budget
+        - link "Gestion" [ref=e121] [cursor=pointer]:
+          - /url: /parent
+          - img [ref=e122]
+          - generic [ref=e125]: Gestion
+        - button "EN" [ref=e127]:
+          - img [ref=e128]
+          - generic [ref=e130]: EN
+        - button "Salir" [ref=e132]:
+          - img [ref=e133]
+          - generic [ref=e135]: Salir
+  - generic [ref=e211]: Perfil - Family Task Manager

--- a/.playwright-mcp/page-2026-05-27T15-12-06-351Z.yml
+++ b/.playwright-mcp/page-2026-05-27T15-12-06-351Z.yml
@@ -1,0 +1,52 @@
+- main [ref=e3]:
+  - generic [ref=e6]:
+    - generic [ref=e7]:
+      - generic [ref=e8]:
+        - heading "Manage your family" [level=2] [ref=e9]
+        - paragraph [ref=e10]: Tasks, rewards, and parental control in one place
+      - generic [ref=e11]:
+        - generic [ref=e12]:
+          - img [ref=e14]
+          - generic [ref=e16]:
+            - paragraph [ref=e17]: Task assignment
+            - paragraph [ref=e18]: Create and assign tasks with points
+        - generic [ref=e19]:
+          - img [ref=e21]
+          - generic [ref=e23]:
+            - paragraph [ref=e24]: Reward system
+            - paragraph [ref=e25]: Motivate with attractive rewards
+        - generic [ref=e26]:
+          - img [ref=e28]
+          - generic [ref=e30]:
+            - paragraph [ref=e31]: Family finances
+            - paragraph [ref=e32]: Budget and expense tracking
+    - generic [ref=e33]:
+      - generic [ref=e34]:
+        - heading "Welcome Back" [level=1] [ref=e35]
+        - paragraph [ref=e36]: Sign in to Family Task Manager
+      - generic [ref=e39]:
+        - button "Acceder con Google. Se abre en una pestaña nueva" [ref=e41] [cursor=pointer]:
+          - generic [ref=e43]:
+            - img [ref=e45]
+            - generic [ref=e52]: Acceder con Google
+        - iframe
+      - generic [ref=e57]: Or continue with email
+      - generic [ref=e58]:
+        - generic [ref=e59]:
+          - generic [ref=e60]: Email Address
+          - textbox "Email Address" [ref=e61]:
+            - /placeholder: parent@demo.com
+        - generic [ref=e62]:
+          - generic [ref=e63]: Password
+          - textbox "Password" [ref=e64]:
+            - /placeholder: ••••••••
+        - link "Forgot password?" [ref=e66] [cursor=pointer]:
+          - /url: /forgot-password
+        - button "Sign In" [ref=e67]
+      - paragraph [ref=e68]:
+        - text: Don't have an account?
+        - link "Create one" [ref=e69] [cursor=pointer]:
+          - /url: /register
+      - button "Español" [ref=e71]:
+        - img [ref=e72]
+        - text: Español

--- a/.playwright-mcp/page-2026-05-27T15-16-48-621Z.yml
+++ b/.playwright-mcp/page-2026-05-27T15-16-48-621Z.yml
@@ -1,0 +1,68 @@
+- generic [ref=e3]:
+  - banner [ref=e4]:
+    - generic [ref=e5]:
+      - generic [ref=e6]: J
+      - generic [ref=e7]:
+        - heading "Juan Carlos Martinez" [level=1] [ref=e8]
+        - paragraph [ref=e9]: juan.mtz79@gmail.com
+        - generic [ref=e10]: parent
+  - main [ref=e11]:
+    - generic [ref=e12]:
+      - heading "Points Summary" [level=2] [ref=e13]
+      - generic [ref=e14]:
+        - generic [ref=e15]:
+          - paragraph [ref=e16]: "0"
+          - paragraph [ref=e17]: Earned
+        - generic [ref=e18]:
+          - paragraph [ref=e19]: "0"
+          - paragraph [ref=e20]: Spent
+        - generic [ref=e21]:
+          - paragraph [ref=e22]: "0"
+          - paragraph [ref=e23]: Balance
+    - generic [ref=e24]:
+      - heading "Preferred Language" [level=2] [ref=e25]
+      - generic [ref=e26]:
+        - combobox [ref=e27]:
+          - option "English" [selected]
+          - option "Spanish"
+        - button "Save Changes" [ref=e28]
+    - generic [ref=e29]:
+      - heading "Change Password" [level=2] [ref=e30]
+      - generic [ref=e31]:
+        - generic [ref=e32]:
+          - generic [ref=e33]: Current Password
+          - textbox "Current Password" [ref=e34]:
+            - /placeholder: ••••••••
+        - generic [ref=e35]:
+          - generic [ref=e36]: New Password
+          - textbox "New Password" [ref=e37]:
+            - /placeholder: ••••••••
+        - button "Update Password" [ref=e38]
+  - navigation [ref=e39]:
+    - generic [ref=e40]:
+      - link "Tasks" [ref=e41] [cursor=pointer]:
+        - /url: /dashboard
+        - img [ref=e42]
+        - generic [ref=e44]: Tasks
+      - link "Rewards" [ref=e45] [cursor=pointer]:
+        - /url: /rewards
+        - img [ref=e46]
+        - generic [ref=e48]: Rewards
+      - link "Profile" [ref=e49] [cursor=pointer]:
+        - /url: /profile
+        - img [ref=e50]
+        - generic [ref=e52]: Profile
+      - link "Budget" [ref=e53] [cursor=pointer]:
+        - /url: /budget/month
+        - img [ref=e54]
+        - generic [ref=e56]: Budget
+      - link "Manage" [ref=e57] [cursor=pointer]:
+        - /url: /parent
+        - img [ref=e58]
+        - generic [ref=e61]: Manage
+      - button "ES" [ref=e63]:
+        - img [ref=e64]
+        - generic [ref=e66]: ES
+      - button "Logout" [ref=e68]:
+        - img [ref=e69]
+        - generic [ref=e71]: Logout

--- a/.playwright-mcp/page-2026-05-27T15-25-48-383Z.yml
+++ b/.playwright-mcp/page-2026-05-27T15-25-48-383Z.yml
@@ -1,0 +1,45 @@
+- generic [ref=e3]:
+  - banner [ref=e4]:
+    - generic [ref=e5]:
+      - generic [ref=e6]:
+        - paragraph [ref=e7]: Hello,
+        - heading "Juan Carlos Martinez" [level=1] [ref=e8]
+      - generic [ref=e9]: J
+    - generic [ref=e10]:
+      - generic [ref=e11]:
+        - paragraph [ref=e12]: My Points
+        - paragraph [ref=e13]: "0"
+      - img [ref=e15]
+  - main [ref=e17]:
+    - heading "Today" [level=2] [ref=e20]
+    - generic [ref=e21]:
+      - img [ref=e23]
+      - paragraph [ref=e25]: No tasks assigned for today. Ask a parent to shuffle!
+  - navigation [ref=e26]:
+    - generic [ref=e27]:
+      - link "Tasks" [ref=e28] [cursor=pointer]:
+        - /url: /dashboard
+        - img [ref=e29]
+        - generic [ref=e31]: Tasks
+      - link "Rewards" [ref=e32] [cursor=pointer]:
+        - /url: /rewards
+        - img [ref=e33]
+        - generic [ref=e35]: Rewards
+      - link "Profile" [ref=e36] [cursor=pointer]:
+        - /url: /profile
+        - img [ref=e37]
+        - generic [ref=e39]: Profile
+      - link "Budget" [ref=e40] [cursor=pointer]:
+        - /url: /budget/month
+        - img [ref=e41]
+        - generic [ref=e43]: Budget
+      - link "Manage" [ref=e44] [cursor=pointer]:
+        - /url: /parent
+        - img [ref=e45]
+        - generic [ref=e48]: Manage
+      - button "ES" [ref=e50]:
+        - img [ref=e51]
+        - generic [ref=e53]: ES
+      - button "Logout" [ref=e55]:
+        - img [ref=e56]
+        - generic [ref=e58]: Logout

--- a/.playwright-mcp/page-2026-05-27T15-26-54-935Z.yml
+++ b/.playwright-mcp/page-2026-05-27T15-26-54-935Z.yml
@@ -1,0 +1,45 @@
+- generic [ref=e3]:
+  - banner [ref=e4]:
+    - generic [ref=e5]:
+      - generic [ref=e6]:
+        - paragraph [ref=e7]: Hello,
+        - heading "Juan Carlos Martinez" [level=1] [ref=e8]
+      - generic [ref=e9]: J
+    - generic [ref=e10]:
+      - generic [ref=e11]:
+        - paragraph [ref=e12]: My Points
+        - paragraph [ref=e13]: "0"
+      - img [ref=e15]
+  - main [ref=e17]:
+    - heading "Today" [level=2] [ref=e20]
+    - generic [ref=e21]:
+      - img [ref=e23]
+      - paragraph [ref=e25]: No tasks assigned for today. Ask a parent to shuffle!
+  - navigation [ref=e26]:
+    - generic [ref=e27]:
+      - link "Tasks" [ref=e28] [cursor=pointer]:
+        - /url: /dashboard
+        - img [ref=e29]
+        - generic [ref=e31]: Tasks
+      - link "Rewards" [ref=e32] [cursor=pointer]:
+        - /url: /rewards
+        - img [ref=e33]
+        - generic [ref=e35]: Rewards
+      - link "Profile" [ref=e36] [cursor=pointer]:
+        - /url: /profile
+        - img [ref=e37]
+        - generic [ref=e39]: Profile
+      - link "Budget" [ref=e40] [cursor=pointer]:
+        - /url: /budget/month
+        - img [ref=e41]
+        - generic [ref=e43]: Budget
+      - link "Manage" [ref=e44] [cursor=pointer]:
+        - /url: /parent
+        - img [ref=e45]
+        - generic [ref=e48]: Manage
+      - button "ES" [ref=e50]:
+        - img [ref=e51]
+        - generic [ref=e53]: ES
+      - button "Logout" [ref=e55]:
+        - img [ref=e56]
+        - generic [ref=e58]: Logout

--- a/.playwright-mcp/page-2026-05-27T15-36-31-728Z.yml
+++ b/.playwright-mcp/page-2026-05-27T15-36-31-728Z.yml
@@ -1,0 +1,45 @@
+- generic [ref=e3]:
+  - banner [ref=e4]:
+    - generic [ref=e5]:
+      - generic [ref=e6]:
+        - paragraph [ref=e7]: Hello,
+        - heading "Juan Carlos Martinez" [level=1] [ref=e8]
+      - generic [ref=e9]: J
+    - generic [ref=e10]:
+      - generic [ref=e11]:
+        - paragraph [ref=e12]: My Points
+        - paragraph [ref=e13]: "0"
+      - img [ref=e15]
+  - main [ref=e17]:
+    - heading "Today" [level=2] [ref=e20]
+    - generic [ref=e21]:
+      - img [ref=e23]
+      - paragraph [ref=e25]: No tasks assigned for today. Ask a parent to shuffle!
+  - navigation [ref=e26]:
+    - generic [ref=e27]:
+      - link "Tasks" [ref=e28] [cursor=pointer]:
+        - /url: /dashboard
+        - img [ref=e29]
+        - generic [ref=e31]: Tasks
+      - link "Rewards" [ref=e32] [cursor=pointer]:
+        - /url: /rewards
+        - img [ref=e33]
+        - generic [ref=e35]: Rewards
+      - link "Profile" [ref=e36] [cursor=pointer]:
+        - /url: /profile
+        - img [ref=e37]
+        - generic [ref=e39]: Profile
+      - link "Budget" [ref=e40] [cursor=pointer]:
+        - /url: /budget/month
+        - img [ref=e41]
+        - generic [ref=e43]: Budget
+      - link "Manage" [ref=e44] [cursor=pointer]:
+        - /url: /parent
+        - img [ref=e45]
+        - generic [ref=e48]: Manage
+      - button "ES" [ref=e50]:
+        - img [ref=e51]
+        - generic [ref=e53]: ES
+      - button "Logout" [ref=e55]:
+        - img [ref=e56]
+        - generic [ref=e58]: Logout

--- a/.playwright-mcp/page-2026-05-27T15-37-01-851Z.yml
+++ b/.playwright-mcp/page-2026-05-27T15-37-01-851Z.yml
@@ -1,0 +1,45 @@
+- generic [ref=e3]:
+  - banner [ref=e4]:
+    - generic [ref=e5]:
+      - generic [ref=e6]:
+        - paragraph [ref=e7]: Hello,
+        - heading "Juan Carlos Martinez" [level=1] [ref=e8]
+      - generic [ref=e9]: J
+    - generic [ref=e10]:
+      - generic [ref=e11]:
+        - paragraph [ref=e12]: My Points
+        - paragraph [ref=e13]: "0"
+      - img [ref=e15]
+  - main [ref=e17]:
+    - heading "Today" [level=2] [ref=e20]
+    - generic [ref=e21]:
+      - img [ref=e23]
+      - paragraph [ref=e25]: No tasks assigned for today. Ask a parent to shuffle!
+  - navigation [ref=e26]:
+    - generic [ref=e27]:
+      - link "Tasks" [ref=e28] [cursor=pointer]:
+        - /url: /dashboard
+        - img [ref=e29]
+        - generic [ref=e31]: Tasks
+      - link "Rewards" [ref=e32] [cursor=pointer]:
+        - /url: /rewards
+        - img [ref=e33]
+        - generic [ref=e35]: Rewards
+      - link "Profile" [ref=e36] [cursor=pointer]:
+        - /url: /profile
+        - img [ref=e37]
+        - generic [ref=e39]: Profile
+      - link "Budget" [ref=e40] [cursor=pointer]:
+        - /url: /budget/month
+        - img [ref=e41]
+        - generic [ref=e43]: Budget
+      - link "Manage" [ref=e44] [cursor=pointer]:
+        - /url: /parent
+        - img [ref=e45]
+        - generic [ref=e48]: Manage
+      - button "ES" [ref=e50]:
+        - img [ref=e51]
+        - generic [ref=e53]: ES
+      - button "Logout" [ref=e55]:
+        - img [ref=e56]
+        - generic [ref=e58]: Logout

--- a/.playwright-mcp/page-2026-05-27T15-39-10-723Z.yml
+++ b/.playwright-mcp/page-2026-05-27T15-39-10-723Z.yml
@@ -1,0 +1,45 @@
+- generic [ref=e3]:
+  - banner [ref=e4]:
+    - generic [ref=e5]:
+      - generic [ref=e6]:
+        - paragraph [ref=e7]: Hello,
+        - heading "Juan Carlos Martinez" [level=1] [ref=e8]
+      - generic [ref=e9]: J
+    - generic [ref=e10]:
+      - generic [ref=e11]:
+        - paragraph [ref=e12]: My Points
+        - paragraph [ref=e13]: "0"
+      - img [ref=e15]
+  - main [ref=e17]:
+    - heading "Today" [level=2] [ref=e20]
+    - generic [ref=e21]:
+      - img [ref=e23]
+      - paragraph [ref=e25]: No tasks assigned for today. Ask a parent to shuffle!
+  - navigation [ref=e26]:
+    - generic [ref=e27]:
+      - link "Tasks" [ref=e28] [cursor=pointer]:
+        - /url: /dashboard
+        - img [ref=e29]
+        - generic [ref=e31]: Tasks
+      - link "Rewards" [ref=e32] [cursor=pointer]:
+        - /url: /rewards
+        - img [ref=e33]
+        - generic [ref=e35]: Rewards
+      - link "Profile" [ref=e36] [cursor=pointer]:
+        - /url: /profile
+        - img [ref=e37]
+        - generic [ref=e39]: Profile
+      - link "Budget" [ref=e40] [cursor=pointer]:
+        - /url: /budget/month
+        - img [ref=e41]
+        - generic [ref=e43]: Budget
+      - link "Manage" [ref=e44] [cursor=pointer]:
+        - /url: /parent
+        - img [ref=e45]
+        - generic [ref=e48]: Manage
+      - button "ES" [ref=e50]:
+        - img [ref=e51]
+        - generic [ref=e53]: ES
+      - button "Logout" [ref=e55]:
+        - img [ref=e56]
+        - generic [ref=e58]: Logout

--- a/.playwright-mcp/page-2026-05-27T15-42-35-798Z.yml
+++ b/.playwright-mcp/page-2026-05-27T15-42-35-798Z.yml
@@ -1,0 +1,45 @@
+- generic [ref=e3]:
+  - banner [ref=e4]:
+    - generic [ref=e5]:
+      - generic [ref=e6]:
+        - paragraph [ref=e7]: Hello,
+        - heading "Juan Carlos Martinez" [level=1] [ref=e8]
+      - generic [ref=e9]: J
+    - generic [ref=e10]:
+      - generic [ref=e11]:
+        - paragraph [ref=e12]: My Points
+        - paragraph [ref=e13]: "0"
+      - img [ref=e15]
+  - main [ref=e17]:
+    - heading "Today" [level=2] [ref=e20]
+    - generic [ref=e21]:
+      - img [ref=e23]
+      - paragraph [ref=e25]: No tasks assigned for today. Ask a parent to shuffle!
+  - navigation [ref=e26]:
+    - generic [ref=e27]:
+      - link "Tasks" [ref=e28] [cursor=pointer]:
+        - /url: /dashboard
+        - img [ref=e29]
+        - generic [ref=e31]: Tasks
+      - link "Rewards" [ref=e32] [cursor=pointer]:
+        - /url: /rewards
+        - img [ref=e33]
+        - generic [ref=e35]: Rewards
+      - link "Profile" [ref=e36] [cursor=pointer]:
+        - /url: /profile
+        - img [ref=e37]
+        - generic [ref=e39]: Profile
+      - link "Budget" [ref=e40] [cursor=pointer]:
+        - /url: /budget/month
+        - img [ref=e41]
+        - generic [ref=e43]: Budget
+      - link "Manage" [ref=e44] [cursor=pointer]:
+        - /url: /parent
+        - img [ref=e45]
+        - generic [ref=e48]: Manage
+      - button "ES" [ref=e50]:
+        - img [ref=e51]
+        - generic [ref=e53]: ES
+      - button "Logout" [ref=e55]:
+        - img [ref=e56]
+        - generic [ref=e58]: Logout

--- a/.playwright-mcp/page-2026-05-27T15-42-58-961Z.yml
+++ b/.playwright-mcp/page-2026-05-27T15-42-58-961Z.yml
@@ -1,0 +1,68 @@
+- generic [ref=e3]:
+  - banner [ref=e4]:
+    - generic [ref=e5]:
+      - generic [ref=e6]: J
+      - generic [ref=e7]:
+        - heading "Juan Carlos Martinez" [level=1] [ref=e8]
+        - paragraph [ref=e9]: juan.mtz79@gmail.com
+        - generic [ref=e10]: parent
+  - main [ref=e11]:
+    - generic [ref=e12]:
+      - heading "Points Summary" [level=2] [ref=e13]
+      - generic [ref=e14]:
+        - generic [ref=e15]:
+          - paragraph [ref=e16]: "0"
+          - paragraph [ref=e17]: Earned
+        - generic [ref=e18]:
+          - paragraph [ref=e19]: "0"
+          - paragraph [ref=e20]: Spent
+        - generic [ref=e21]:
+          - paragraph [ref=e22]: "0"
+          - paragraph [ref=e23]: Balance
+    - generic [ref=e24]:
+      - heading "Preferred Language" [level=2] [ref=e25]
+      - generic [ref=e26]:
+        - combobox [ref=e27]:
+          - option "English" [selected]
+          - option "Spanish"
+        - button "Save Changes" [ref=e28]
+    - generic [ref=e29]:
+      - heading "Change Password" [level=2] [ref=e30]
+      - generic [ref=e31]:
+        - generic [ref=e32]:
+          - generic [ref=e33]: Current Password
+          - textbox "Current Password" [ref=e34]:
+            - /placeholder: ••••••••
+        - generic [ref=e35]:
+          - generic [ref=e36]: New Password
+          - textbox "New Password" [ref=e37]:
+            - /placeholder: ••••••••
+        - button "Update Password" [ref=e38]
+  - navigation [ref=e39]:
+    - generic [ref=e40]:
+      - link "Tasks" [ref=e41] [cursor=pointer]:
+        - /url: /dashboard
+        - img [ref=e42]
+        - generic [ref=e44]: Tasks
+      - link "Rewards" [ref=e45] [cursor=pointer]:
+        - /url: /rewards
+        - img [ref=e46]
+        - generic [ref=e48]: Rewards
+      - link "Profile" [ref=e49] [cursor=pointer]:
+        - /url: /profile
+        - img [ref=e50]
+        - generic [ref=e52]: Profile
+      - link "Budget" [ref=e53] [cursor=pointer]:
+        - /url: /budget/month
+        - img [ref=e54]
+        - generic [ref=e56]: Budget
+      - link "Manage" [ref=e57] [cursor=pointer]:
+        - /url: /parent
+        - img [ref=e58]
+        - generic [ref=e61]: Manage
+      - button "ES" [ref=e63]:
+        - img [ref=e64]
+        - generic [ref=e66]: ES
+      - button "Logout" [ref=e68]:
+        - img [ref=e69]
+        - generic [ref=e71]: Logout

--- a/.playwright-mcp/page-2026-05-27T15-54-15-635Z.yml
+++ b/.playwright-mcp/page-2026-05-27T15-54-15-635Z.yml
@@ -1,0 +1,45 @@
+- generic [ref=e3]:
+  - banner [ref=e4]:
+    - generic [ref=e5]:
+      - generic [ref=e6]:
+        - paragraph [ref=e7]: Hello,
+        - heading "Juan Carlos Martinez" [level=1] [ref=e8]
+      - generic [ref=e9]: J
+    - generic [ref=e10]:
+      - generic [ref=e11]:
+        - paragraph [ref=e12]: My Points
+        - paragraph [ref=e13]: "0"
+      - img [ref=e15]
+  - main [ref=e17]:
+    - heading "Today" [level=2] [ref=e20]
+    - generic [ref=e21]:
+      - img [ref=e23]
+      - paragraph [ref=e25]: No tasks assigned for today. Ask a parent to shuffle!
+  - navigation [ref=e26]:
+    - generic [ref=e27]:
+      - link "Tasks" [ref=e28] [cursor=pointer]:
+        - /url: /dashboard
+        - img [ref=e29]
+        - generic [ref=e31]: Tasks
+      - link "Rewards" [ref=e32] [cursor=pointer]:
+        - /url: /rewards
+        - img [ref=e33]
+        - generic [ref=e35]: Rewards
+      - link "Profile" [ref=e36] [cursor=pointer]:
+        - /url: /profile
+        - img [ref=e37]
+        - generic [ref=e39]: Profile
+      - link "Budget" [ref=e40] [cursor=pointer]:
+        - /url: /budget/month
+        - img [ref=e41]
+        - generic [ref=e43]: Budget
+      - link "Manage" [ref=e44] [cursor=pointer]:
+        - /url: /parent
+        - img [ref=e45]
+        - generic [ref=e48]: Manage
+      - button "ES" [ref=e50]:
+        - img [ref=e51]
+        - generic [ref=e53]: ES
+      - button "Logout" [ref=e55]:
+        - img [ref=e56]
+        - generic [ref=e58]: Logout

--- a/.playwright-mcp/page-2026-05-27T16-14-34-466Z.yml
+++ b/.playwright-mcp/page-2026-05-27T16-14-34-466Z.yml
@@ -1,0 +1,54 @@
+- main [ref=e3]:
+  - generic [ref=e6]:
+    - generic [ref=e7]:
+      - generic [ref=e8]:
+        - heading "Gestiona tu familia" [level=2] [ref=e9]
+        - paragraph [ref=e10]: Tareas, recompensas y control parental en un solo lugar
+      - generic [ref=e11]:
+        - generic [ref=e12]:
+          - img [ref=e14]
+          - generic [ref=e16]:
+            - paragraph [ref=e17]: Asignación de tareas
+            - paragraph [ref=e18]: Crea y asigna tareas con puntos
+        - generic [ref=e19]:
+          - img [ref=e21]
+          - generic [ref=e23]:
+            - paragraph [ref=e24]: Sistema de recompensas
+            - paragraph [ref=e25]: Motiva con recompensas atractivas
+        - generic [ref=e26]:
+          - img [ref=e28]
+          - generic [ref=e30]:
+            - paragraph [ref=e31]: Finanzas familiares
+            - paragraph [ref=e32]: Presupuesto y control de gastos
+    - generic [ref=e33]:
+      - generic [ref=e34]:
+        - heading "Bienvenido" [level=1] [ref=e35]
+        - paragraph [ref=e36]: Iniciar sesión en Family Task Manager
+      - generic [ref=e39]:
+        - button "Sign in with Google. Opens in new tab" [ref=e41] [cursor=pointer]:
+          - generic [ref=e43]:
+            - img [ref=e45]
+            - generic [ref=e52]: Sign in with Google
+        - iframe
+      - generic [ref=e57]: O continúa con correo
+      - generic [ref=e58]:
+        - generic [ref=e59]:
+          - generic [ref=e60]: Correo Electrónico
+          - textbox "Correo Electrónico" [ref=e61]:
+            - /placeholder: parent@demo.com
+            - text: mom@demo.com
+        - generic [ref=e62]:
+          - generic [ref=e63]: Contraseña
+          - textbox "Contraseña" [ref=e64]:
+            - /placeholder: ••••••••
+            - text: password123
+        - link "¿Olvidaste tu contraseña?" [ref=e66] [cursor=pointer]:
+          - /url: /forgot-password
+        - button "Iniciar Sesión" [ref=e67]
+      - paragraph [ref=e68]:
+        - text: ¿No tienes cuenta?
+        - link "Crear cuenta" [ref=e69] [cursor=pointer]:
+          - /url: /register
+      - button "English" [ref=e71]:
+        - img [ref=e72]
+        - text: English

--- a/.playwright-mcp/page-2026-05-27T16-14-53-170Z.yml
+++ b/.playwright-mcp/page-2026-05-27T16-14-53-170Z.yml
@@ -1,0 +1,54 @@
+- main [ref=e3]:
+  - generic [ref=e6]:
+    - generic [ref=e7]:
+      - generic [ref=e8]:
+        - heading "Gestiona tu familia" [level=2] [ref=e9]
+        - paragraph [ref=e10]: Tareas, recompensas y control parental en un solo lugar
+      - generic [ref=e11]:
+        - generic [ref=e12]:
+          - img [ref=e14]
+          - generic [ref=e16]:
+            - paragraph [ref=e17]: Asignación de tareas
+            - paragraph [ref=e18]: Crea y asigna tareas con puntos
+        - generic [ref=e19]:
+          - img [ref=e21]
+          - generic [ref=e23]:
+            - paragraph [ref=e24]: Sistema de recompensas
+            - paragraph [ref=e25]: Motiva con recompensas atractivas
+        - generic [ref=e26]:
+          - img [ref=e28]
+          - generic [ref=e30]:
+            - paragraph [ref=e31]: Finanzas familiares
+            - paragraph [ref=e32]: Presupuesto y control de gastos
+    - generic [ref=e33]:
+      - generic [ref=e34]:
+        - heading "Bienvenido" [level=1] [ref=e35]
+        - paragraph [ref=e36]: Iniciar sesión en Family Task Manager
+      - generic [ref=e39]:
+        - button "Sign in with Google. Opens in new tab" [ref=e41] [cursor=pointer]:
+          - generic [ref=e43]:
+            - img [ref=e45]
+            - generic [ref=e52]: Sign in with Google
+        - iframe
+      - generic [ref=e57]: O continúa con correo
+      - generic [ref=e58]:
+        - generic [ref=e59]:
+          - generic [ref=e60]: Correo Electrónico
+          - textbox "Correo Electrónico" [ref=e61]:
+            - /placeholder: parent@demo.com
+            - text: mom@demo.com
+        - generic [ref=e62]:
+          - generic [ref=e63]: Contraseña
+          - textbox "Contraseña" [ref=e64]:
+            - /placeholder: ••••••••
+            - text: password123
+        - link "¿Olvidaste tu contraseña?" [ref=e66] [cursor=pointer]:
+          - /url: /forgot-password
+        - button "Iniciar Sesión" [ref=e67]
+      - paragraph [ref=e68]:
+        - text: ¿No tienes cuenta?
+        - link "Crear cuenta" [ref=e69] [cursor=pointer]:
+          - /url: /register
+      - button "English" [ref=e71]:
+        - img [ref=e72]
+        - text: English

--- a/.playwright-mcp/page-2026-05-27T16-14-55-860Z.yml
+++ b/.playwright-mcp/page-2026-05-27T16-14-55-860Z.yml
@@ -1,0 +1,54 @@
+- main [ref=e3]:
+  - generic [ref=e6]:
+    - generic [ref=e7]:
+      - generic [ref=e8]:
+        - heading "Gestiona tu familia" [level=2] [ref=e9]
+        - paragraph [ref=e10]: Tareas, recompensas y control parental en un solo lugar
+      - generic [ref=e11]:
+        - generic [ref=e12]:
+          - img [ref=e14]
+          - generic [ref=e16]:
+            - paragraph [ref=e17]: Asignación de tareas
+            - paragraph [ref=e18]: Crea y asigna tareas con puntos
+        - generic [ref=e19]:
+          - img [ref=e21]
+          - generic [ref=e23]:
+            - paragraph [ref=e24]: Sistema de recompensas
+            - paragraph [ref=e25]: Motiva con recompensas atractivas
+        - generic [ref=e26]:
+          - img [ref=e28]
+          - generic [ref=e30]:
+            - paragraph [ref=e31]: Finanzas familiares
+            - paragraph [ref=e32]: Presupuesto y control de gastos
+    - generic [ref=e33]:
+      - generic [ref=e34]:
+        - heading "Bienvenido" [level=1] [ref=e35]
+        - paragraph [ref=e36]: Iniciar sesión en Family Task Manager
+      - generic [ref=e39]:
+        - button "Sign in with Google. Opens in new tab" [ref=e41] [cursor=pointer]:
+          - generic [ref=e43]:
+            - img [ref=e45]
+            - generic [ref=e52]: Sign in with Google
+        - iframe
+      - generic [ref=e57]: O continúa con correo
+      - generic [ref=e58]:
+        - generic [ref=e59]:
+          - generic [ref=e60]: Correo Electrónico
+          - textbox "Correo Electrónico" [ref=e61]:
+            - /placeholder: parent@demo.com
+            - text: mom@demo.com
+        - generic [ref=e62]:
+          - generic [ref=e63]: Contraseña
+          - textbox "Contraseña" [ref=e64]:
+            - /placeholder: ••••••••
+            - text: password123
+        - link "¿Olvidaste tu contraseña?" [ref=e66] [cursor=pointer]:
+          - /url: /forgot-password
+        - button "Iniciar Sesión" [ref=e67]
+      - paragraph [ref=e68]:
+        - text: ¿No tienes cuenta?
+        - link "Crear cuenta" [ref=e69] [cursor=pointer]:
+          - /url: /register
+      - button "English" [ref=e71]:
+        - img [ref=e72]
+        - text: English

--- a/backend/app/api/routes/budget/__init__.py
+++ b/backend/app/api/routes/budget/__init__.py
@@ -5,7 +5,7 @@ API endpoints for budget management.
 """
 
 from fastapi import APIRouter
-from app.api.routes.budget import categories, accounts, transactions, allocations, payees, month, transfers, reports, categorization_rules, goals, recurring_transactions, months, recycle_bin, saved_filters, tags, export, custom_reports, receipt_drafts, items
+from app.api.routes.budget import categories, accounts, transactions, allocations, payees, month, transfers, reports, categorization_rules, goals, recurring_transactions, months, recycle_bin, saved_filters, tags, export, custom_reports, receipt_drafts, items, a2a_webhook as _a2a
 
 router = APIRouter()
 
@@ -29,5 +29,6 @@ router.include_router(export.router, tags=["budget-export"])
 router.include_router(custom_reports.router, prefix="/custom-reports", tags=["budget-custom-reports"])
 router.include_router(receipt_drafts.router, prefix="/receipt-drafts", tags=["budget-receipt-drafts"])
 router.include_router(items.router, prefix="/items", tags=["budget-items"])
+router.include_router(_a2a.router, prefix="/a2a-webhook", tags=["budget-a2a"])
 
 __all__ = ["router"]

--- a/backend/app/api/routes/budget/__init__.py
+++ b/backend/app/api/routes/budget/__init__.py
@@ -5,7 +5,7 @@ API endpoints for budget management.
 """
 
 from fastapi import APIRouter
-from app.api.routes.budget import categories, accounts, transactions, allocations, payees, month, transfers, reports, categorization_rules, goals, recurring_transactions, months, recycle_bin, saved_filters, tags, export, custom_reports, receipt_drafts
+from app.api.routes.budget import categories, accounts, transactions, allocations, payees, month, transfers, reports, categorization_rules, goals, recurring_transactions, months, recycle_bin, saved_filters, tags, export, custom_reports, receipt_drafts, items
 
 router = APIRouter()
 
@@ -28,5 +28,6 @@ router.include_router(tags.router, prefix="/tags", tags=["Budget - Tags"])
 router.include_router(export.router, tags=["budget-export"])
 router.include_router(custom_reports.router, prefix="/custom-reports", tags=["budget-custom-reports"])
 router.include_router(receipt_drafts.router, prefix="/receipt-drafts", tags=["budget-receipt-drafts"])
+router.include_router(items.router, prefix="/items", tags=["budget-items"])
 
 __all__ = ["router"]

--- a/backend/app/api/routes/budget/a2a_webhook.py
+++ b/backend/app/api/routes/budget/a2a_webhook.py
@@ -1,0 +1,52 @@
+"""Per-family a2a webhook configuration."""
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_db
+from app.core.dependencies import require_parent_role
+from app.core.type_utils import to_uuid_required
+from app.models import User
+from app.schemas.a2a import A2AWebhookRead, A2AWebhookSaveResult, A2AWebhookUpdate
+from app.services.budget.a2a_webhook_service import A2AWebhookService
+
+router = APIRouter()
+
+
+@router.get("", response_model=A2AWebhookRead)
+async def get_webhook(
+    current_user: User = Depends(require_parent_role),
+    db: AsyncSession = Depends(get_db),
+):
+    """Return current webhook config for the family.  Never exposes the secret."""
+    family_id = to_uuid_required(current_user.family_id)
+    cfg = await A2AWebhookService.get_config(db, family_id)
+    if cfg is None:
+        return A2AWebhookRead(enabled=False)
+    return cfg
+
+
+@router.put("", response_model=A2AWebhookSaveResult)
+async def put_webhook(
+    payload: A2AWebhookUpdate,
+    current_user: User = Depends(require_parent_role),
+    db: AsyncSession = Depends(get_db),
+):
+    """Create or update webhook config.
+
+    When ``rotate_secret=True`` the response includes the new plaintext secret
+    (the ONLY time it is returned — store it immediately).  Subsequent reads
+    omit the secret entirely.
+    """
+    family_id = to_uuid_required(current_user.family_id)
+    cfg, plaintext = await A2AWebhookService.upsert_config(
+        db,
+        family_id,
+        url=payload.url,
+        enabled=payload.enabled,
+        rotate_secret=payload.rotate_secret,
+    )
+    return A2AWebhookSaveResult(
+        config=A2AWebhookRead.model_validate(cfg),
+        secret=plaintext,
+    )

--- a/backend/app/api/routes/budget/items.py
+++ b/backend/app/api/routes/budget/items.py
@@ -1,0 +1,62 @@
+"""Item history + price-trend endpoints."""
+
+from datetime import datetime
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_db
+from app.core.dependencies import get_current_user
+from app.core.type_utils import to_uuid_required
+from app.models import User
+from app.schemas.budget import ItemTrend, TransactionItemRead
+from app.services.budget.transaction_item_service import TransactionItemService
+
+router = APIRouter()
+
+
+@router.get("/", response_model=list[TransactionItemRead])
+async def list_items(
+    normalized_name: Optional[str] = Query(None),
+    since: Optional[datetime] = Query(None),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """List transaction items for the authenticated user's family.
+
+    Optionally filter by normalized_name, since (datetime), with pagination.
+    Family-scoped — results are always isolated to the calling user's family.
+    """
+    family_id = to_uuid_required(current_user.family_id)
+    return await TransactionItemService.list_for_family(
+        db,
+        family_id,
+        normalized_name=normalized_name,
+        since=since,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.get("/trend", response_model=Optional[ItemTrend])
+async def get_trend(
+    normalized_name: str = Query(...),
+    window_days: int = Query(90, ge=7, le=365),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Return price-trend data for an item over the last window_days.
+
+    Returns null (HTTP 200) when there are fewer than 3 samples with
+    unit_price_cents — the caller should treat null as "no trend data".
+    """
+    family_id = to_uuid_required(current_user.family_id)
+    return await TransactionItemService.get_trend(
+        db,
+        family_id,
+        normalized_name=normalized_name,
+        window_days=window_days,
+    )

--- a/backend/app/api/routes/budget/items.py
+++ b/backend/app/api/routes/budget/items.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.database import get_db
 from app.core.dependencies import get_current_user
+from app.core.premium import require_feature
 from app.core.type_utils import to_uuid_required
 from app.models import User
 from app.schemas.budget import ItemTrend, TransactionItemRead
@@ -54,6 +55,10 @@ async def get_trend(
     unit_price_cents — the caller should treat null as "no trend data".
     """
     family_id = to_uuid_required(current_user.family_id)
+    # Item-trend lookup is a Pro feature; the scanner pipeline already
+    # checks this with is_feature_enabled(), but the public endpoint also
+    # needs the gate so direct API callers can't bypass plan limits.
+    await require_feature("item_trends", db, current_user)
     return await TransactionItemService.get_trend(
         db,
         family_id,

--- a/backend/app/api/routes/budget/transactions.py
+++ b/backend/app/api/routes/budget/transactions.py
@@ -4,7 +4,7 @@ Transaction routes
 CRUD endpoints for budget transactions.
 """
 
-from fastapi import APIRouter, Body, Depends, status, Query, File, UploadFile, Form
+from fastapi import APIRouter, Body, Depends, Response, status, Query, File, UploadFile, Form
 from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing import List, Optional, Dict
@@ -434,9 +434,11 @@ async def import_file_transactions_endpoint(
 @router.post("/scan-receipt", status_code=status.HTTP_200_OK)
 async def scan_receipt_endpoint(
     file: UploadFile = File(..., description="Receipt photo or scanned PDF (JPEG, PNG, WebP, GIF, PDF)"),
-    account_id: UUID = Form(..., description="Target account for the transaction"),
+    account_id: Optional[UUID] = Form(None, description="Target account; omit for auto-detect"),
+    force: bool = Query(False, description="Bypass duplicate guard and commit the transaction"),
     current_user: User = Depends(require_parent_role),
     db: AsyncSession = Depends(get_db),
+    response: Response = None,
 ):
     """Scan a receipt (image or PDF) and create a transaction (parent only, premium feature).
 
@@ -449,6 +451,9 @@ async def scan_receipt_endpoint(
     Auto-creates the payee if new, applies categorization rules, and
     creates the transaction. Returns scanned data, confidence score,
     and the created transaction ID.
+
+    When a duplicate is detected, returns HTTP 409 with a ``dup_warning``
+    field. Pass ``?force=true`` to bypass the guard and commit anyway.
     """
     family_id = to_uuid_required(current_user.family_id)
 
@@ -461,9 +466,10 @@ async def scan_receipt_endpoint(
     # Track usage
     await UsageService.increment(db, family_id, "receipt_scan")
 
-    # Validate account belongs to family
-    from app.services.budget.account_service import AccountService
-    await AccountService.get_by_id(db, account_id, family_id)
+    # Validate caller-supplied account belongs to this family (404 on mismatch)
+    if account_id is not None:
+        from app.services.budget.account_service import AccountService
+        await AccountService.get_by_id(db, account_id, family_id)
 
     # Validate file type. PDF is accepted — receipt_scanner_service
     # rasterizes the first page to PNG in memory before the vision call.
@@ -500,9 +506,17 @@ async def scan_receipt_endpoint(
     result = await scan_and_create_transaction(
         db=db,
         family_id=family_id,
+        user_id=current_user.id,
         account_id=account_id,
         image_bytes=file_bytes,
         media_type=content_type,
+        force=force,
     )
+
+    # Signal duplicate to callers: HTTP 409 lets them prompt "scan again?" or
+    # redirect to the existing transaction without an extra GET round-trip.
+    if result.get("dup_warning") is not None:
+        response.status_code = status.HTTP_409_CONFLICT
+
     return result
 

--- a/backend/app/api/routes/budget/transactions.py
+++ b/backend/app/api/routes/budget/transactions.py
@@ -463,8 +463,11 @@ async def scan_receipt_endpoint(
     await require_feature("ai_features", db, current_user)
     await require_feature("receipt_scan", db, current_user)
 
-    # Track usage
-    await UsageService.increment(db, family_id, "receipt_scan")
+    # Track usage. force=True is a retry after a dup-warning; the original
+    # attempt already incremented the meter, so we skip to avoid charging
+    # the user twice for the same logical scan.
+    if not force:
+        await UsageService.increment(db, family_id, "receipt_scan")
 
     # Validate caller-supplied account belongs to this family (404 on mismatch)
     if account_id is not None:

--- a/backend/app/api/routes/frankie.py
+++ b/backend/app/api/routes/frankie.py
@@ -20,7 +20,7 @@ from app.services.frankie_service import FrankieService
 router = APIRouter()
 
 
-ALLOWED_MODELS = {"claude-haiku", "claude-sonnet", "gemma3", "gpt-4o", "gemini-2.5-flash"}
+ALLOWED_MODELS = {"claude-haiku", "claude-sonnet", "qwen3", "gpt-4o", "gemini-2.5-flash"}
 
 
 class ChatRequest(BaseModel):

--- a/backend/app/api/routes/internal/a2a_retry.py
+++ b/backend/app/api/routes/internal/a2a_retry.py
@@ -1,0 +1,25 @@
+"""Internal retry sweep — invoked by external cron / scheduler."""
+
+from fastapi import APIRouter, Depends, Header, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.core.database import get_db
+from app.services.budget.a2a_webhook_service import A2AWebhookService
+
+
+router = APIRouter()
+
+
+def _require_token(x_internal_token: str = Header(None)):
+    if not settings.INTERNAL_API_TOKEN or x_internal_token != settings.INTERNAL_API_TOKEN:
+        raise HTTPException(status.HTTP_403_FORBIDDEN, "invalid internal token")
+
+
+@router.post("/a2a/retry")
+async def retry_sweep(
+    _t: None = Depends(_require_token),
+    db: AsyncSession = Depends(get_db),
+):
+    n = await A2AWebhookService.sweep_retries(db, limit=50)
+    return {"processed": n}

--- a/backend/app/api/routes/internal/a2a_retry.py
+++ b/backend/app/api/routes/internal/a2a_retry.py
@@ -1,5 +1,7 @@
 """Internal retry sweep — invoked by external cron / scheduler."""
 
+import hmac
+
 from fastapi import APIRouter, Depends, Header, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -12,7 +14,15 @@ router = APIRouter()
 
 
 def _require_token(x_internal_token: str = Header(None)):
-    if not settings.INTERNAL_API_TOKEN or x_internal_token != settings.INTERNAL_API_TOKEN:
+    # Constant-time comparison so an attacker can't time-side-channel the
+    # token byte by byte. Reject empty/missing on either side first to
+    # avoid passing None into compare_digest (which would TypeError).
+    expected = settings.INTERNAL_API_TOKEN or ""
+    if (
+        not expected
+        or not x_internal_token
+        or not hmac.compare_digest(x_internal_token, expected)
+    ):
         raise HTTPException(status.HTTP_403_FORBIDDEN, "invalid internal token")
 
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -131,6 +131,10 @@ class Settings(BaseSettings):
 
     # Anthropic API (for receipt scanning via Claude Vision)
     ANTHROPIC_API_KEY: str = ""
+
+    # Internal service-to-service token (for /api/internal/* endpoints).
+    # If empty, all internal endpoints reject with 403.
+    INTERNAL_API_TOKEN: str = ""
     
     # Logging
     LOG_LEVEL: str = "INFO"

--- a/backend/app/core/premium.py
+++ b/backend/app/core/premium.py
@@ -31,6 +31,9 @@ DEFAULT_FREE_LIMITS: dict[str, Any] = {
     "max_receipt_scans_per_month": 0,
     "ai_features": False,
     "max_gigs_per_month": 3,
+    "a2a_webhook": False,
+    "item_trends": False,
+    "fx_cross_charge": False,
 }
 
 # Maps feature name → limit key in the plan's limits dict
@@ -47,6 +50,10 @@ FEATURE_LIMIT_MAP: dict[str, str] = {
     "family_member": "max_family_members",
     "budget_account": "max_budget_accounts",
     "gig_completion": "max_gigs_per_month",
+    # Scanner v2 boolean features
+    "a2a_webhook": "a2a_webhook",
+    "item_trends": "item_trends",
+    "fx_cross_charge": "fx_cross_charge",
 }
 
 # Minimum plan tier required for each feature (omitted → available on free)
@@ -59,6 +66,10 @@ FEATURE_MIN_PLAN: dict[str, str] = {
     "recurring_transaction": "plus",
     # gig_completion available on free with low cap; plus tier raises it
     "gig_completion": "plus",
+    # Scanner v2 features
+    "a2a_webhook": "plus",
+    "item_trends": "plus",
+    "fx_cross_charge": "pro",
 }
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -180,6 +180,8 @@ app.include_router(meals.router, prefix="/api/meals", tags=["Meals"])
 app.include_router(family_chat.router, prefix="/api/chat", tags=["Chat"])
 app.include_router(frankie_schedules.router, prefix="/api/frankie/schedules", tags=["Frankie Schedules"])
 app.include_router(dm.router, prefix="/api/dm", tags=["DM"])
+from app.api.routes.internal import a2a_retry as _internal_a2a  # noqa: E402
+app.include_router(_internal_a2a.router, prefix="/api/internal", tags=["internal"])
 
 
 @app.get("/")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -31,7 +31,7 @@ from app.models.budget import (
     BudgetSyncState,
     BudgetTransactionItem,
 )
-from app.models.a2a import FamilyA2AWebhook, A2AWebhookDelivery  # noqa: F401
+from app.models.a2a import FamilyA2AWebhook, A2AWebhookDelivery
 from app.models.subscription import (
     SubscriptionPlan,
     FamilySubscription,

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -29,7 +29,9 @@ from app.models.budget import (
     BudgetPayee,
     BudgetTransaction,
     BudgetSyncState,
+    BudgetTransactionItem,
 )
+from app.models.a2a import FamilyA2AWebhook, A2AWebhookDelivery  # noqa: F401
 from app.models.subscription import (
     SubscriptionPlan,
     FamilySubscription,
@@ -70,6 +72,10 @@ __all__ = [
     "BudgetPayee",
     "BudgetTransaction",
     "BudgetSyncState",
+    "BudgetTransactionItem",
+    # A2A webhook models
+    "FamilyA2AWebhook",
+    "A2AWebhookDelivery",
     # Subscription Models
     "SubscriptionPlan",
     "FamilySubscription",

--- a/backend/app/models/a2a.py
+++ b/backend/app/models/a2a.py
@@ -1,0 +1,72 @@
+"""A2A webhook configuration and delivery log."""
+
+from datetime import datetime
+from typing import Any, Optional
+from uuid import UUID, uuid4
+
+from sqlalchemy import (
+    Boolean, DateTime, ForeignKey, Integer, String, Text, func,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base
+
+
+class FamilyA2AWebhook(Base):
+    """One row per family. Per-family opt-in to the external price-agent."""
+
+    __tablename__ = "family_a2a_webhooks"
+
+    family_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("families.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    url: Mapped[str] = mapped_column(Text, nullable=False)
+    secret: Mapped[str] = mapped_column(Text, nullable=False)
+    enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    last_success_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    last_error: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    failure_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(),
+        onupdate=func.now(), nullable=False,
+    )
+
+
+class A2AWebhookDelivery(Base):
+    """Retry log for a2a webhook deliveries."""
+
+    __tablename__ = "a2a_webhook_deliveries"
+
+    id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), primary_key=True, default=uuid4)
+    family_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("families.id", ondelete="CASCADE"),
+        nullable=False, index=True,
+    )
+    transaction_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("budget_transactions.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    payload_json: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
+    status: Mapped[str] = mapped_column(String(16), nullable=False, default="pending")
+    attempts: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    next_retry_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    last_error: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(),
+        onupdate=func.now(), nullable=False,
+    )

--- a/backend/app/models/a2a.py
+++ b/backend/app/models/a2a.py
@@ -54,7 +54,7 @@ class A2AWebhookDelivery(Base):
     transaction_id: Mapped[UUID] = mapped_column(
         PGUUID(as_uuid=True),
         ForeignKey("budget_transactions.id", ondelete="CASCADE"),
-        nullable=False,
+        nullable=False, index=True,
     )
     payload_json: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
     status: Mapped[str] = mapped_column(String(16), nullable=False, default="pending")

--- a/backend/app/models/budget.py
+++ b/backend/app/models/budget.py
@@ -482,4 +482,6 @@ class BudgetTransactionItem(Base):
     transaction: Mapped["BudgetTransaction"] = relationship(
         "BudgetTransaction", back_populates="items"
     )
-    category: Mapped[Optional["BudgetCategory"]] = relationship("BudgetCategory")
+    category: Mapped[Optional["BudgetCategory"]] = relationship(
+        "BudgetCategory", foreign_keys=[category_id]
+    )

--- a/backend/app/models/budget.py
+++ b/backend/app/models/budget.py
@@ -9,10 +9,11 @@ This module contains all models for the budget management feature:
 - Budget Allocations (monthly budget amounts)
 """
 from datetime import date, datetime
+from decimal import Decimal
 from typing import Optional
 from uuid import UUID, uuid4
 
-from sqlalchemy import BigInteger, Boolean, Date, DateTime, Float, ForeignKey, Index, Integer, String, Text, UniqueConstraint
+from sqlalchemy import BigInteger, Boolean, CHAR, Date, DateTime, Float, ForeignKey, Index, Integer, Numeric, String, Text, UniqueConstraint
 from sqlalchemy.dialects.postgresql import JSONB, UUID as PGUUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.sql import func
@@ -103,6 +104,10 @@ class BudgetAccount(Base):
     sort_order: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
     starting_balance: Mapped[int] = mapped_column(BigInteger, default=0, nullable=False, comment="Initial account balance in cents at creation time")
     currency: Mapped[str] = mapped_column(String(3), nullable=False, server_default="MXN", comment="ISO 4217 currency code (e.g. MXN, USD, EUR)")
+    card_last4: Mapped[Optional[str]] = mapped_column(
+        CHAR(4), nullable=True,
+        comment="Last 4 digits of the card associated with this account; used for receipt auto-match",
+    )
     deleted_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True, index=True, comment="Soft delete timestamp")
     deleted_by_id: Mapped[Optional[UUID]] = mapped_column(PGUUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True, comment="User who deleted this account")
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
@@ -157,6 +162,11 @@ class BudgetTransaction(Base):
     account_id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), ForeignKey("budget_accounts.id", ondelete="CASCADE"), nullable=False)
     date: Mapped[date] = mapped_column(Date, nullable=False, index=True)
     amount: Mapped[int] = mapped_column(BigInteger, nullable=False, comment="Amount in cents (negative=expense, positive=income)")
+    card_last4: Mapped[Optional[str]] = mapped_column(CHAR(4), nullable=True)
+    iva_cents: Mapped[Optional[int]] = mapped_column(BigInteger, nullable=True)
+    fx_rate: Mapped[Optional[Decimal]] = mapped_column(Numeric(12, 6), nullable=True)
+    original_amount_cents: Mapped[Optional[int]] = mapped_column(BigInteger, nullable=True)
+    original_currency: Mapped[Optional[str]] = mapped_column(CHAR(3), nullable=True)
     payee_id: Mapped[Optional[UUID]] = mapped_column(PGUUID(as_uuid=True), ForeignKey("budget_payees.id", ondelete="SET NULL"), nullable=True)
     category_id: Mapped[Optional[UUID]] = mapped_column(PGUUID(as_uuid=True), ForeignKey("budget_categories.id", ondelete="SET NULL"), nullable=True)
     notes: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
@@ -179,6 +189,11 @@ class BudgetTransaction(Base):
     category: Mapped[Optional["BudgetCategory"]] = relationship("BudgetCategory", back_populates="transactions", foreign_keys=[category_id])
     parent_transaction: Mapped[Optional["BudgetTransaction"]] = relationship("BudgetTransaction", remote_side=[id], back_populates="split_transactions")
     split_transactions: Mapped[list["BudgetTransaction"]] = relationship("BudgetTransaction", back_populates="parent_transaction", cascade="all, delete-orphan")
+    items: Mapped[list["BudgetTransactionItem"]] = relationship(
+        "BudgetTransactionItem",
+        back_populates="transaction",
+        cascade="all, delete-orphan",
+    )
 
 
 class BudgetSyncState(Base):
@@ -426,3 +441,45 @@ class BudgetReceiptDraft(Base):
     # Relationships
     family: Mapped["Family"] = relationship("Family")
     account: Mapped["BudgetAccount"] = relationship("BudgetAccount")
+
+
+class BudgetTransactionItem(Base):
+    """Line items extracted from a receipt scan or manual transaction edit."""
+
+    __tablename__ = "budget_transaction_items"
+
+    id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), primary_key=True, default=uuid4)
+    family_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("families.id", ondelete="CASCADE"),
+        nullable=False, index=True,
+    )
+    transaction_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("budget_transactions.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    normalized_name: Mapped[str] = mapped_column(Text, nullable=False)
+    qty: Mapped[Optional[Decimal]] = mapped_column(Numeric(10, 3), nullable=True)
+    unit_price_cents: Mapped[Optional[int]] = mapped_column(BigInteger, nullable=True)
+    total_cents: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    category_id: Mapped[Optional[UUID]] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("budget_categories.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    brand: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    raw_text: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(),
+        onupdate=func.now(), nullable=False,
+    )
+
+    transaction: Mapped["BudgetTransaction"] = relationship(
+        "BudgetTransaction", back_populates="items"
+    )
+    category: Mapped[Optional["BudgetCategory"]] = relationship("BudgetCategory")

--- a/backend/app/schemas/a2a.py
+++ b/backend/app/schemas/a2a.py
@@ -1,0 +1,39 @@
+"""Pydantic schemas for the per-family a2a webhook."""
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl, field_validator
+
+
+class A2AWebhookRead(BaseModel):
+    url: Optional[str] = None
+    enabled: bool = False
+    last_success_at: Optional[datetime] = None
+    failure_count: int = 0
+    # secret is intentionally NOT exposed here
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class A2AWebhookUpdate(BaseModel):
+    url: str = Field(..., description="HTTPS endpoint to POST receipt events to")
+    enabled: bool = False
+    rotate_secret: bool = False
+
+    @field_validator("url")
+    @classmethod
+    def must_be_https(cls, v: str) -> str:
+        if not v.startswith("https://"):
+            raise ValueError("webhook URL must use https://")
+        # Pydantic HttpUrl validates the rest
+        HttpUrl(v)
+        return v
+
+
+class A2AWebhookSaveResult(BaseModel):
+    config: A2AWebhookRead
+    secret: Optional[str] = Field(
+        None,
+        description="Plaintext secret. Returned ONLY when rotate_secret=true on save.",
+    )

--- a/backend/app/schemas/budget.py
+++ b/backend/app/schemas/budget.py
@@ -4,7 +4,9 @@ Budget-related Pydantic schemas
 Request and response models for budget management operations.
 """
 
-from pydantic import BaseModel, Field, field_validator
+from decimal import Decimal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 from typing import Optional, List
 from datetime import date as DateType, datetime
 from uuid import UUID
@@ -113,6 +115,11 @@ class AccountBase(BaseModel):
             raise ValueError(f'type must be one of: {", ".join(allowed_types)}')
         return v
 
+    card_last4: Optional[str] = Field(
+        None, min_length=4, max_length=4, pattern=r"^\d{4}$",
+        description="Last 4 digits of the card; used for receipt scanner auto-detect",
+    )
+
     @field_validator('currency')
     @classmethod
     def validate_currency(cls, v):
@@ -136,6 +143,10 @@ class AccountUpdate(BaseModel):
     sort_order: Optional[int] = Field(None, ge=0)
     starting_balance: Optional[int] = Field(None, description="Initial account balance in cents")
     currency: Optional[str] = Field(None, min_length=3, max_length=3)
+    card_last4: Optional[str] = Field(
+        None, min_length=4, max_length=4, pattern=r"^\d{4}$",
+        description="Last 4 digits of the card; used for receipt scanner auto-detect",
+    )
 
     @field_validator('type')
     @classmethod
@@ -779,3 +790,65 @@ class ReceiptDraftResponse(BaseModel):
 # Rebuild models to resolve forward references
 CategoryWithGroup.model_rebuild()
 CategoryGroupWithCategories.model_rebuild()
+
+
+# ============================================================================
+# RECEIPT SCANNER V2 SCHEMAS
+# ============================================================================
+
+class TransactionItemRead(BaseModel):
+    id: UUID
+    transaction_id: UUID
+    name: str
+    normalized_name: str
+    qty: Optional[Decimal] = None
+    unit_price_cents: Optional[int] = None
+    total_cents: int
+    category_id: Optional[UUID] = None
+    brand: Optional[str] = None
+    raw_text: Optional[str] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ItemTrend(BaseModel):
+    normalized_name: str
+    avg_unit_cents: int
+    last_unit_cents: int
+    pct_change: float  # e.g. 0.142 = +14.2%
+    sample_size: int
+
+
+class AccountMatch(BaseModel):
+    strategy: str  # "card_last4" | "last_used" | "override"
+    matched_card_last4: Optional[str] = None
+
+
+class DupWarning(BaseModel):
+    existing_transaction_id: UUID
+    scanned_at: datetime
+    payee: Optional[str] = None
+    amount_cents: int
+
+
+class FXInfo(BaseModel):
+    rate: Decimal
+    original_amount_cents: int
+    original_currency: str
+
+
+class ScanReceiptResponse(BaseModel):
+    success: bool
+    transaction_id: Optional[UUID] = None
+    transaction: Optional[TransactionResponse] = None
+    items: list[TransactionItemRead] = []
+    account_match: Optional[AccountMatch] = None
+    fx: Optional[FXInfo] = None
+    trends: list[ItemTrend] = []
+    confidence: float = 0.0
+    shopping_auto_checked: list[str] = []
+    warnings: list[str] = []
+    dup_warning: Optional[DupWarning] = None
+    scanned_preview: Optional[dict] = None
+    draft_id: Optional[UUID] = None
+    message: Optional[str] = None

--- a/backend/app/schemas/budget.py
+++ b/backend/app/schemas/budget.py
@@ -6,7 +6,7 @@ Request and response models for budget management operations.
 
 from decimal import Decimal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator
 from typing import Optional, List
 from datetime import date as DateType, datetime
 from uuid import UUID
@@ -246,6 +246,10 @@ class TransactionBase(BaseModel):
 class TransactionCreate(TransactionBase):
     """Schema for creating a transaction"""
     payee_name: Optional[str] = Field(None, max_length=255, description="Payee name; creates payee if payee_id is absent")
+    # Scanner v2 fields — let the draft-approval path carry these through
+    # so the resulting BudgetTransaction is not stripped of card_last4 / iva.
+    card_last4: Optional[str] = Field(None, min_length=4, max_length=4, pattern=r"^\d{4}$")
+    iva_cents: Optional[int] = None
 
 
 class TransactionUpdate(BaseModel):
@@ -277,6 +281,14 @@ class TransactionResponse(TransactionBase):
     fx_rate: Optional[Decimal] = None
     original_amount_cents: Optional[int] = None
     original_currency: Optional[str] = Field(None, min_length=3, max_length=3)
+
+    # Force JSON to emit a real number for Decimal fields. Pydantic v2's
+    # default is to serialize Decimal as a string, which breaks strict
+    # mobile clients (Swift Codable / Kotlin kotlinx.serialization) that
+    # expect a numeric token. See CLAUDE.md note on Decimal serialization.
+    @field_serializer("fx_rate")
+    def _serialize_fx_rate(self, v: Optional[Decimal]) -> Optional[float]:
+        return float(v) if v is not None else None
 
     class Config:
         from_attributes = True
@@ -813,6 +825,12 @@ class TransactionItemRead(BaseModel):
     brand: Optional[str] = None
     raw_text: Optional[str] = None
 
+    # See TransactionResponse.fx_rate — keep Decimal numeric in JSON for
+    # strict-decoding mobile clients.
+    @field_serializer("qty")
+    def _serialize_qty(self, v: Optional[Decimal]) -> Optional[float]:
+        return float(v) if v is not None else None
+
     model_config = ConfigDict(from_attributes=True)
 
 
@@ -840,6 +858,12 @@ class FXInfo(BaseModel):
     rate: Decimal
     original_amount_cents: int
     original_currency: str
+
+    # See TransactionResponse.fx_rate — keep Decimal numeric in JSON for
+    # strict-decoding mobile clients.
+    @field_serializer("rate")
+    def _serialize_rate(self, v: Decimal) -> float:
+        return float(v)
 
 
 class ScanReceiptResponse(BaseModel):

--- a/backend/app/schemas/budget.py
+++ b/backend/app/schemas/budget.py
@@ -106,6 +106,10 @@ class AccountBase(BaseModel):
         min_length=3, max_length=3,
         description="ISO 4217 currency code. All accounts in a family must share the same currency — reports/balances do not convert.",
     )
+    card_last4: Optional[str] = Field(
+        None, min_length=4, max_length=4, pattern=r"^\d{4}$",
+        description="Last 4 digits of the card; used for receipt scanner auto-detect",
+    )
 
     @field_validator('type')
     @classmethod
@@ -114,11 +118,6 @@ class AccountBase(BaseModel):
         if v not in allowed_types:
             raise ValueError(f'type must be one of: {", ".join(allowed_types)}')
         return v
-
-    card_last4: Optional[str] = Field(
-        None, min_length=4, max_length=4, pattern=r"^\d{4}$",
-        description="Last 4 digits of the card; used for receipt scanner auto-detect",
-    )
 
     @field_validator('currency')
     @classmethod
@@ -272,6 +271,12 @@ class TransactionResponse(TransactionBase):
     family_id: UUID
     created_at: datetime
     updated_at: datetime
+    # Scanner v2 fields — populated by the receipt scanner pipeline
+    card_last4: Optional[str] = Field(None, min_length=4, max_length=4, pattern=r"^\d{4}$")
+    iva_cents: Optional[int] = None
+    fx_rate: Optional[Decimal] = None
+    original_amount_cents: Optional[int] = None
+    original_currency: Optional[str] = Field(None, min_length=3, max_length=3)
 
     class Config:
         from_attributes = True

--- a/backend/app/services/budget/a2a_webhook_service.py
+++ b/backend/app/services/budget/a2a_webhook_service.py
@@ -1,0 +1,161 @@
+"""Per-family a2a webhook: enqueue, sign, dispatch, retry."""
+
+import hashlib
+import hmac
+import json
+import secrets
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+from uuid import UUID
+
+import httpx
+from sqlalchemy import and_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.a2a import A2AWebhookDelivery, FamilyA2AWebhook
+
+
+# Exponential backoff schedule for failed deliveries.
+_BACKOFF_SCHEDULE = [
+    timedelta(minutes=1),
+    timedelta(minutes=5),
+    timedelta(minutes=30),
+    timedelta(hours=2),
+    timedelta(hours=12),
+]
+_MAX_ATTEMPTS = len(_BACKOFF_SCHEDULE)
+_DISPATCH_TIMEOUT_SECONDS = 10.0
+
+
+def generate_secret() -> str:
+    return secrets.token_hex(32)
+
+
+class A2AWebhookService:
+
+    @staticmethod
+    async def get_config(
+        db: AsyncSession, family_id: UUID
+    ) -> Optional[FamilyA2AWebhook]:
+        result = await db.execute(
+            select(FamilyA2AWebhook).where(
+                FamilyA2AWebhook.family_id == family_id
+            )
+        )
+        return result.scalar_one_or_none()
+
+    @staticmethod
+    async def upsert_config(
+        db: AsyncSession,
+        family_id: UUID,
+        url: str,
+        enabled: bool,
+        rotate_secret: bool,
+    ) -> tuple[FamilyA2AWebhook, Optional[str]]:
+        existing = await A2AWebhookService.get_config(db, family_id)
+        plaintext_secret: Optional[str] = None
+        if existing is None:
+            plaintext_secret = generate_secret()
+            row = FamilyA2AWebhook(
+                family_id=family_id, url=url,
+                secret=plaintext_secret, enabled=enabled,
+            )
+            db.add(row)
+            await db.commit()
+            await db.refresh(row)
+            return row, plaintext_secret
+
+        existing.url = url
+        existing.enabled = enabled
+        if rotate_secret:
+            plaintext_secret = generate_secret()
+            existing.secret = plaintext_secret
+        await db.commit()
+        await db.refresh(existing)
+        return existing, plaintext_secret
+
+    @staticmethod
+    async def enqueue(
+        db: AsyncSession,
+        family_id: UUID,
+        transaction_id: UUID,
+        payload: dict,
+    ) -> Optional[A2AWebhookDelivery]:
+        cfg = await A2AWebhookService.get_config(db, family_id)
+        if cfg is None or not cfg.enabled:
+            return None
+        delivery = A2AWebhookDelivery(
+            family_id=family_id,
+            transaction_id=transaction_id,
+            payload_json=payload,
+            status="pending",
+        )
+        db.add(delivery)
+        await db.commit()
+        await db.refresh(delivery)
+        return delivery
+
+    @staticmethod
+    async def dispatch_once(db: AsyncSession, delivery_id: UUID) -> None:
+        delivery = await db.get(A2AWebhookDelivery, delivery_id)
+        if delivery is None:
+            return
+        cfg = await A2AWebhookService.get_config(db, delivery.family_id)
+        if cfg is None or not cfg.enabled:
+            delivery.status = "dead"
+            delivery.last_error = "no enabled webhook config"
+            await db.commit()
+            return
+
+        body = json.dumps(delivery.payload_json, separators=(",", ":"),
+                          sort_keys=True).encode("utf-8")
+        signature = "sha256=" + hmac.new(
+            cfg.secret.encode("utf-8"), body, hashlib.sha256
+        ).hexdigest()
+        headers = {
+            "Content-Type": "application/json",
+            "X-A2A-Signature": signature,
+            "X-A2A-Delivery": str(delivery.id),
+            "X-A2A-Schema": "family-budget.receipt.v1",
+        }
+
+        delivery.attempts += 1
+        try:
+            async with httpx.AsyncClient(timeout=_DISPATCH_TIMEOUT_SECONDS) as client:
+                resp = await client.post(cfg.url, content=body, headers=headers)
+            if 200 <= resp.status_code < 300:
+                delivery.status = "sent"
+                delivery.last_error = None
+                delivery.next_retry_at = None
+                cfg.last_success_at = datetime.now(timezone.utc)
+                cfg.failure_count = 0
+                cfg.last_error = None
+            else:
+                raise RuntimeError(f"HTTP {resp.status_code}: {resp.text[:200]}")
+        except Exception as exc:
+            delivery.last_error = str(exc)[:500]
+            if delivery.attempts >= _MAX_ATTEMPTS:
+                delivery.status = "dead"
+                delivery.next_retry_at = None
+            else:
+                delivery.status = "failed"
+                delay = _BACKOFF_SCHEDULE[delivery.attempts - 1]
+                delivery.next_retry_at = datetime.now(timezone.utc) + delay
+            cfg.failure_count += 1
+            cfg.last_error = delivery.last_error
+        await db.commit()
+
+    @staticmethod
+    async def sweep_retries(db: AsyncSession, limit: int = 50) -> int:
+        now = datetime.now(timezone.utc)
+        result = await db.execute(
+            select(A2AWebhookDelivery.id).where(and_(
+                A2AWebhookDelivery.status.in_(["pending", "failed"]),
+                A2AWebhookDelivery.next_retry_at.isnot(None),
+                A2AWebhookDelivery.next_retry_at <= now,
+            )).limit(limit)
+        )
+        ids = [r[0] for r in result.all()]
+        for _id in ids:
+            await A2AWebhookService.dispatch_once(db, _id)
+        return len(ids)

--- a/backend/app/services/budget/a2a_webhook_service.py
+++ b/backend/app/services/budget/a2a_webhook_service.py
@@ -9,7 +9,7 @@ from typing import Optional
 from uuid import UUID
 
 import httpx
-from sqlalchemy import and_, or_, select
+from sqlalchemy import and_, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.a2a import A2AWebhookDelivery, FamilyA2AWebhook
@@ -148,6 +148,8 @@ class A2AWebhookService:
     @staticmethod
     async def sweep_retries(db: AsyncSession, limit: int = 50) -> int:
         now = datetime.now(timezone.utc)
+        # SELECT ... FOR UPDATE SKIP LOCKED so two concurrent sweeps
+        # (cron + manual trigger) never claim the same row.
         result = await db.execute(
             select(A2AWebhookDelivery.id).where(or_(
                 A2AWebhookDelivery.status == "pending",
@@ -156,9 +158,20 @@ class A2AWebhookService:
                     A2AWebhookDelivery.next_retry_at.isnot(None),
                     A2AWebhookDelivery.next_retry_at <= now,
                 ),
-            )).limit(limit)
+            )).with_for_update(skip_locked=True).limit(limit)
         )
         ids = [r[0] for r in result.all()]
+        if ids:
+            # Push next_retry_at 10 minutes into the future so a parallel
+            # sweep that started before this commit cannot re-claim these
+            # rows. dispatch_once will overwrite next_retry_at with the
+            # real backoff value (or clear it on success).
+            await db.execute(
+                update(A2AWebhookDelivery).where(
+                    A2AWebhookDelivery.id.in_(ids)
+                ).values(next_retry_at=now + timedelta(minutes=10))
+            )
+            await db.commit()
         for _id in ids:
             await A2AWebhookService.dispatch_once(db, _id)
         return len(ids)

--- a/backend/app/services/budget/a2a_webhook_service.py
+++ b/backend/app/services/budget/a2a_webhook_service.py
@@ -9,7 +9,7 @@ from typing import Optional
 from uuid import UUID
 
 import httpx
-from sqlalchemy import and_, select
+from sqlalchemy import and_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.a2a import A2AWebhookDelivery, FamilyA2AWebhook
@@ -149,10 +149,13 @@ class A2AWebhookService:
     async def sweep_retries(db: AsyncSession, limit: int = 50) -> int:
         now = datetime.now(timezone.utc)
         result = await db.execute(
-            select(A2AWebhookDelivery.id).where(and_(
-                A2AWebhookDelivery.status.in_(["pending", "failed"]),
-                A2AWebhookDelivery.next_retry_at.isnot(None),
-                A2AWebhookDelivery.next_retry_at <= now,
+            select(A2AWebhookDelivery.id).where(or_(
+                A2AWebhookDelivery.status == "pending",
+                and_(
+                    A2AWebhookDelivery.status == "failed",
+                    A2AWebhookDelivery.next_retry_at.isnot(None),
+                    A2AWebhookDelivery.next_retry_at <= now,
+                ),
             )).limit(limit)
         )
         ids = [r[0] for r in result.all()]

--- a/backend/app/services/budget/account_matching_service.py
+++ b/backend/app/services/budget/account_matching_service.py
@@ -56,6 +56,12 @@ class AccountMatchingService:
                              same card_last4), or None.
         override_account_id: Explicit account chosen by the caller; validated
                              for ownership before accepting.
+
+        NOTE: an `override_account_id` that does NOT belong to ``family_id``
+        is silently ignored — the method falls through to the next strategy
+        rather than raising. Callers are expected to pre-validate ownership
+        of an explicit override (the scan-receipt endpoint does this via
+        ``AccountService.get_by_id``).
         """
 
         # --- Strategy 1: caller override ----------------------------------------

--- a/backend/app/services/budget/account_matching_service.py
+++ b/backend/app/services/budget/account_matching_service.py
@@ -1,0 +1,130 @@
+"""Pick a target account for a scanned receipt.
+
+Strategy order:
+1. Caller-supplied account_id (validated to belong to family) → strategy="override"
+2. Match BudgetAccount.card_last4 → narrow by receipt currency if >1  → strategy="card_last4"
+3. Most-recent transaction in the family (any user) → strategy="last_used"
+   NOTE: BudgetTransaction has no created_by_id / user_id column as of the
+   current schema, so per-user disambiguation is not possible.
+   TODO: add created_by_id to budget_transactions and introduce a
+   per-user step between card_last4 and the family-wide fallback.
+4. None → strategy="none"
+"""
+
+from dataclasses import dataclass, field
+from typing import Optional
+from uuid import UUID
+
+from sqlalchemy import and_, desc, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.budget import BudgetAccount, BudgetTransaction
+
+
+@dataclass
+class AccountMatchResult:
+    account_id: Optional[UUID]
+    strategy: str  # "card_last4" | "last_used" | "override" | "none"
+    matched_card_last4: Optional[str] = field(default=None)
+    matched_account_currency: Optional[str] = field(default=None)
+
+
+class AccountMatchingService:
+
+    @staticmethod
+    async def match(
+        db: AsyncSession,
+        family_id: UUID,
+        user_id: UUID,
+        card_last4: Optional[str],
+        receipt_currency: Optional[str],
+        override_account_id: Optional[UUID] = None,
+    ) -> AccountMatchResult:
+        """Return the best account match for a scanned receipt.
+
+        Parameters
+        ----------
+        db:                  Async SQLAlchemy session.
+        family_id:           Tenant scope — all queries are filtered by this.
+        user_id:             Authenticated user (reserved for future per-user
+                             last-used step once created_by_id is added to
+                             budget_transactions).
+        card_last4:          4-digit suffix extracted from the receipt by the
+                             vision model, or None.
+        receipt_currency:    ISO-4217 currency detected on the receipt (used
+                             to disambiguate when multiple accounts share the
+                             same card_last4), or None.
+        override_account_id: Explicit account chosen by the caller; validated
+                             for ownership before accepting.
+        """
+
+        # --- Strategy 1: caller override ----------------------------------------
+        if override_account_id is not None:
+            stmt = select(BudgetAccount).where(and_(
+                BudgetAccount.id == override_account_id,
+                BudgetAccount.family_id == family_id,
+            ))
+            row = (await db.execute(stmt)).scalar_one_or_none()
+            if row is not None:
+                return AccountMatchResult(
+                    account_id=row.id,
+                    strategy="override",
+                    matched_account_currency=row.currency,
+                )
+
+        # --- Strategy 2: card_last4 match ---------------------------------------
+        if card_last4:
+            stmt = select(BudgetAccount).where(and_(
+                BudgetAccount.family_id == family_id,
+                BudgetAccount.card_last4 == card_last4,
+                BudgetAccount.closed.is_(False),
+                BudgetAccount.deleted_at.is_(None),
+            ))
+            hits = list((await db.execute(stmt)).scalars().all())
+
+            if len(hits) == 1:
+                return AccountMatchResult(
+                    account_id=hits[0].id,
+                    strategy="card_last4",
+                    matched_card_last4=card_last4,
+                    matched_account_currency=hits[0].currency,
+                )
+
+            if len(hits) > 1 and receipt_currency:
+                by_ccy = [h for h in hits
+                          if h.currency == receipt_currency.upper()]
+                if len(by_ccy) == 1:
+                    return AccountMatchResult(
+                        account_id=by_ccy[0].id,
+                        strategy="card_last4",
+                        matched_card_last4=card_last4,
+                        matched_account_currency=by_ccy[0].currency,
+                    )
+
+        # --- Strategy 3: most-recent transaction in family ----------------------
+        # Per-user narrowing is intentionally skipped here because
+        # BudgetTransaction.created_by_id does not exist yet.
+        # TODO: once created_by_id is added, insert a per-user step before
+        # this family-wide fallback.
+        stmt = (
+            select(BudgetTransaction.account_id, BudgetAccount.currency)
+            .join(BudgetAccount, BudgetAccount.id == BudgetTransaction.account_id)
+            .where(and_(
+                BudgetTransaction.family_id == family_id,
+                BudgetTransaction.deleted_at.is_(None),
+                BudgetAccount.deleted_at.is_(None),
+                BudgetAccount.closed.is_(False),
+            ))
+            .order_by(desc(BudgetTransaction.created_at))
+            .limit(1)
+        )
+        result = (await db.execute(stmt)).first()
+        if result:
+            return AccountMatchResult(
+                account_id=result[0],
+                strategy="last_used",
+                matched_account_currency=result[1],
+            )
+
+        # --- Strategy 4: nothing ------------------------------------------------
+        return AccountMatchResult(account_id=None, strategy="none")

--- a/backend/app/services/budget/categorization_rule_service.py
+++ b/backend/app/services/budget/categorization_rule_service.py
@@ -221,30 +221,44 @@ class CategorizationRuleService(BaseFamilyService[BudgetCategorizationRule]):
         family_id: UUID,
         payee: Optional[str] = None,
         description: Optional[str] = None,
+        item_name: Optional[str] = None,
     ) -> Optional[UUID]:
         """
-        Suggest a category for a transaction based on payee/description and rules.
+        Suggest a category for a transaction based on payee/description/item_name and rules.
 
         Rules are evaluated in priority order (highest priority first).
         Returns the category_id from the first matching rule, or None if no match.
+
+        The match field semantics:
+          - rule.match_field == "payee"        → match against `payee`
+          - rule.match_field == "description"  → match against `description`,
+            falling back to `item_name` when description is None
+          - rule.match_field == "both"         → match if payee OR description
+            OR item_name matches
+
+        `item_name` enables per-line categorization for receipt scans
+        (e.g. a rule keyed on "leche" categorizes the milk line item even
+        when the receipt's payee/description doesn't mention it).
 
         Args:
             db: Database session
             family_id: Family ID
             payee: Payee name (optional)
             description: Transaction description (optional)
+            item_name: Single line-item name to match against
+                description-pattern rules (optional)
 
         Returns:
             Suggested category_id or None if no rule matches
         """
-        if not payee and not description:
+        if not payee and not description and not item_name:
             return None
 
         # Get all enabled rules for this family, ordered by priority
         rules = await cls.list_rules(db, family_id, enabled_only=True)
 
         for rule in rules:
-            if cls._match_rule(rule, payee, description):
+            if cls._match_rule(rule, payee, description, item_name):
                 return rule.category_id
 
         return None
@@ -294,14 +308,19 @@ class CategorizationRuleService(BaseFamilyService[BudgetCategorizationRule]):
         rule: BudgetCategorizationRule,
         payee: Optional[str],
         description: Optional[str],
+        item_name: Optional[str] = None,
     ) -> bool:
         """
-        Check if a rule matches the given payee and/or description.
+        Check if a rule matches the given payee/description/item_name.
 
         Args:
             rule: The categorization rule
             payee: Payee name (optional)
             description: Transaction description (optional)
+            item_name: Receipt line-item name (optional). Used as an
+                additional source when match_field is 'description' or
+                'both' — receipt scans don't have a free-form description
+                column but each line item can drive categorization.
 
         Returns:
             True if the rule matches
@@ -311,11 +330,15 @@ class CategorizationRuleService(BaseFamilyService[BudgetCategorizationRule]):
                 rule.pattern, payee, rule.rule_type
             )
         elif rule.match_field == "description":
-            return description is not None and CategorizationRuleService._match_pattern(
+            desc_match = description is not None and CategorizationRuleService._match_pattern(
                 rule.pattern, description, rule.rule_type
             )
+            item_match = item_name is not None and CategorizationRuleService._match_pattern(
+                rule.pattern, item_name, rule.rule_type
+            )
+            return desc_match or item_match
         elif rule.match_field == "both":
-            # For "both", match if either payee or description matches
+            # For "both", match if payee OR description OR item_name matches
             payee_match = (
                 payee is not None
                 and CategorizationRuleService._match_pattern(
@@ -328,7 +351,13 @@ class CategorizationRuleService(BaseFamilyService[BudgetCategorizationRule]):
                     rule.pattern, description, rule.rule_type
                 )
             )
-            return payee_match or description_match
+            item_match = (
+                item_name is not None
+                and CategorizationRuleService._match_pattern(
+                    rule.pattern, item_name, rule.rule_type
+                )
+            )
+            return payee_match or description_match or item_match
         else:
             return False
 

--- a/backend/app/services/budget/duplicate_guard_service.py
+++ b/backend/app/services/budget/duplicate_guard_service.py
@@ -1,0 +1,69 @@
+"""Detect a likely duplicate receipt scan within a short time window.
+
+Public surface:
+    DuplicateGuardService.check(db, family_id, payee_id, amount_cents)
+        -> DupWarning | None
+
+Logic:
+- Skip immediately when payee_id is None (can't deduplicate without a payee).
+- Look for an existing BudgetTransaction in the same family, with the same
+  payee, created within the last 60 seconds, whose amount is within 1% of
+  the incoming amount.
+- Returns the MOST RECENT match (order by created_at desc, limit 1), or None.
+- Amount tolerance: max(1, int(abs(amount_cents) * 0.01)) cents — at least
+  1 cent so that tiny amounts still dedup correctly.
+"""
+
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+from uuid import UUID
+
+from sqlalchemy import and_, desc, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.budget import BudgetTransaction
+from app.schemas.budget import DupWarning
+
+
+class DuplicateGuardService:
+
+    WINDOW_SECONDS = 60
+    AMOUNT_TOLERANCE = 0.01  # 1%
+
+    @classmethod
+    async def check(
+        cls,
+        db: AsyncSession,
+        family_id: UUID,
+        payee_id: Optional[UUID],
+        amount_cents: int,
+    ) -> Optional[DupWarning]:
+        """Return a DupWarning if a likely duplicate exists, else None."""
+        if payee_id is None:
+            return None
+
+        cutoff = datetime.now(timezone.utc) - timedelta(seconds=cls.WINDOW_SECONDS)
+        tol = max(1, int(abs(amount_cents) * cls.AMOUNT_TOLERANCE))
+
+        stmt = (
+            select(BudgetTransaction)
+            .where(and_(
+                BudgetTransaction.family_id == family_id,
+                BudgetTransaction.payee_id == payee_id,
+                BudgetTransaction.created_at >= cutoff,
+                BudgetTransaction.amount.between(
+                    amount_cents - tol, amount_cents + tol
+                ),
+            ))
+            .order_by(desc(BudgetTransaction.created_at))
+            .limit(1)
+        )
+        row = (await db.execute(stmt)).scalar_one_or_none()
+        if row is None:
+            return None
+
+        return DupWarning(
+            existing_transaction_id=row.id,
+            scanned_at=row.created_at,
+            amount_cents=int(row.amount),
+        )

--- a/backend/app/services/budget/duplicate_guard_service.py
+++ b/backend/app/services/budget/duplicate_guard_service.py
@@ -50,6 +50,9 @@ class DuplicateGuardService:
             .where(and_(
                 BudgetTransaction.family_id == family_id,
                 BudgetTransaction.payee_id == payee_id,
+                # Exclude soft-deleted rows so the recycle bin can't
+                # resurrect a dup-warning on a re-scan.
+                BudgetTransaction.deleted_at.is_(None),
                 BudgetTransaction.created_at >= cutoff,
                 BudgetTransaction.amount.between(
                     amount_cents - tol, amount_cents + tol

--- a/backend/app/services/budget/receipt_draft_service.py
+++ b/backend/app/services/budget/receipt_draft_service.py
@@ -134,6 +134,10 @@ class ReceiptDraftService:
             from app.services.budget.receipt_scanner_service import _build_notes
             notes = _build_notes(sd.get("payee_name"), sd.get("items", []), sd.get("currency", "MXN"))
 
+        # Carry v2 scanner fields (card_last4, iva_cents) from the draft
+        # through to the persisted transaction. FX fields are intentionally
+        # NOT propagated: FX rate lookup happens at scan time, not at
+        # draft-approval time, and the original FX context is gone by now.
         txn_data = TransactionCreate(
             account_id=draft.account_id,
             date=txn_date,
@@ -143,6 +147,8 @@ class ReceiptDraftService:
             notes=notes,
             cleared=False,
             reconciled=False,
+            card_last4=sd.get("card_last4"),
+            iva_cents=sd.get("iva_cents"),
         )
         transaction = await TransactionService.create(db, family_id, txn_data)
 

--- a/backend/app/services/budget/receipt_scanner_service.py
+++ b/backend/app/services/budget/receipt_scanner_service.py
@@ -22,6 +22,7 @@ import os
 import re
 from dataclasses import dataclass
 from datetime import date
+from decimal import Decimal, ROUND_HALF_UP
 from typing import Optional
 from uuid import UUID
 
@@ -32,11 +33,18 @@ from openai import OpenAI
 
 from app.core.config import settings
 from app.core.exceptions import ValidationError
+from app.core.premium import FEATURE_MIN_PLAN, get_family_plan
 from app.models.budget import BudgetPayee, BudgetTransaction
 from app.schemas.budget import TransactionCreate
 from app.services.budget.transaction_service import TransactionService
 from app.services.budget.categorization_rule_service import CategorizationRuleService
 from app.services.budget.receipt_draft_service import ReceiptDraftService
+
+
+# Plan rank used by is_feature_enabled() to compare a family's plan against
+# the minimum plan required for a given feature. Mirrors core/premium.py's
+# tier ordering without importing the SubscriptionPlan model.
+_PLAN_ORDER = {"free": 0, "plus": 1, "pro": 2}
 
 
 # LiteLLM model alias. Registered in /mnt/nvme/docker-prod/litellm-proxy/
@@ -298,123 +306,336 @@ async def scan_receipt(image_bytes: bytes, media_type: str) -> ScannedReceipt:
     )
 
 
+async def is_feature_enabled(
+    db: AsyncSession, family_id: UUID, feature: str,
+) -> bool:
+    """Cheap boolean check for an optional pipeline feature.
+
+    Unlike ``app.core.premium.require_feature``, this never raises and
+    does not increment usage. Used for the per-call gates inside the
+    scan pipeline — fx_cross_charge, item_trends, a2a_webhook — where a
+    "False" result silently disables the feature rather than rejecting
+    the request.
+
+    Resolves any user in the family to read the plan via
+    ``get_family_plan`` and compares the plan tier to ``FEATURE_MIN_PLAN``.
+    Returns False when no user exists for the family (shouldn't happen
+    in practice but is the safe default).
+    """
+    from app.models.user import User
+
+    r = await db.execute(
+        select(User).where(User.family_id == family_id).limit(1)
+    )
+    user = r.scalar_one_or_none()
+    if user is None:
+        return False
+    plan = await get_family_plan(db, user)
+    min_plan = FEATURE_MIN_PLAN.get(feature, "free")
+    return _PLAN_ORDER.get(plan.name, 0) >= _PLAN_ORDER.get(min_plan, 0)
+
+
 async def scan_and_create_transaction(
     db: AsyncSession,
     family_id: UUID,
-    account_id: UUID,
-    image_bytes: bytes,
-    media_type: str,
+    account_id: Optional[UUID] = None,
+    image_bytes: bytes = b"",
+    media_type: str = "image/jpeg",
+    user_id: Optional[UUID] = None,
+    force: bool = False,
 ) -> dict:
-    """Scan a receipt and create a transaction from the extracted data.
+    """Run the v2 7-stage receipt-scan pipeline.
+
+    Stages:
+        (1) Vision extract
+        (2) Account auto-detect (card_last4 → last_used → none)
+        (3) Drafts routing (low confidence | no accounts | currency mismatch
+            on non-Pro plans)
+        (4) Duplicate guard (60-second / 1% same-payee window)
+        (5) FX cross-charge (for Pro plans when receipt currency != account
+            currency)
+        (6) Persist transaction + items + auto-categorize header and each
+            line item
+        (7) Fan-out: shopping auto-check, item-price trends, a2a webhook
 
     Args:
-        db: Database session
-        family_id: Family ID
-        account_id: Target account
-        image_bytes: Receipt image bytes
-        media_type: Image MIME type
+        db: Async DB session
+        family_id: Tenant scope
+        account_id: Caller-supplied account override; when None the
+            AccountMatchingService picks one
+        image_bytes: Raw bytes of the receipt image / rasterized PDF page
+        media_type: MIME type
+        user_id: Authenticated user — reserved for the future per-user
+            last-used account fallback once ``created_by_id`` is added to
+            ``budget_transactions``. Optional (defaults to None) to keep
+            the v1 endpoint callable until T10 lands.
+        force: When True, bypass the duplicate guard. Set by the endpoint
+            in response to the 409 dup_warning prompt.
 
     Returns:
-        Dict with scanned data, created transaction ID, and metadata
+        dict with the v2 response shape (success, transaction_id, items,
+        account_match, fx, trends, confidence, shopping_auto_checked,
+        warnings, dup_warning, scanned_preview, draft_id, message).
     """
-    # Scan the receipt
+    # Lazy imports — these services live in the same package and would
+    # otherwise create an import cycle at module-load time.
+    from app.services.budget.account_matching_service import (
+        AccountMatchingService,
+    )
+    from app.services.budget.duplicate_guard_service import (
+        DuplicateGuardService,
+    )
+    from app.services.budget.transaction_item_service import (
+        TransactionItemService,
+    )
+    from app.services.budget.a2a_webhook_service import A2AWebhookService
+    from app.services.fx_service import FXService
+
+    # (1) Vision extract -----------------------------------------------------
     receipt = await scan_receipt(image_bytes, media_type)
 
-    scanned_data_dict = {
+    scanned_dict = {
         "date": receipt.date.isoformat() if receipt.date else None,
         "total_amount": receipt.total_amount,
         "payee_name": receipt.payee_name,
         "items": receipt.items,
         "currency": receipt.currency,
+        "card_last4": receipt.card_last4,
+        "iva_cents": receipt.iva_cents,
     }
 
+    # HITL: low confidence routes to the drafts queue (unchanged from v1)
     if receipt.confidence < 0.3 or receipt.total_amount is None:
-        # Save for human review instead of silently discarding
-        draft = await ReceiptDraftService.create(
-            db=db,
-            family_id=family_id,
-            account_id=account_id,
-            scanned_data=scanned_data_dict,
-            confidence=receipt.confidence,
+        return await _route_to_drafts(
+            db, family_id, account_id, image_bytes, receipt, scanned_dict,
+            reason="low_confidence",
         )
-        # Persist the image so the review queue can display it
-        try:
-            os.makedirs(RECEIPT_UPLOADS_DIR, exist_ok=True)
-            img_path = os.path.join(RECEIPT_UPLOADS_DIR, f"{draft.id}.jpg")
-            with open(img_path, "wb") as f:
-                f.write(image_bytes)  # already JPEG (rasterized if PDF)
-            draft.image_url = f"/api/budget/receipt-drafts/{draft.id}/image"
-            await db.commit()
-        except Exception:
-            pass  # image storage failure is non-fatal — draft still exists
-        return {
-            "success": False,
-            "draft_id": str(draft.id),
-            "confidence": receipt.confidence,
-            "scanned_data": scanned_data_dict,
-            "message": "Low confidence — saved for review in the receipt queue.",
-            "transaction_id": None,
-        }
 
-    # Find or create payee
-    payee_id = None
-    if receipt.payee_name:
-        stmt = select(BudgetPayee).where(
-            BudgetPayee.family_id == family_id,
-            BudgetPayee.name == receipt.payee_name,
+    # (2) Account auto-detect ------------------------------------------------
+    match = await AccountMatchingService.match(
+        db, family_id, user_id=user_id,
+        card_last4=receipt.card_last4,
+        receipt_currency=receipt.currency,
+        override_account_id=account_id,
+    )
+    if match.account_id is None:
+        # No accounts at all — drafts queue with no account binding.
+        return await _route_to_drafts(
+            db, family_id, None, image_bytes, receipt, scanned_dict,
+            reason="no_accounts",
         )
-        result = await db.execute(stmt)
-        payee = result.scalars().first()
-        if payee:
-            payee_id = payee.id
-        else:
-            new_payee = BudgetPayee(
-                family_id=family_id,
-                name=receipt.payee_name,
-            )
-            db.add(new_payee)
-            await db.flush()
-            payee_id = new_payee.id
 
-    # Auto-categorize via rules
-    category_id = await CategorizationRuleService.suggest_category(
-        db, family_id,
-        payee=receipt.payee_name,
-        description=None,
+    # Drafts gate: non-Pro and currency mismatch routes to drafts queue.
+    fx_allowed = await is_feature_enabled(db, family_id, "fx_cross_charge")
+    if (
+        match.matched_account_currency
+        and receipt.currency
+        and match.matched_account_currency != receipt.currency
+        and not fx_allowed
+    ):
+        return await _route_to_drafts(
+            db, family_id, match.account_id, image_bytes, receipt,
+            scanned_dict, reason="currency_mismatch",
+        )
+
+    # Resolve payee (needed for dup-guard regardless of force flag — we
+    # want subsequent force=True retries to find the same payee row)
+    payee_id = await _find_or_create_payee(
+        db, family_id, receipt.payee_name,
     )
 
-    # Create the transaction
+    # (3) Duplicate guard ----------------------------------------------------
+    if not force:
+        dup = await DuplicateGuardService.check(
+            db, family_id, payee_id=payee_id,
+            amount_cents=receipt.total_amount,
+        )
+        if dup is not None:
+            # Do NOT commit — the flushed-but-uncommitted new payee row
+            # (if any) will be rolled back when the session closes at the
+            # request boundary. A subsequent force=True call will find/
+            # reuse this payee idempotently via _find_or_create_payee.
+            # We intentionally do not call db.rollback() here: callers
+            # (tests + endpoint) often hold other in-flight reads on the
+            # same session that we must not invalidate.
+            return {
+                "success": False,
+                "transaction_id": None,
+                "dup_warning": {
+                    "existing_transaction_id": str(
+                        dup.existing_transaction_id
+                    ),
+                    "scanned_at": dup.scanned_at.isoformat(),
+                    "amount_cents": dup.amount_cents,
+                    "payee": receipt.payee_name,
+                },
+                "scanned_preview": scanned_dict,
+                "confidence": receipt.confidence,
+                "items": [],
+                "account_match": {
+                    "strategy": match.strategy,
+                    "matched_card_last4": match.matched_card_last4,
+                },
+                "fx": None,
+                "trends": [],
+                "shopping_auto_checked": [],
+                "warnings": [],
+            }
+
+    # (4) FX cross-charge ----------------------------------------------------
+    fx_info: Optional[dict] = None
+    final_amount = receipt.total_amount
+    original_amount_cents: Optional[int] = None
+    original_currency: Optional[str] = None
+    fx_rate: Optional[Decimal] = None
+    warnings: list[str] = []
+    if (
+        match.matched_account_currency
+        and receipt.currency
+        and match.matched_account_currency != receipt.currency
+        and fx_allowed
+    ):
+        rate = await FXService.get_rate(
+            receipt.currency, match.matched_account_currency,
+            on_date=receipt.date or date.today(),
+        )
+        if rate is None:
+            warnings.append("fx_unavailable")
+        else:
+            original_amount_cents = receipt.total_amount
+            original_currency = receipt.currency
+            fx_rate = rate
+            # Convert (signed) — quantize to whole cents with ROUND_HALF_UP
+            final_amount = int(
+                (Decimal(receipt.total_amount) * rate).quantize(
+                    Decimal("1"), rounding=ROUND_HALF_UP,
+                )
+            )
+            fx_info = {
+                "rate": str(rate),
+                "original_amount_cents": original_amount_cents,
+                "original_currency": original_currency,
+            }
+
+    # (5) Persist transaction ------------------------------------------------
     txn_date = receipt.date or date.today()
-    transaction_data = TransactionCreate(
-        account_id=account_id,
+    txn = BudgetTransaction(
+        family_id=family_id,
+        account_id=match.account_id,
         date=txn_date,
-        amount=receipt.total_amount,
+        amount=final_amount,
         payee_id=payee_id,
-        category_id=category_id,
-        notes=_build_notes(receipt.payee_name, receipt.items, receipt.currency),
+        notes=_build_notes(
+            receipt.payee_name, receipt.items, receipt.currency,
+        ),
         cleared=False,
         reconciled=False,
+        card_last4=receipt.card_last4,
+        iva_cents=receipt.iva_cents,
+        fx_rate=fx_rate,
+        original_amount_cents=original_amount_cents,
+        original_currency=original_currency,
+    )
+    db.add(txn)
+    await db.flush()
+
+    # (5b) Persist items ----------------------------------------------------
+    items_persisted = await TransactionItemService.bulk_create(
+        db, family_id, txn.id, items=receipt.items or [],
     )
 
-    transaction = await TransactionService.create(db, family_id, transaction_data)
+    # (6) Auto-categorize (transaction header + each item) ------------------
+    header_cat = await CategorizationRuleService.suggest_category(
+        db, family_id, payee=receipt.payee_name, description=None,
+    )
+    if header_cat:
+        txn.category_id = header_cat
+    for it in items_persisted:
+        it.category_id = await CategorizationRuleService.suggest_category(
+            db, family_id,
+            payee=receipt.payee_name,
+            description=None,
+            item_name=it.name,
+        )
+    await db.commit()
+    await db.refresh(txn)
 
-    # W5.1: Cross-check receipt items against pending shopping items and
-    # auto-mark matches as bought. Failures here must NOT block the
-    # receipt scan response, so we swallow errors after logging.
-    auto_checked: list[str] = []
+    # (7a) Shopping auto-check ----------------------------------------------
+    shopping_auto_checked: list[str] = []
     try:
-        from app.services.shopping_service import ShoppingService  # noqa
-        auto_checked = await _auto_check_shopping_items(
-            db, family_id, [i.get("name", "") for i in receipt.items]
+        shopping_auto_checked = await _auto_check_shopping_items(
+            db, family_id, [i.get("name", "") for i in (receipt.items or [])]
         )
     except Exception:
         import logging
-        logging.getLogger(__name__).exception("shopping auto-check failed")
+        logging.getLogger(__name__).exception(
+            "shopping auto-check failed",
+        )
+
+    # (7b) Trends per item ---------------------------------------------------
+    trends: list[dict] = []
+    if items_persisted and await is_feature_enabled(
+        db, family_id, "item_trends",
+    ):
+        seen: set[str] = set()
+        for it in items_persisted:
+            if it.normalized_name in seen:
+                continue
+            seen.add(it.normalized_name)
+            trend = await TransactionItemService.get_trend(
+                db, family_id, normalized_name=it.normalized_name,
+            )
+            if trend:
+                trends.append(trend.model_dump())
+
+    # (7c) A2A webhook enqueue ----------------------------------------------
+    if await is_feature_enabled(db, family_id, "a2a_webhook"):
+        try:
+            payload = _build_webhook_payload(
+                family_id, txn, items_persisted, receipt.currency,
+                payee_name=receipt.payee_name,
+            )
+            delivery = await A2AWebhookService.enqueue(
+                db, family_id, txn.id, payload=payload,
+            )
+            if delivery is not None:
+                # Best-effort first attempt inline; sweep handles retries.
+                await A2AWebhookService.dispatch_once(db, delivery.id)
+        except Exception:
+            import logging
+            logging.getLogger(__name__).exception(
+                "a2a enqueue/dispatch failed",
+            )
 
     return {
         "success": True,
+        "transaction_id": str(txn.id),
         "draft_id": None,
+        "items": [
+            {
+                "id": str(it.id),
+                "name": it.name,
+                "normalized_name": it.normalized_name,
+                "qty": float(it.qty) if it.qty is not None else None,
+                "unit_price_cents": it.unit_price_cents,
+                "total_cents": it.total_cents,
+                "brand": it.brand,
+                "category_id": str(it.category_id) if it.category_id else None,
+            }
+            for it in items_persisted
+        ],
+        "account_match": {
+            "strategy": match.strategy,
+            "matched_card_last4": match.matched_card_last4,
+        },
+        "fx": fx_info,
+        "trends": trends,
         "confidence": receipt.confidence,
+        "shopping_auto_checked": shopping_auto_checked,
+        "warnings": warnings,
+        "dup_warning": None,
+        "scanned_preview": None,
+        # Back-compat with v1 callers that still read `scanned_data`.
         "scanned_data": {
             "date": txn_date.isoformat(),
             "total_amount": receipt.total_amount,
@@ -422,8 +643,6 @@ async def scan_and_create_transaction(
             "items": receipt.items,
             "currency": receipt.currency,
         },
-        "transaction_id": str(transaction.id),
-        "shopping_auto_checked": auto_checked,
         "message": "Transaction created from receipt scan.",
     }
 
@@ -478,3 +697,167 @@ async def _auto_check_shopping_items(
     if matched_names:
         await db.commit()
     return matched_names
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers for the v2 pipeline.
+# These are module-private (single-underscore) and not part of the public
+# surface — they exist solely to keep scan_and_create_transaction linear
+# and readable. They share the same family-tenant assumptions as the
+# caller (every input is already scoped by family_id).
+# ---------------------------------------------------------------------------
+
+
+async def _find_or_create_payee(
+    db: AsyncSession, family_id: UUID, payee_name: Optional[str],
+) -> Optional[UUID]:
+    """Resolve a payee_id for the given name, inserting a new row if needed.
+
+    Returns None when payee_name is None/empty (anonymous receipt). The
+    new payee row is flushed (so the FK exists for the transaction insert)
+    but NOT committed — the caller's commit / rollback boundary controls
+    durability.
+    """
+    if not payee_name:
+        return None
+    stmt = select(BudgetPayee).where(
+        BudgetPayee.family_id == family_id,
+        BudgetPayee.name == payee_name,
+    )
+    payee = (await db.execute(stmt)).scalars().first()
+    if payee:
+        return payee.id
+    new_payee = BudgetPayee(family_id=family_id, name=payee_name)
+    db.add(new_payee)
+    await db.flush()
+    return new_payee.id
+
+
+async def _route_to_drafts(
+    db: AsyncSession,
+    family_id: UUID,
+    account_id: Optional[UUID],
+    image_bytes: bytes,
+    receipt: "ScannedReceipt",
+    scanned_dict: dict,
+    reason: str = "low_confidence",
+) -> dict:
+    """HITL fallback — persist a BudgetReceiptDraft for human review.
+
+    Used for three cases:
+        - low_confidence: vision returned < 0.3 or no total
+        - no_accounts: family has no active accounts (cannot place tx)
+        - currency_mismatch: receipt currency differs from account
+          currency on a plan that does not allow fx_cross_charge
+
+    When account_id is None (no_accounts case), we cannot create a
+    draft row because ``BudgetReceiptDraft.account_id`` is non-nullable.
+    Returns an error-shape dict in that case instead of crashing.
+    """
+    if account_id is None:
+        # Try to fall back to ANY active, non-deleted account in the family
+        # so the draft has somewhere to live. If there is truly no account
+        # at all we report the error instead of crashing on a NOT-NULL FK.
+        from app.models.budget import BudgetAccount
+        stmt = (
+            select(BudgetAccount)
+            .where(
+                BudgetAccount.family_id == family_id,
+                BudgetAccount.closed.is_(False),
+                BudgetAccount.deleted_at.is_(None),
+            )
+            .limit(1)
+        )
+        fallback = (await db.execute(stmt)).scalars().first()
+        if fallback is None:
+            return {
+                "success": False,
+                "transaction_id": None,
+                "draft_id": None,
+                "confidence": receipt.confidence,
+                "scanned_data": scanned_dict,
+                "message": (
+                    f"No budget account available to attach this receipt "
+                    f"to ({reason})."
+                ),
+            }
+        account_id = fallback.id
+
+    draft = await ReceiptDraftService.create(
+        db=db,
+        family_id=family_id,
+        account_id=account_id,
+        scanned_data=scanned_dict,
+        confidence=receipt.confidence,
+    )
+    # Persist the image so the review queue can render it. Failures here
+    # are non-fatal — the draft row still exists for review.
+    try:
+        os.makedirs(RECEIPT_UPLOADS_DIR, exist_ok=True)
+        img_path = os.path.join(RECEIPT_UPLOADS_DIR, f"{draft.id}.jpg")
+        with open(img_path, "wb") as f:
+            f.write(image_bytes)
+        draft.image_url = f"/api/budget/receipt-drafts/{draft.id}/image"
+        await db.commit()
+    except Exception:
+        pass
+
+    # Surface the routing reason in the message but keep the legacy
+    # "Low confidence" wording so existing v1 UI strings keep working.
+    if reason == "low_confidence":
+        message = "Low confidence — saved for review in the receipt queue."
+    elif reason == "currency_mismatch":
+        message = (
+            "Currency mismatch — saved for review in the receipt queue. "
+            "Upgrade to Pro for automatic FX conversion."
+        )
+    else:
+        message = f"Routed to drafts queue: {reason}"
+
+    return {
+        "success": False,
+        "transaction_id": None,
+        "draft_id": str(draft.id),
+        "confidence": receipt.confidence,
+        "scanned_data": scanned_dict,
+        "message": message,
+    }
+
+
+def _build_webhook_payload(
+    family_id: UUID,
+    txn: BudgetTransaction,
+    items: list,
+    currency: Optional[str],
+    payee_name: Optional[str] = None,
+) -> dict:
+    """Build the a2a webhook payload for a freshly persisted scan.
+
+    Schema: family-budget.receipt.v1 — versioned so external agents can
+    pin against a contract. Mirrors the dispatch headers' X-A2A-Schema.
+    """
+    return {
+        "schema": "family-budget.receipt.v1",
+        "family_id": str(family_id),
+        "transaction_id": str(txn.id),
+        "occurred_at": txn.created_at.isoformat() if txn.created_at else None,
+        "payee": payee_name,
+        "currency": currency,
+        "total_cents": int(txn.amount),
+        "iva_cents": txn.iva_cents,
+        "items": [
+            {
+                "name": it.name,
+                "normalized_name": it.normalized_name,
+                "qty": float(it.qty) if it.qty is not None else None,
+                "unit_price_cents": it.unit_price_cents,
+                "total_cents": it.total_cents,
+                "category": (
+                    str(it.category_id) if it.category_id else None
+                ),
+                "brand": it.brand,
+            }
+            for it in items
+        ],
+        "location_hint": None,
+    }

--- a/backend/app/services/budget/receipt_scanner_service.py
+++ b/backend/app/services/budget/receipt_scanner_service.py
@@ -34,7 +34,7 @@ from openai import OpenAI
 from app.core.config import settings
 from app.core.exceptions import ValidationError
 from app.core.premium import FEATURE_MIN_PLAN, get_family_plan
-from app.models.budget import BudgetPayee, BudgetTransaction
+from app.models.budget import BudgetAccount, BudgetPayee, BudgetTransaction
 from app.schemas.budget import TransactionCreate
 from app.services.budget.transaction_service import TransactionService
 from app.services.budget.categorization_rule_service import CategorizationRuleService
@@ -289,13 +289,33 @@ async def scan_receipt(image_bytes: bytes, media_type: str) -> ScannedReceipt:
         else None
     )
 
-    # Validate iva_cents: only accept int
+    # Coerce total_amount: vision models sometimes emit a float ("-15050.0")
+    # which asyncpg refuses to bind to an INTEGER column ("expected int,
+    # got float"). bool is a subclass of int — reject it explicitly so
+    # `true` in the JSON doesn't get persisted as 1.
+    raw_total = data.get("total_amount")
+    if isinstance(raw_total, bool):
+        parsed_total = None
+    elif isinstance(raw_total, (int, float)):
+        parsed_total = int(raw_total)
+    else:
+        parsed_total = None
+
+    # Same coercion for iva_cents (also INTEGER on the column). Same
+    # bool-rejection trick as above.
     raw_iva = data.get("iva_cents")
-    parsed_iva_cents = raw_iva if isinstance(raw_iva, int) else None
+    if isinstance(raw_iva, bool):
+        parsed_iva_cents = None
+    elif isinstance(raw_iva, int):
+        parsed_iva_cents = raw_iva
+    elif isinstance(raw_iva, float):
+        parsed_iva_cents = int(raw_iva)
+    else:
+        parsed_iva_cents = None
 
     return ScannedReceipt(
         date=parsed_date,
-        total_amount=data.get("total_amount"),
+        total_amount=parsed_total,
         payee_name=data.get("payee_name"),
         items=data.get("items", []),
         currency=data.get("currency", "MXN"),
@@ -444,11 +464,57 @@ async def scan_and_create_transaction(
         db, family_id, receipt.payee_name,
     )
 
-    # (3) Duplicate guard ----------------------------------------------------
+    # (3) FX cross-charge ----------------------------------------------------
+    # Compute final_amount BEFORE dup-guard so cross-currency duplicates
+    # actually compare like-for-like values. Persisted rows hold post-FX
+    # cents — checking against pre-FX would never match.
+    fx_info: Optional[dict] = None
+    final_amount = receipt.total_amount
+    original_amount_cents: Optional[int] = None
+    original_currency: Optional[str] = None
+    fx_rate: Optional[Decimal] = None
+    warnings: list[str] = []
+    if (
+        match.matched_account_currency
+        and receipt.currency
+        and match.matched_account_currency != receipt.currency
+        and fx_allowed
+    ):
+        rate = await FXService.get_rate(
+            receipt.currency, match.matched_account_currency,
+            on_date=receipt.date or date.today(),
+        )
+        if rate is None:
+            # No FX rate available — route to drafts instead of writing the
+            # raw foreign-currency cents into a local-currency account
+            # (would create a ~17x amount error MXN→USD or similar).
+            return await _route_to_drafts(
+                db, family_id, match.account_id, image_bytes, receipt,
+                scanned_dict, reason="fx_unavailable",
+            )
+        original_amount_cents = receipt.total_amount
+        original_currency = receipt.currency
+        fx_rate = rate
+        # Convert (signed) — quantize to whole cents with ROUND_HALF_UP
+        final_amount = int(
+            (Decimal(receipt.total_amount) * rate).quantize(
+                Decimal("1"), rounding=ROUND_HALF_UP,
+            )
+        )
+        fx_info = {
+            "rate": str(rate),
+            "original_amount_cents": original_amount_cents,
+            "original_currency": original_currency,
+        }
+
+    # (4) Duplicate guard ----------------------------------------------------
+    # Compare against the post-FX amount (the value that would actually
+    # land in the database). Pre-FX comparison would let cross-currency
+    # duplicates through.
     if not force:
         dup = await DuplicateGuardService.check(
             db, family_id, payee_id=payee_id,
-            amount_cents=receipt.total_amount,
+            amount_cents=final_amount,
         )
         if dup is not None:
             # Do NOT commit — the flushed-but-uncommitted new payee row
@@ -476,49 +542,27 @@ async def scan_and_create_transaction(
                     "strategy": match.strategy,
                     "matched_card_last4": match.matched_card_last4,
                 },
-                "fx": None,
+                "fx": fx_info,
                 "trends": [],
                 "shopping_auto_checked": [],
-                "warnings": [],
-            }
-
-    # (4) FX cross-charge ----------------------------------------------------
-    fx_info: Optional[dict] = None
-    final_amount = receipt.total_amount
-    original_amount_cents: Optional[int] = None
-    original_currency: Optional[str] = None
-    fx_rate: Optional[Decimal] = None
-    warnings: list[str] = []
-    if (
-        match.matched_account_currency
-        and receipt.currency
-        and match.matched_account_currency != receipt.currency
-        and fx_allowed
-    ):
-        rate = await FXService.get_rate(
-            receipt.currency, match.matched_account_currency,
-            on_date=receipt.date or date.today(),
-        )
-        if rate is None:
-            warnings.append("fx_unavailable")
-        else:
-            original_amount_cents = receipt.total_amount
-            original_currency = receipt.currency
-            fx_rate = rate
-            # Convert (signed) — quantize to whole cents with ROUND_HALF_UP
-            final_amount = int(
-                (Decimal(receipt.total_amount) * rate).quantize(
-                    Decimal("1"), rounding=ROUND_HALF_UP,
-                )
-            )
-            fx_info = {
-                "rate": str(rate),
-                "original_amount_cents": original_amount_cents,
-                "original_currency": original_currency,
+                "warnings": warnings,
             }
 
     # (5) Persist transaction ------------------------------------------------
     txn_date = receipt.date or date.today()
+    # Month-locking gate: a parent may have closed the month after the
+    # receipt date. Route to drafts so the human can re-date or unlock.
+    from app.services.budget.month_locking_service import MonthLockingService
+    try:
+        await MonthLockingService.validate_month_not_closed(
+            db, family_id, date(txn_date.year, txn_date.month, 1),
+        )
+    except ValidationError as exc:
+        scanned_dict["locked_month_error"] = str(exc)
+        return await _route_to_drafts(
+            db, family_id, match.account_id, image_bytes, receipt,
+            scanned_dict, reason="locked_month",
+        )
     txn = BudgetTransaction(
         family_id=family_id,
         account_id=match.account_id,
@@ -595,21 +639,41 @@ async def scan_and_create_transaction(
                 family_id, txn, items_persisted, receipt.currency,
                 payee_name=receipt.payee_name,
             )
-            delivery = await A2AWebhookService.enqueue(
+            # Enqueue only — DO NOT dispatch inline. The webhook target
+            # may be slow (or unreachable) and a 10 s timeout would block
+            # the scan response. The retry sweep (cron, runs every 5 min)
+            # picks up pending deliveries and dispatches them off the hot
+            # path. This keeps the user-facing scan ≤2 s.
+            await A2AWebhookService.enqueue(
                 db, family_id, txn.id, payload=payload,
             )
-            if delivery is not None:
-                # Best-effort first attempt inline; sweep handles retries.
-                await A2AWebhookService.dispatch_once(db, delivery.id)
         except Exception:
             import logging
             logging.getLogger(__name__).exception(
-                "a2a enqueue/dispatch failed",
+                "a2a enqueue failed",
             )
+
+    # Build a small `transaction` sub-object so the confirm card on the
+    # client can render { payee, amount, currency, account_name, iva }
+    # without an extra round-trip. The full TransactionResponse is more
+    # than the card needs and would force a Decimal-aware decoder client
+    # side.
+    matched_account = await db.get(BudgetAccount, match.account_id)
+    display_currency = match.matched_account_currency or receipt.currency
+    transaction_summary = {
+        "id": str(txn.id),
+        "account_id": str(match.account_id),
+        "account_name": matched_account.name if matched_account else None,
+        "amount": int(final_amount),
+        "currency": display_currency,
+        "payee_name": receipt.payee_name,
+        "iva_cents": receipt.iva_cents,
+    }
 
     return {
         "success": True,
         "transaction_id": str(txn.id),
+        "transaction": transaction_summary,
         "draft_id": None,
         "items": [
             {

--- a/backend/app/services/budget/receipt_scanner_service.py
+++ b/backend/app/services/budget/receipt_scanner_service.py
@@ -808,7 +808,7 @@ async def _route_to_drafts(
         message = "Low confidence — saved for review in the receipt queue."
     elif reason == "currency_mismatch":
         message = (
-            "Currency mismatch — saved for review in the receipt queue. "
+            "currency_mismatch — saved for review in the receipt queue. "
             "Upgrade to Pro for automatic FX conversion."
         )
     else:

--- a/backend/app/services/budget/receipt_scanner_service.py
+++ b/backend/app/services/budget/receipt_scanner_service.py
@@ -142,10 +142,13 @@ class ScannedReceipt:
     date: Optional[date]
     total_amount: Optional[int]  # in cents
     payee_name: Optional[str]
-    items: list  # [{name, amount_cents}]
+    items: list  # [{name, amount_cents, ...}]
     currency: str = "MXN"
     raw_text: str = ""
     confidence: float = 0.0
+    # v2 fields
+    card_last4: Optional[str] = None
+    iva_cents: Optional[int] = None
 
 
 RECEIPT_PROMPT = """Analyze this receipt image and extract the following information. Return ONLY valid JSON, no markdown or explanation.
@@ -153,9 +156,20 @@ RECEIPT_PROMPT = """Analyze this receipt image and extract the following informa
 {
   "date": "YYYY-MM-DD or null if unreadable",
   "total_amount": <total in the receipt's smallest currency unit (cents/centavos), as integer, NEGATIVE for expenses>,
+  "iva_cents": <tax/IVA line as positive integer cents, or null if not present>,
   "payee_name": "store/business name or null",
-  "items": [{"name": "item description", "amount_cents": <price in cents as integer>}],
+  "card_last4": "4-digit string (last 4 of the card used) or null",
   "currency": "MXN or USD or other ISO code",
+  "items": [
+    {
+      "name": "item description",
+      "qty": <number or null>,
+      "unit_price_cents": <positive integer cents per unit, or null>,
+      "total_cents": <positive integer cents for the line>,
+      "brand": "string or null",
+      "raw_text": "the original line as printed on the receipt"
+    }
+  ],
   "confidence": <0.0-1.0 how confident you are in the extraction>
 }
 
@@ -163,8 +177,9 @@ Rules:
 - total_amount MUST be negative (it's an expense)
 - If the receipt shows MXN $150.50, total_amount = -15050
 - If the receipt shows $42.99 USD, total_amount = -4299
-- Extract the business/store name as payee_name
-- List individual items if visible
+- card_last4: look for "**1234", "XXXX1234", "terminada en 1234", "Card: ...1234"
+- iva_cents: look for "IVA", "Tax", "Impuesto" line; extract as POSITIVE cents
+- Per item: extract qty when explicit ("2 x", "2 PZA"), brand when present
 - Set confidence based on image clarity and readability
 - If you cannot read the receipt at all, set confidence to 0 and all values to null"""
 
@@ -258,6 +273,18 @@ async def scan_receipt(image_bytes: bytes, media_type: str) -> ScannedReceipt:
         except (ValueError, TypeError):
             pass
 
+    # Validate card_last4: only accept exactly 4 digit characters
+    raw_card = data.get("card_last4")
+    parsed_card_last4 = (
+        raw_card
+        if (isinstance(raw_card, str) and len(raw_card) == 4 and raw_card.isdigit())
+        else None
+    )
+
+    # Validate iva_cents: only accept int
+    raw_iva = data.get("iva_cents")
+    parsed_iva_cents = raw_iva if isinstance(raw_iva, int) else None
+
     return ScannedReceipt(
         date=parsed_date,
         total_amount=data.get("total_amount"),
@@ -266,6 +293,8 @@ async def scan_receipt(image_bytes: bytes, media_type: str) -> ScannedReceipt:
         currency=data.get("currency", "MXN"),
         raw_text=response_text,
         confidence=data.get("confidence", 0.0),
+        card_last4=parsed_card_last4,
+        iva_cents=parsed_iva_cents,
     )
 
 

--- a/backend/app/services/budget/transaction_item_service.py
+++ b/backend/app/services/budget/transaction_item_service.py
@@ -1,0 +1,146 @@
+"""Transaction item CRUD + price-trend lookup.
+
+Items are first-class child rows of a BudgetTransaction. They power:
+- per-item categorization
+- price-trend badges on the confirm card
+- the a2a webhook payload to the external price-comparison agent
+"""
+
+import re
+import unicodedata
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+from uuid import UUID
+
+from sqlalchemy import and_, desc, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.budget import BudgetTransactionItem
+from app.schemas.budget import ItemTrend
+
+
+_LEADING_QTY_RE = re.compile(r"^\s*\d+\s*(?:x|pza|pzas|pieza|piezas)?\s+", re.IGNORECASE)
+# Strips trailing "500g", "1L", "2 kg" etc. (with leading digit)
+_TRAILING_UNIT_RE = re.compile(
+    r"\s*\b\d+\s*(?:kg|g|lt|l|ml|pza|pzas)\b\s*$", re.IGNORECASE
+)
+# Strips trailing bare unit words with no digit, e.g. " kg", " lt", " g"
+_TRAILING_BARE_UNIT_RE = re.compile(
+    r"\s+\b(?:kg|g|lt|l|ml|pza|pzas)\b\s*$", re.IGNORECASE
+)
+_UNIT_SUFFIX_RE = re.compile(
+    r"\s*\b(\d+\s*(?:kg|g|lt|l|ml|pza|pzas|pieza|piezas|pkg|pack))\b\s*",
+    flags=re.IGNORECASE,
+)
+
+
+def normalize_name(raw: str) -> str:
+    """Lowercase, strip accents, strip unit suffixes + leading quantities."""
+    s = unicodedata.normalize("NFKD", raw)
+    s = "".join(c for c in s if not unicodedata.combining(c))
+    s = s.lower()
+    s = _LEADING_QTY_RE.sub("", s)
+    s = _TRAILING_UNIT_RE.sub("", s)
+    s = _TRAILING_BARE_UNIT_RE.sub("", s)
+    s = _UNIT_SUFFIX_RE.sub(" ", s)
+    s = re.sub(r"\s+", " ", s).strip()
+    return s
+
+
+class TransactionItemService:
+
+    @staticmethod
+    async def bulk_create(
+        db: AsyncSession,
+        family_id: UUID,
+        transaction_id: UUID,
+        items: list[dict],
+    ) -> list[BudgetTransactionItem]:
+        """Insert a batch of items as children of a transaction."""
+        rows: list[BudgetTransactionItem] = []
+        for it in items:
+            name = (it.get("name") or "").strip()
+            if not name:
+                continue
+            row = BudgetTransactionItem(
+                family_id=family_id,
+                transaction_id=transaction_id,
+                name=name,
+                normalized_name=normalize_name(name),
+                qty=it.get("qty"),
+                unit_price_cents=it.get("unit_price_cents"),
+                total_cents=int(it.get("total_cents") or 0),
+                category_id=it.get("category_id"),
+                brand=it.get("brand"),
+                raw_text=it.get("raw_text"),
+            )
+            db.add(row)
+            rows.append(row)
+        await db.commit()
+        for r in rows:
+            await db.refresh(r)
+        return rows
+
+    @staticmethod
+    async def list_for_family(
+        db: AsyncSession,
+        family_id: UUID,
+        normalized_name: Optional[str] = None,
+        since: Optional[datetime] = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[BudgetTransactionItem]:
+        stmt = select(BudgetTransactionItem).where(
+            BudgetTransactionItem.family_id == family_id
+        )
+        if normalized_name:
+            stmt = stmt.where(BudgetTransactionItem.normalized_name == normalized_name)
+        if since:
+            stmt = stmt.where(BudgetTransactionItem.created_at >= since)
+        stmt = stmt.order_by(desc(BudgetTransactionItem.created_at)).limit(limit).offset(offset)
+        result = await db.execute(stmt)
+        return list(result.scalars().all())
+
+    @staticmethod
+    async def get_trend(
+        db: AsyncSession,
+        family_id: UUID,
+        normalized_name: str,
+        window_days: int = 90,
+        min_sample: int = 3,
+    ) -> Optional[ItemTrend]:
+        """Return price trend for an item over the last window_days.
+
+        avg_unit_cents = mean of all PRIOR items (excludes the most recent)
+        last_unit_cents = the most recent item's unit_price_cents
+        pct_change = (last - avg) / avg
+        Returns None when sample_size < min_sample OR no priors with unit_price_cents.
+        """
+        since = datetime.now(timezone.utc) - timedelta(days=window_days)
+        stmt = (
+            select(BudgetTransactionItem)
+            .where(and_(
+                BudgetTransactionItem.family_id == family_id,
+                BudgetTransactionItem.normalized_name == normalized_name,
+                BudgetTransactionItem.created_at >= since,
+                BudgetTransactionItem.unit_price_cents.isnot(None),
+            ))
+            .order_by(desc(BudgetTransactionItem.created_at))
+        )
+        rows = list((await db.execute(stmt)).scalars().all())
+        if len(rows) < min_sample:
+            return None
+        last = rows[0]
+        priors = rows[1:]
+        avg = sum(int(p.unit_price_cents) for p in priors) // len(priors)
+        if avg == 0:
+            return None
+        last_v = int(last.unit_price_cents)
+        pct = (last_v - avg) / avg
+        return ItemTrend(
+            normalized_name=normalized_name,
+            avg_unit_cents=avg,
+            last_unit_cents=last_v,
+            pct_change=round(pct, 4),
+            sample_size=len(rows),
+        )

--- a/backend/app/services/budget/transaction_item_service.py
+++ b/backend/app/services/budget/transaction_item_service.py
@@ -12,7 +12,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Optional
 from uuid import UUID
 
-from sqlalchemy import and_, desc, func, select
+from sqlalchemy import and_, desc, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.budget import BudgetTransactionItem

--- a/backend/app/services/budget/transaction_service.py
+++ b/backend/app/services/budget/transaction_service.py
@@ -86,6 +86,11 @@ class TransactionService(BaseFamilyService[BudgetTransaction]):
             parent_id=data.parent_id,
             is_parent=data.is_parent,
             transfer_account_id=data.transfer_account_id,
+            # Scanner v2 fields (forwarded by ReceiptDraftService.approve
+            # so the v2 metadata isn't dropped on the floor when a draft
+            # is promoted to a real transaction).
+            card_last4=getattr(data, "card_last4", None),
+            iva_cents=getattr(data, "iva_cents", None),
         )
 
         db.add(transaction)

--- a/backend/app/services/frankie_service.py
+++ b/backend/app/services/frankie_service.py
@@ -293,6 +293,7 @@ class FrankieService:
                     "reply": reply,
                     "actions": actions_taken,
                     "message_id": str(bot_row.id),
+                    "model": effective_model,
                 })
                 + "\n\n"
             )

--- a/backend/app/services/fx_service.py
+++ b/backend/app/services/fx_service.py
@@ -1,0 +1,78 @@
+"""Foreign-exchange rate lookup with Redis cache.
+
+Public surface: FXService.get_rate(from_ccy, to_ccy, on_date) -> Decimal | None
+
+Source: https://exchangerate.host (free, no API key). Historical endpoint
+returns rates as of a given date. We cache (from, to, date) → rate in Redis
+for 24h since historical rates are immutable.
+"""
+
+from datetime import date
+from decimal import Decimal
+from typing import Optional
+
+import httpx
+import redis.asyncio as aioredis
+
+from app.core.config import settings
+
+
+_REDIS_TTL_SECONDS = 24 * 3600
+
+
+def _get_redis():
+    return aioredis.from_url(settings.REDIS_URL, decode_responses=False)
+
+
+def _cache_key(from_ccy: str, to_ccy: str, on_date: date) -> str:
+    return f"fx:{from_ccy}:{to_ccy}:{on_date.isoformat()}"
+
+
+class FXService:
+
+    @staticmethod
+    async def get_rate(
+        from_ccy: str,
+        to_ccy: str,
+        on_date: date,
+    ) -> Optional[Decimal]:
+        """Return the rate to convert 1 unit of from_ccy into to_ccy on on_date.
+
+        Returns None on any upstream failure — caller decides fallback.
+        """
+        from_ccy = from_ccy.upper()
+        to_ccy = to_ccy.upper()
+        if from_ccy == to_ccy:
+            return Decimal("1")
+
+        redis = _get_redis()
+        key = _cache_key(from_ccy, to_ccy, on_date)
+        try:
+            cached = await redis.get(key)
+            if cached is not None:
+                return Decimal(cached.decode("utf-8"))
+        except Exception:
+            cached = None
+
+        url = f"https://api.exchangerate.host/{on_date.isoformat()}"
+        params = {"base": from_ccy, "symbols": to_ccy}
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                resp = await client.get(url, params=params)
+                resp.raise_for_status()
+                data = resp.json()
+        except Exception:
+            return None
+
+        if not data.get("success", True):  # exchangerate.host omits 'success' on OK
+            return None
+        rate_val = data.get("rates", {}).get(to_ccy)
+        if rate_val is None:
+            return None
+
+        rate = Decimal(str(rate_val))
+        try:
+            await redis.set(key, str(rate), ex=_REDIS_TTL_SECONDS)
+        except Exception:
+            pass
+        return rate

--- a/backend/migrations/versions/2026_05_28_wave4_scanner_v2.py
+++ b/backend/migrations/versions/2026_05_28_wave4_scanner_v2.py
@@ -35,8 +35,8 @@ def upgrade() -> None:
     # later to set the correct last-4.
     op.execute(sa.text(
         "UPDATE budget_accounts SET card_last4 = "
-        "regexp_replace(name, '.*(?:\\*{2,}|terminada en |XXXX|xxxx)(\\d{4}).*', '\\1') "
-        "WHERE name ~* '(\\*{2,}|terminada en |XXXX|xxxx)\\d{4}' "
+        "regexp_replace(name, '.*(?:\\*{2,}|terminada en |XXXX)(\\d{4}).*', '\\1') "
+        "WHERE name ~* '(\\*{2,}|terminada en |XXXX)\\d{4}' "
         "AND card_last4 IS NULL"
     ))
 
@@ -136,9 +136,12 @@ def upgrade() -> None:
                     postgresql_where=sa.text("status IN ('pending', 'failed')"))
     op.create_index("ix_a2a_deliveries_family",
                     "a2a_webhook_deliveries", ["family_id"])
+    op.create_index("ix_a2a_deliveries_transaction",
+                    "a2a_webhook_deliveries", ["transaction_id"])
 
 
 def downgrade() -> None:
+    op.drop_index("ix_a2a_deliveries_transaction", table_name="a2a_webhook_deliveries")
     op.drop_index("ix_a2a_deliveries_family", table_name="a2a_webhook_deliveries")
     op.drop_index("ix_a2a_deliveries_due", table_name="a2a_webhook_deliveries")
     op.drop_table("a2a_webhook_deliveries")

--- a/backend/migrations/versions/2026_05_28_wave4_scanner_v2.py
+++ b/backend/migrations/versions/2026_05_28_wave4_scanner_v2.py
@@ -1,0 +1,161 @@
+"""wave4_scanner_v2: item rows, account card_last4, FX/IVA cols, a2a webhooks
+
+Revision ID: wave4_scanner_v2
+Revises: drop_stripe_v1
+Create Date: 2026-05-28
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID, JSONB
+
+
+revision = "wave4_scanner_v2"
+down_revision = "drop_stripe_v1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # --- BudgetAccount.card_last4 -------------------------------------------------
+    op.add_column(
+        "budget_accounts",
+        sa.Column("card_last4", sa.CHAR(4), nullable=True),
+    )
+    op.create_index(
+        "ix_budget_accounts_family_card_last4",
+        "budget_accounts",
+        ["family_id", "card_last4"],
+        postgresql_where=sa.text("card_last4 IS NOT NULL"),
+    )
+
+    # Backfill from existing account names (e.g. "Mastercard **9222",
+    # "Cheques Banamex ***313", "Tarjeta terminada en 1234"). The regex
+    # requires exactly 4 trailing digits — 3-digit suffixes (e.g. "***313")
+    # are intentionally NOT backfilled and the user can edit the account
+    # later to set the correct last-4.
+    op.execute(sa.text(
+        "UPDATE budget_accounts SET card_last4 = "
+        "regexp_replace(name, '.*(?:\\*{2,}|terminada en |XXXX|xxxx)(\\d{4}).*', '\\1') "
+        "WHERE name ~* '(\\*{2,}|terminada en |XXXX|xxxx)\\d{4}' "
+        "AND card_last4 IS NULL"
+    ))
+
+    # --- BudgetTransaction extra columns -----------------------------------------
+    op.add_column("budget_transactions",
+                  sa.Column("card_last4", sa.CHAR(4), nullable=True))
+    op.add_column("budget_transactions",
+                  sa.Column("iva_cents", sa.BigInteger(), nullable=True))
+    op.add_column("budget_transactions",
+                  sa.Column("fx_rate", sa.Numeric(12, 6), nullable=True))
+    op.add_column("budget_transactions",
+                  sa.Column("original_amount_cents", sa.BigInteger(), nullable=True))
+    op.add_column("budget_transactions",
+                  sa.Column("original_currency", sa.CHAR(3), nullable=True))
+
+    # --- budget_transaction_items ------------------------------------------------
+    op.create_table(
+        "budget_transaction_items",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True,
+                  server_default=sa.text("gen_random_uuid()")),
+        sa.Column("family_id", UUID(as_uuid=True),
+                  sa.ForeignKey("families.id", ondelete="CASCADE"),
+                  nullable=False),
+        sa.Column("transaction_id", UUID(as_uuid=True),
+                  sa.ForeignKey("budget_transactions.id", ondelete="CASCADE"),
+                  nullable=False),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("normalized_name", sa.Text(), nullable=False),
+        sa.Column("qty", sa.Numeric(10, 3), nullable=True),
+        sa.Column("unit_price_cents", sa.BigInteger(), nullable=True),
+        sa.Column("total_cents", sa.BigInteger(), nullable=False),
+        sa.Column("category_id", UUID(as_uuid=True),
+                  sa.ForeignKey("budget_categories.id", ondelete="SET NULL"),
+                  nullable=True),
+        sa.Column("brand", sa.Text(), nullable=True),
+        sa.Column("raw_text", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True),
+                  server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True),
+                  server_default=sa.func.now(), nullable=False),
+    )
+    op.create_index("ix_bti_family_normalized_created",
+                    "budget_transaction_items",
+                    ["family_id", "normalized_name",
+                     sa.text("created_at DESC")])
+    op.create_index("ix_bti_transaction",
+                    "budget_transaction_items", ["transaction_id"])
+    op.create_index("ix_bti_family_category",
+                    "budget_transaction_items", ["family_id", "category_id"])
+
+    # --- family_a2a_webhooks -----------------------------------------------------
+    op.create_table(
+        "family_a2a_webhooks",
+        sa.Column("family_id", UUID(as_uuid=True),
+                  sa.ForeignKey("families.id", ondelete="CASCADE"),
+                  primary_key=True),
+        sa.Column("url", sa.Text(), nullable=False),
+        sa.Column("secret", sa.Text(), nullable=False),
+        sa.Column("enabled", sa.Boolean(), nullable=False,
+                  server_default=sa.text("false")),
+        sa.Column("last_success_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_error", sa.Text(), nullable=True),
+        sa.Column("failure_count", sa.Integer(), nullable=False,
+                  server_default=sa.text("0")),
+        sa.Column("created_at", sa.DateTime(timezone=True),
+                  server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True),
+                  server_default=sa.func.now(), nullable=False),
+    )
+
+    # --- a2a_webhook_deliveries --------------------------------------------------
+    op.create_table(
+        "a2a_webhook_deliveries",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True,
+                  server_default=sa.text("gen_random_uuid()")),
+        sa.Column("family_id", UUID(as_uuid=True),
+                  sa.ForeignKey("families.id", ondelete="CASCADE"),
+                  nullable=False),
+        sa.Column("transaction_id", UUID(as_uuid=True),
+                  sa.ForeignKey("budget_transactions.id", ondelete="CASCADE"),
+                  nullable=False),
+        sa.Column("payload_json", JSONB, nullable=False),
+        sa.Column("status", sa.String(16), nullable=False,
+                  server_default="pending"),
+        sa.Column("attempts", sa.Integer(), nullable=False,
+                  server_default=sa.text("0")),
+        sa.Column("next_retry_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_error", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True),
+                  server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True),
+                  server_default=sa.func.now(), nullable=False),
+    )
+    op.create_index("ix_a2a_deliveries_due",
+                    "a2a_webhook_deliveries",
+                    ["next_retry_at"],
+                    postgresql_where=sa.text("status IN ('pending', 'failed')"))
+    op.create_index("ix_a2a_deliveries_family",
+                    "a2a_webhook_deliveries", ["family_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_a2a_deliveries_family", table_name="a2a_webhook_deliveries")
+    op.drop_index("ix_a2a_deliveries_due", table_name="a2a_webhook_deliveries")
+    op.drop_table("a2a_webhook_deliveries")
+    op.drop_table("family_a2a_webhooks")
+
+    op.drop_index("ix_bti_family_category", table_name="budget_transaction_items")
+    op.drop_index("ix_bti_transaction", table_name="budget_transaction_items")
+    op.drop_index("ix_bti_family_normalized_created",
+                  table_name="budget_transaction_items")
+    op.drop_table("budget_transaction_items")
+
+    op.drop_column("budget_transactions", "original_currency")
+    op.drop_column("budget_transactions", "original_amount_cents")
+    op.drop_column("budget_transactions", "fx_rate")
+    op.drop_column("budget_transactions", "iva_cents")
+    op.drop_column("budget_transactions", "card_last4")
+
+    op.drop_index("ix_budget_accounts_family_card_last4",
+                  table_name="budget_accounts")
+    op.drop_column("budget_accounts", "card_last4")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -457,13 +457,15 @@ async def account_factory(db: AsyncSession):
     async def _make(family_id, *, name: str = "Test Account",
                     card_last4: str | None = None,
                     currency: str = "MXN",
-                    account_type: str = "checking"):
+                    account_type: str = "checking",
+                    closed: bool = False):
         acct = BudgetAccount(
             family_id=family_id,
             name=name,
             type=account_type,
             currency=currency,
             card_last4=card_last4,
+            closed=closed,
         )
         db.add(acct)
         await db.commit()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -353,3 +353,75 @@ async def gig_template_factory(db_session: AsyncSession):
         return t
 
     return _make
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures for scanner-v2 tasks (T4+)
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def family(db: AsyncSession):
+    """A fresh family for scanner-v2 service tests."""
+    from app.models.family import Family
+    fam = Family(name="Test Family")
+    db.add(fam)
+    await db.commit()
+    await db.refresh(fam)
+    return fam
+
+
+@pytest_asyncio.fixture
+async def other_family(db: AsyncSession):
+    """A second family for tenant-isolation tests."""
+    from app.models.family import Family
+    fam = Family(name="Other Family")
+    db.add(fam)
+    await db.commit()
+    await db.refresh(fam)
+    return fam
+
+
+@pytest_asyncio.fixture
+async def transaction(db: AsyncSession, family):
+    """A minimal BudgetTransaction attached to the shared family fixture."""
+    from app.models.budget import BudgetAccount, BudgetTransaction
+    from datetime import date
+    acct = BudgetAccount(family_id=family.id, name="Cash", type="checking",
+                         currency="MXN")
+    db.add(acct)
+    await db.commit()
+    await db.refresh(acct)
+    tx = BudgetTransaction(
+        family_id=family.id, account_id=acct.id, date=date.today(),
+        amount=-10000,
+    )
+    db.add(tx)
+    await db.commit()
+    await db.refresh(tx)
+    return tx
+
+
+@pytest_asyncio.fixture
+async def transaction_factory(db: AsyncSession, family):
+    """Factory that creates BudgetTransaction rows for the shared family."""
+    from app.models.budget import BudgetAccount, BudgetTransaction
+    acct = BudgetAccount(family_id=family.id, name="F", type="checking",
+                         currency="MXN")
+    db.add(acct)
+    await db.commit()
+    await db.refresh(acct)
+
+    async def _make(**kwargs):
+        tx = BudgetTransaction(
+            family_id=kwargs.get("family_id", family.id),
+            account_id=acct.id,
+            date=kwargs.get("date"),
+            amount=kwargs.get("amount", -10000),
+        )
+        db.add(tx)
+        await db.commit()
+        await db.refresh(tx)
+        return tx
+
+    return _make

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -501,3 +501,65 @@ async def transaction_factory_for_account(db: AsyncSession, family):
         return tx
 
     return _make
+
+
+# ---------------------------------------------------------------------------
+# Fixtures for Task 6: DuplicateGuardService
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def payee(db: AsyncSession, family):
+    """A BudgetPayee belonging to the shared family fixture."""
+    from app.models.budget import BudgetPayee
+    p = BudgetPayee(family_id=family.id, name="Test Payee")
+    db.add(p)
+    await db.commit()
+    await db.refresh(p)
+    return p
+
+
+@pytest_asyncio.fixture
+async def transaction_factory_with_payee(db: AsyncSession, family):
+    """Factory: creates a BudgetTransaction with a specific payee + amount.
+
+    If created_at is provided, the timestamp is forced after flush because
+    the column uses server_default=now() — SQLAlchemy only populates it on
+    INSERT, so we override it with a direct UPDATE after the flush.
+    """
+    from app.models.budget import BudgetAccount, BudgetTransaction
+    from datetime import date as date_type
+
+    acct = BudgetAccount(
+        family_id=family.id, name="DupGuard Account",
+        type="checking", currency="MXN",
+    )
+    db.add(acct)
+    await db.commit()
+    await db.refresh(acct)
+
+    async def _make(family_id, payee_id, *, amount: int = -10000,
+                    created_at=None):
+        tx = BudgetTransaction(
+            family_id=family_id,
+            account_id=acct.id,
+            date=date_type.today(),
+            amount=amount,
+            payee_id=payee_id,
+        )
+        db.add(tx)
+        await db.flush()          # assigns PK + server_default created_at
+        if created_at is not None:
+            # Override the server-generated timestamp with the requested value
+            from sqlalchemy import update
+            from app.models.budget import BudgetTransaction as _BT
+            await db.execute(
+                update(_BT)
+                .where(_BT.id == tx.id)
+                .values(created_at=created_at)
+            )
+        await db.commit()
+        await db.refresh(tx)
+        return tx
+
+    return _make

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -425,3 +425,77 @@ async def transaction_factory(db: AsyncSession, family):
         return tx
 
     return _make
+
+
+# ---------------------------------------------------------------------------
+# Fixtures for Task 5: AccountMatchingService
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def user(db: AsyncSession, family):
+    """A minimal PARENT user belonging to the shared family fixture."""
+    from app.models.user import User, UserRole
+    u = User(
+        email="acct-match-test@example.com",
+        name="Test Parent",
+        role=UserRole.PARENT,
+        family_id=family.id,
+        email_verified=True,
+    )
+    db.add(u)
+    await db.commit()
+    await db.refresh(u)
+    return u
+
+
+@pytest_asyncio.fixture
+async def account_factory(db: AsyncSession):
+    """Factory that creates BudgetAccount rows with optional card_last4."""
+    from app.models.budget import BudgetAccount
+
+    async def _make(family_id, *, name: str = "Test Account",
+                    card_last4: str | None = None,
+                    currency: str = "MXN",
+                    account_type: str = "checking"):
+        acct = BudgetAccount(
+            family_id=family_id,
+            name=name,
+            type=account_type,
+            currency=currency,
+            card_last4=card_last4,
+        )
+        db.add(acct)
+        await db.commit()
+        await db.refresh(acct)
+        return acct
+
+    return _make
+
+
+@pytest_asyncio.fixture
+async def transaction_factory_for_account(db: AsyncSession, family):
+    """Factory that creates a BudgetTransaction on a specific account.
+
+    NOTE: BudgetTransaction has no created_by_id / user_id column as of the
+    current schema (only deleted_by_id exists). The user_id kwarg is accepted
+    for API compatibility with the test but is not persisted.
+    TODO: introduce created_by_id on budget_transactions to enable per-user
+    last-used fallback in AccountMatchingService.
+    """
+    from app.models.budget import BudgetTransaction
+    from datetime import date as date_type
+
+    async def _make(account_id, *, user_id=None, amount: int = -10000):
+        tx = BudgetTransaction(
+            family_id=family.id,
+            account_id=account_id,
+            date=date_type.today(),
+            amount=amount,
+        )
+        db.add(tx)
+        await db.commit()
+        await db.refresh(tx)
+        return tx
+
+    return _make

--- a/backend/tests/test_a2a_webhook_service.py
+++ b/backend/tests/test_a2a_webhook_service.py
@@ -1,4 +1,4 @@
-"""A2AWebhookService — enqueue, dispatch, signature, retry sweep."""
+"""A2AWebhookService — enqueue, dispatch, signature, retry sweep, HTTP endpoints."""
 
 import hashlib
 import hmac
@@ -8,8 +8,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
+import pytest_asyncio
+from httpx import AsyncClient
 
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.services.budget.a2a_webhook_service import A2AWebhookService
 from app.models.a2a import FamilyA2AWebhook, A2AWebhookDelivery
@@ -172,3 +175,60 @@ async def test_sweep_picks_up_pending_with_null_next_retry(db, family, transacti
         n = await A2AWebhookService.sweep_retries(db, limit=10)
     assert n == 1
     assert len(ids) == 1
+
+
+# ---------------------------------------------------------------------------
+# HTTP endpoint tests (Task 12): GET / PUT /api/budget/a2a-webhook
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def enabled_webhook(db: AsyncSession, test_family):
+    """Create an enabled FamilyA2AWebhook for test_family (used with auth_headers)."""
+    row = FamilyA2AWebhook(
+        family_id=test_family.id,
+        url="https://hook.example/existing",
+        secret="existing_secret_xyz",
+        enabled=True,
+    )
+    db.add(row)
+    await db.commit()
+    await db.refresh(row)
+    return row
+
+
+@pytest.mark.asyncio
+async def test_put_webhook_returns_secret_on_rotate(
+    client: AsyncClient, auth_headers: dict
+):
+    """PUT with rotate_secret=True must return plaintext secret in response."""
+    resp = await client.put(
+        "/api/budget/a2a-webhook",
+        json={"url": "https://hook.example/x", "enabled": True, "rotate_secret": True},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["secret"] is not None
+
+
+@pytest.mark.asyncio
+async def test_put_rejects_http(client: AsyncClient, auth_headers: dict):
+    """PUT with an http:// URL must be rejected with 422 (Pydantic validation)."""
+    resp = await client.put(
+        "/api/budget/a2a-webhook",
+        json={"url": "http://hook.example/x", "enabled": True, "rotate_secret": True},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_get_webhook_hides_secret(
+    client: AsyncClient, auth_headers: dict, enabled_webhook
+):
+    """GET response must NOT include the secret field."""
+    resp = await client.get("/api/budget/a2a-webhook", headers=auth_headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "secret" not in body

--- a/backend/tests/test_a2a_webhook_service.py
+++ b/backend/tests/test_a2a_webhook_service.py
@@ -232,3 +232,35 @@ async def test_get_webhook_hides_secret(
     assert resp.status_code == 200
     body = resp.json()
     assert "secret" not in body
+
+
+# ---------------------------------------------------------------------------
+# Task 13: /api/internal/a2a/retry sweep endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_internal_retry_requires_token(client: AsyncClient):
+    resp = await client.post("/api/internal/a2a/retry")
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_internal_retry_calls_sweep(client: AsyncClient, monkeypatch):
+    monkeypatch.setattr("app.core.config.settings.INTERNAL_API_TOKEN", "tkn")
+    called = {}
+
+    async def fake_sweep(db, limit=50):
+        called["n"] = limit
+        return 3
+
+    monkeypatch.setattr(
+        "app.services.budget.a2a_webhook_service.A2AWebhookService.sweep_retries",
+        fake_sweep,
+    )
+    resp = await client.post(
+        "/api/internal/a2a/retry",
+        headers={"X-Internal-Token": "tkn"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["processed"] == 3

--- a/backend/tests/test_a2a_webhook_service.py
+++ b/backend/tests/test_a2a_webhook_service.py
@@ -9,6 +9,8 @@ from uuid import uuid4
 
 import pytest
 
+from sqlalchemy import select
+
 from app.services.budget.a2a_webhook_service import A2AWebhookService
 from app.models.a2a import FamilyA2AWebhook, A2AWebhookDelivery
 
@@ -83,6 +85,14 @@ async def test_dispatch_once_signs_and_marks_sent(db, family, transaction):
     ).hexdigest()
     assert sent_headers["X-A2A-Signature"] == expected
 
+    # cfg-side state updates
+    cfg = (await db.execute(
+        select(FamilyA2AWebhook).where(FamilyA2AWebhook.family_id == family.id)
+    )).scalar_one()
+    assert cfg.last_success_at is not None
+    assert cfg.failure_count == 0
+    assert cfg.last_error is None
+
 
 @pytest.mark.asyncio
 async def test_dispatch_failure_schedules_retry(db, family, transaction):
@@ -109,6 +119,12 @@ async def test_dispatch_failure_schedules_retry(db, family, transaction):
     assert delivery.next_retry_at is not None
     assert delivery.next_retry_at > datetime.now(timezone.utc)
 
+    cfg = (await db.execute(
+        select(FamilyA2AWebhook).where(FamilyA2AWebhook.family_id == family.id)
+    )).scalar_one()
+    assert cfg.failure_count == 1
+    assert cfg.last_error is not None
+
 
 @pytest.mark.asyncio
 async def test_sweep_picks_up_due_failed(db, family, transaction):
@@ -131,5 +147,28 @@ async def test_sweep_picks_up_due_failed(db, family, transaction):
                       side_effect=fake_dispatch):
         n = await A2AWebhookService.sweep_retries(db, limit=10)
 
+    assert n == 1
+    assert len(ids) == 1
+
+
+@pytest.mark.asyncio
+async def test_sweep_picks_up_pending_with_null_next_retry(db, family, transaction):
+    """Pending rows must be picked up by the sweep even when next_retry_at is NULL
+    (the freshly-enqueued state). Regression test for the sweep delivery hole."""
+    db.add(FamilyA2AWebhook(
+        family_id=family.id, url="https://x", secret="s", enabled=True,
+    ))
+    db.add(A2AWebhookDelivery(
+        family_id=family.id, transaction_id=transaction.id,
+        payload_json={"a": 1}, status="pending", attempts=0,
+        next_retry_at=None,
+    ))
+    await db.commit()
+    ids: list = []
+    async def fake_dispatch(_db, _id):
+        ids.append(_id)
+    with patch.object(A2AWebhookService, "dispatch_once",
+                      side_effect=fake_dispatch):
+        n = await A2AWebhookService.sweep_retries(db, limit=10)
     assert n == 1
     assert len(ids) == 1

--- a/backend/tests/test_a2a_webhook_service.py
+++ b/backend/tests/test_a2a_webhook_service.py
@@ -1,0 +1,135 @@
+"""A2AWebhookService — enqueue, dispatch, signature, retry sweep."""
+
+import hashlib
+import hmac
+import json
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.services.budget.a2a_webhook_service import A2AWebhookService
+from app.models.a2a import FamilyA2AWebhook, A2AWebhookDelivery
+
+
+@pytest.mark.asyncio
+async def test_enqueue_skips_when_family_has_no_webhook(db, family, transaction):
+    delivery = await A2AWebhookService.enqueue(
+        db, family.id, transaction.id, payload={"hello": "world"},
+    )
+    assert delivery is None
+
+
+@pytest.mark.asyncio
+async def test_enqueue_skips_when_disabled(db, family, transaction):
+    db.add(FamilyA2AWebhook(
+        family_id=family.id, url="https://x", secret="s", enabled=False,
+    ))
+    await db.commit()
+    delivery = await A2AWebhookService.enqueue(
+        db, family.id, transaction.id, payload={"a": 1},
+    )
+    assert delivery is None
+
+
+@pytest.mark.asyncio
+async def test_enqueue_creates_delivery_row(db, family, transaction):
+    db.add(FamilyA2AWebhook(
+        family_id=family.id, url="https://x", secret="s", enabled=True,
+    ))
+    await db.commit()
+    delivery = await A2AWebhookService.enqueue(
+        db, family.id, transaction.id, payload={"k": "v"},
+    )
+    assert delivery is not None
+    assert delivery.status == "pending"
+    assert delivery.payload_json == {"k": "v"}
+
+
+@pytest.mark.asyncio
+async def test_dispatch_once_signs_and_marks_sent(db, family, transaction):
+    secret = "abc123"
+    db.add(FamilyA2AWebhook(
+        family_id=family.id, url="https://hook.example/x",
+        secret=secret, enabled=True,
+    ))
+    await db.commit()
+    delivery = await A2AWebhookService.enqueue(
+        db, family.id, transaction.id, payload={"foo": "bar"},
+    )
+
+    fake_resp = MagicMock()
+    fake_resp.status_code = 202
+    fake_resp.text = "ok"
+
+    fake_client = AsyncMock()
+    fake_client.post = AsyncMock(return_value=fake_resp)
+    fake_client.__aenter__.return_value = fake_client
+    fake_client.__aexit__.return_value = False
+
+    with patch("app.services.budget.a2a_webhook_service.httpx.AsyncClient",
+               return_value=fake_client):
+        await A2AWebhookService.dispatch_once(db, delivery.id)
+
+    await db.refresh(delivery)
+    assert delivery.status == "sent"
+    assert delivery.attempts == 1
+
+    sent_headers = fake_client.post.await_args.kwargs["headers"]
+    body = fake_client.post.await_args.kwargs["content"]
+    expected = "sha256=" + hmac.new(
+        secret.encode(), body, hashlib.sha256
+    ).hexdigest()
+    assert sent_headers["X-A2A-Signature"] == expected
+
+
+@pytest.mark.asyncio
+async def test_dispatch_failure_schedules_retry(db, family, transaction):
+    db.add(FamilyA2AWebhook(
+        family_id=family.id, url="https://x", secret="s", enabled=True,
+    ))
+    await db.commit()
+    delivery = await A2AWebhookService.enqueue(
+        db, family.id, transaction.id, payload={"a": 1},
+    )
+
+    fake_client = AsyncMock()
+    fake_client.post = AsyncMock(side_effect=RuntimeError("net"))
+    fake_client.__aenter__.return_value = fake_client
+    fake_client.__aexit__.return_value = False
+
+    with patch("app.services.budget.a2a_webhook_service.httpx.AsyncClient",
+               return_value=fake_client):
+        await A2AWebhookService.dispatch_once(db, delivery.id)
+
+    await db.refresh(delivery)
+    assert delivery.status == "failed"
+    assert delivery.attempts == 1
+    assert delivery.next_retry_at is not None
+    assert delivery.next_retry_at > datetime.now(timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_sweep_picks_up_due_failed(db, family, transaction):
+    db.add(FamilyA2AWebhook(
+        family_id=family.id, url="https://x", secret="s", enabled=True,
+    ))
+    db.add(A2AWebhookDelivery(
+        family_id=family.id, transaction_id=transaction.id,
+        payload_json={"a": 1}, status="failed", attempts=1,
+        next_retry_at=datetime.now(timezone.utc) - timedelta(seconds=5),
+    ))
+    await db.commit()
+
+    ids: list = []
+
+    async def fake_dispatch(_db, _id):
+        ids.append(_id)
+
+    with patch.object(A2AWebhookService, "dispatch_once",
+                      side_effect=fake_dispatch):
+        n = await A2AWebhookService.sweep_retries(db, limit=10)
+
+    assert n == 1
+    assert len(ids) == 1

--- a/backend/tests/test_account_matching_service.py
+++ b/backend/tests/test_account_matching_service.py
@@ -1,0 +1,56 @@
+"""AccountMatchingService — pick an account from card_last4 + fallbacks."""
+
+from uuid import uuid4
+import pytest
+
+from app.services.budget.account_matching_service import AccountMatchingService
+
+
+@pytest.mark.asyncio
+async def test_exact_card_last4_match(db, family, account_factory):
+    a = await account_factory(family.id, name="MC 9222", card_last4="9222",
+                               currency="MXN")
+    pick = await AccountMatchingService.match(
+        db, family.id, user_id=uuid4(),
+        card_last4="9222", receipt_currency="MXN",
+    )
+    assert pick.strategy == "card_last4"
+    assert pick.account_id == a.id
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_card_last4_narrows_by_currency(db, family, account_factory):
+    mxn = await account_factory(family.id, name="MC 9222 MXN",
+                                 card_last4="9222", currency="MXN")
+    usd = await account_factory(family.id, name="MC 9222 USD",
+                                 card_last4="9222", currency="USD")
+    pick = await AccountMatchingService.match(
+        db, family.id, user_id=uuid4(),
+        card_last4="9222", receipt_currency="USD",
+    )
+    assert pick.strategy == "card_last4"
+    assert pick.account_id == usd.id
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_last_used_when_no_match(db, family, user, account_factory,
+                                                     transaction_factory_for_account):
+    a1 = await account_factory(family.id, name="A1", currency="MXN")
+    a2 = await account_factory(family.id, name="A2", currency="MXN")
+    # Most recent tx in family is on a2 (transaction_factory_for_account creates it)
+    await transaction_factory_for_account(a2.id, user_id=user.id)
+    pick = await AccountMatchingService.match(
+        db, family.id, user_id=user.id,
+        card_last4=None, receipt_currency="MXN",
+    )
+    assert pick.strategy == "last_used"
+    assert pick.account_id == a2.id
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_no_accounts_at_all(db, family, user):
+    pick = await AccountMatchingService.match(
+        db, family.id, user_id=user.id,
+        card_last4=None, receipt_currency="MXN",
+    )
+    assert pick.account_id is None

--- a/backend/tests/test_account_matching_service.py
+++ b/backend/tests/test_account_matching_service.py
@@ -54,3 +54,45 @@ async def test_returns_none_when_no_accounts_at_all(db, family, user):
         card_last4=None, receipt_currency="MXN",
     )
     assert pick.account_id is None
+    assert pick.strategy == "none"
+
+
+@pytest.mark.asyncio
+async def test_override_account_id_wins_when_valid(db, family, user, account_factory):
+    a = await account_factory(family.id, name="Override target", currency="MXN")
+    pick = await AccountMatchingService.match(
+        db, family.id, user_id=user.id,
+        card_last4="9222", receipt_currency="MXN",
+        override_account_id=a.id,
+    )
+    assert pick.strategy == "override"
+    assert pick.account_id == a.id
+
+
+@pytest.mark.asyncio
+async def test_override_from_other_family_is_silently_ignored(
+    db, family, other_family, user, account_factory,
+):
+    """An override pointing to another family's account is dropped silently,
+    matching the documented behavior. The method falls through to the next
+    strategy (here: 'none' because no other accounts exist)."""
+    other_acct = await account_factory(other_family.id, name="OF", currency="MXN")
+    pick = await AccountMatchingService.match(
+        db, family.id, user_id=user.id,
+        card_last4=None, receipt_currency="MXN",
+        override_account_id=other_acct.id,
+    )
+    assert pick.strategy != "override"
+    assert pick.account_id is None
+
+
+@pytest.mark.asyncio
+async def test_card_last4_skips_closed_account(db, family, user, account_factory):
+    closed_acct = await account_factory(
+        family.id, name="closed", card_last4="9222", currency="MXN", closed=True,
+    )
+    pick = await AccountMatchingService.match(
+        db, family.id, user_id=user.id,
+        card_last4="9222", receipt_currency="MXN",
+    )
+    assert pick.strategy != "card_last4"

--- a/backend/tests/test_duplicate_guard_service.py
+++ b/backend/tests/test_duplicate_guard_service.py
@@ -1,0 +1,63 @@
+"""DuplicateGuardService — flag same-payee same-amount recent receipts."""
+
+from datetime import datetime, timedelta, timezone
+import pytest
+
+from app.services.budget.duplicate_guard_service import DuplicateGuardService
+
+
+@pytest.mark.asyncio
+async def test_flags_same_payee_same_amount_within_60s(
+    db, family, payee, transaction_factory_with_payee,
+):
+    recent = await transaction_factory_with_payee(
+        family.id, payee.id, amount=-72040,
+        created_at=datetime.now(timezone.utc) - timedelta(seconds=30),
+    )
+    dup = await DuplicateGuardService.check(
+        db, family.id, payee_id=payee.id, amount_cents=-72040,
+    )
+    assert dup is not None
+    assert dup.existing_transaction_id == recent.id
+
+
+@pytest.mark.asyncio
+async def test_does_not_flag_after_60s(
+    db, family, payee, transaction_factory_with_payee,
+):
+    await transaction_factory_with_payee(
+        family.id, payee.id, amount=-72040,
+        created_at=datetime.now(timezone.utc) - timedelta(seconds=90),
+    )
+    dup = await DuplicateGuardService.check(
+        db, family.id, payee_id=payee.id, amount_cents=-72040,
+    )
+    assert dup is None
+
+
+@pytest.mark.asyncio
+async def test_does_not_flag_when_amount_differs_more_than_1pct(
+    db, family, payee, transaction_factory_with_payee,
+):
+    await transaction_factory_with_payee(
+        family.id, payee.id, amount=-72040,
+        created_at=datetime.now(timezone.utc) - timedelta(seconds=10),
+    )
+    dup = await DuplicateGuardService.check(
+        db, family.id, payee_id=payee.id, amount_cents=-80000,
+    )
+    assert dup is None
+
+
+@pytest.mark.asyncio
+async def test_does_not_cross_families(
+    db, family, other_family, payee, transaction_factory_with_payee,
+):
+    await transaction_factory_with_payee(
+        other_family.id, payee.id, amount=-72040,
+        created_at=datetime.now(timezone.utc) - timedelta(seconds=10),
+    )
+    dup = await DuplicateGuardService.check(
+        db, family.id, payee_id=payee.id, amount_cents=-72040,
+    )
+    assert dup is None

--- a/backend/tests/test_fx_service.py
+++ b/backend/tests/test_fx_service.py
@@ -1,6 +1,5 @@
 """FXService — historical rate lookup via exchangerate.host with Redis cache."""
 
-import json
 from datetime import date
 from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -45,6 +44,8 @@ async def test_fetches_and_caches(monkeypatch):
         # Second call: redis returns cached
         rate2 = await FXService.get_rate("USD", "MXN", date(2026, 5, 28))
         assert rate2 == Decimal("17.15")
+        # Lock in cache-hit semantics: HTTP must NOT be called on the second invocation.
+        fake_client.get.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_fx_service.py
+++ b/backend/tests/test_fx_service.py
@@ -1,0 +1,65 @@
+"""FXService — historical rate lookup via exchangerate.host with Redis cache."""
+
+import json
+from datetime import date
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.fx_service import FXService
+
+
+@pytest.mark.asyncio
+async def test_returns_one_for_same_currency():
+    rate = await FXService.get_rate("MXN", "MXN", date(2026, 5, 28))
+    assert rate == Decimal("1")
+
+
+@pytest.mark.asyncio
+async def test_fetches_and_caches(monkeypatch):
+    """First call hits HTTP; second hits Redis cache."""
+    fake_redis = MagicMock()
+    fake_redis.get = AsyncMock(side_effect=[None, b"17.15"])
+    fake_redis.set = AsyncMock()
+    monkeypatch.setattr("app.services.fx_service._get_redis",
+                        lambda: fake_redis)
+
+    fake_response = MagicMock()
+    fake_response.json.return_value = {
+        "success": True,
+        "rates": {"MXN": 17.15},
+    }
+    fake_response.raise_for_status = MagicMock()
+
+    fake_client = AsyncMock()
+    fake_client.get = AsyncMock(return_value=fake_response)
+    fake_client.__aenter__.return_value = fake_client
+    fake_client.__aexit__.return_value = False
+
+    with patch("app.services.fx_service.httpx.AsyncClient", return_value=fake_client):
+        rate = await FXService.get_rate("USD", "MXN", date(2026, 5, 28))
+        assert rate == Decimal("17.15")
+        fake_redis.set.assert_awaited_once()
+
+        # Second call: redis returns cached
+        rate2 = await FXService.get_rate("USD", "MXN", date(2026, 5, 28))
+        assert rate2 == Decimal("17.15")
+
+
+@pytest.mark.asyncio
+async def test_returns_none_on_http_failure(monkeypatch):
+    fake_redis = MagicMock()
+    fake_redis.get = AsyncMock(return_value=None)
+    fake_redis.set = AsyncMock()
+    monkeypatch.setattr("app.services.fx_service._get_redis",
+                        lambda: fake_redis)
+
+    fake_client = AsyncMock()
+    fake_client.get = AsyncMock(side_effect=RuntimeError("boom"))
+    fake_client.__aenter__.return_value = fake_client
+    fake_client.__aexit__.return_value = False
+
+    with patch("app.services.fx_service.httpx.AsyncClient", return_value=fake_client):
+        rate = await FXService.get_rate("USD", "MXN", date(2026, 5, 28))
+        assert rate is None

--- a/backend/tests/test_premium_v2.py
+++ b/backend/tests/test_premium_v2.py
@@ -1,0 +1,224 @@
+"""Tests for scanner-v2 premium feature flags.
+
+Covers:
+  - a2a_webhook blocked on free plan (plus required)
+  - fx_cross_charge allowed on pro plan
+  - Regression: free-tier user with USD receipt on MXN account is routed to
+    HITL drafts queue, not auto-FX-converted (Spec §10 + T9 spec review).
+"""
+import pytest
+import pytest_asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+from app.core.premium import FamilyPlan, DEFAULT_FREE_LIMITS
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def free_user(db, family):
+    """A PARENT user whose family is on the free plan (no active subscription).
+
+    Plan is resolved via monkeypatching get_family_plan in each test — this
+    fixture only creates the User row so require_feature has a valid user arg.
+    """
+    from app.models.user import User, UserRole
+    u = User(
+        email="free-plan-user@test.example",
+        name="Free User",
+        role=UserRole.PARENT,
+        family_id=family.id,
+        email_verified=True,
+    )
+    db.add(u)
+    await db.commit()
+    await db.refresh(u)
+    return u
+
+
+@pytest_asyncio.fixture
+async def pro_user(db, family):
+    """A PARENT user whose family will be patched onto the pro plan."""
+    from app.models.user import User, UserRole
+    u = User(
+        email="pro-plan-user@test.example",
+        name="Pro User",
+        role=UserRole.PARENT,
+        family_id=family.id,
+        email_verified=True,
+    )
+    db.add(u)
+    await db.commit()
+    await db.refresh(u)
+    return u
+
+
+def _free_plan(family_id=None) -> FamilyPlan:
+    """Return a FamilyPlan representing the free tier."""
+    return FamilyPlan(
+        name="free",
+        limits=dict(DEFAULT_FREE_LIMITS),
+        status="active",
+        family_id=family_id,
+    )
+
+
+def _pro_plan(family_id=None) -> FamilyPlan:
+    """Return a FamilyPlan representing the pro tier."""
+    return FamilyPlan(
+        name="pro",
+        limits={
+            **DEFAULT_FREE_LIMITS,
+            "budget_reports": True,
+            "budget_goals": True,
+            "csv_import": True,
+            "ai_features": True,
+            "max_receipt_scans_per_month": -1,
+            "max_recurring_transactions": -1,
+            "max_budget_transactions_per_month": -1,
+            "max_family_members": -1,
+            "max_budget_accounts": -1,
+            "max_gigs_per_month": -1,
+            "a2a_webhook": True,
+            "item_trends": True,
+            "fx_cross_charge": True,
+        },
+        status="active",
+        family_id=family_id,
+    )
+
+
+def _plus_plan(family_id=None) -> FamilyPlan:
+    """Return a FamilyPlan representing the plus tier."""
+    return FamilyPlan(
+        name="plus",
+        limits={
+            **DEFAULT_FREE_LIMITS,
+            "budget_reports": True,
+            "budget_goals": True,
+            "csv_import": True,
+            "ai_features": True,
+            "max_receipt_scans_per_month": -1,
+            "max_recurring_transactions": -1,
+            "max_budget_transactions_per_month": -1,
+            "max_family_members": -1,
+            "max_budget_accounts": -1,
+            "max_gigs_per_month": -1,
+            "a2a_webhook": True,
+            "item_trends": True,
+            "fx_cross_charge": False,
+        },
+        status="active",
+        family_id=family_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Plan flag tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_free_plan_blocks_a2a_webhook(db, free_user, monkeypatch):
+    """Free plan must not allow a2a_webhook (requires plus)."""
+    from app.core.premium import require_feature
+
+    monkeypatch.setattr(
+        "app.core.premium.get_family_plan",
+        AsyncMock(return_value=_free_plan(free_user.family_id)),
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        await require_feature("a2a_webhook", db, free_user)
+
+    # Should be an HTTP 403
+    exc = exc_info.value
+    assert hasattr(exc, "status_code"), (
+        f"Expected HTTPException, got {type(exc).__name__}: {exc}"
+    )
+    assert exc.status_code == 403
+    assert exc.detail["error"] == "upgrade_required"
+    assert exc.detail["feature"] == "a2a_webhook"
+    assert exc.detail["plan_needed"] == "plus"
+
+
+@pytest.mark.asyncio
+async def test_pro_plan_allows_fx_cross_charge(db, pro_user, monkeypatch):
+    """Pro plan must allow fx_cross_charge (no exception raised)."""
+    from app.core.premium import require_feature
+
+    monkeypatch.setattr(
+        "app.core.premium.get_family_plan",
+        AsyncMock(return_value=_pro_plan(pro_user.family_id)),
+    )
+
+    # Must not raise
+    plan = await require_feature("fx_cross_charge", db, pro_user)
+    assert plan.name == "pro"
+
+
+# ---------------------------------------------------------------------------
+# Regression: Spec §10 — free-tier currency mismatch routes to drafts
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_free_user_currency_mismatch_routes_to_drafts(
+    db, family, free_user, account_factory, monkeypatch,
+):
+    """Spec §10 + T9 spec review: free-tier users with a USD receipt on an MXN
+    account must be routed to the HITL drafts queue (not auto-FX-converted).
+    """
+    from datetime import date
+    from app.services.budget.receipt_scanner_service import scan_and_create_transaction
+
+    mxn = await account_factory(family.id, name="MXN cash", currency="MXN")
+
+    fake_receipt = MagicMock(
+        date=date(2026, 5, 28),
+        total_amount=-4200,
+        payee_name="WALMART US",
+        currency="USD",
+        card_last4=None,
+        iva_cents=None,
+        confidence=0.92,
+        items=[],
+        raw_text="",
+    )
+
+    async def fake_scan(_b, _t):
+        return fake_receipt
+
+    monkeypatch.setattr(
+        "app.services.budget.receipt_scanner_service.scan_receipt", fake_scan,
+    )
+
+    # Patch get_family_plan in the scanner service module to return free plan.
+    # is_feature_enabled() resolves it via get_family_plan, so patching at
+    # the scanner module level is sufficient.
+    monkeypatch.setattr(
+        "app.services.budget.receipt_scanner_service.get_family_plan",
+        AsyncMock(return_value=_free_plan(family.id)),
+    )
+
+    result = await scan_and_create_transaction(
+        db=db,
+        family_id=family.id,
+        user_id=free_user.id,
+        account_id=mxn.id,
+        image_bytes=b"x",
+        media_type="image/jpeg",
+        force=False,
+    )
+
+    assert result["success"] is False
+    assert result["transaction_id"] is None
+    assert result.get("draft_id") is not None, (
+        f"Expected draft_id to be set, got result={result!r}"
+    )
+    assert "currency_mismatch" in (result.get("message") or ""), (
+        f"Expected 'currency_mismatch' in message, got: {result.get('message')!r}"
+    )

--- a/backend/tests/test_receipt_scanner_v2.py
+++ b/backend/tests/test_receipt_scanner_v2.py
@@ -1,7 +1,11 @@
+from datetime import date
 from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
-from app.services.budget.receipt_scanner_service import scan_receipt
+from app.services.budget.receipt_scanner_service import (
+    scan_and_create_transaction,
+    scan_receipt,
+)
 
 
 def _mock_vision_json(payload: dict):
@@ -50,3 +54,241 @@ async def test_scan_extracts_card_last4_iva_and_items(monkeypatch):
     assert item["qty"] == 2
     assert item["unit_price_cents"] == 3200
     assert item["raw_text"].startswith("LECHE ALPURA")
+
+
+# ---------------------------------------------------------------------------
+# T9 — full 7-stage scan_and_create_transaction pipeline
+# ---------------------------------------------------------------------------
+
+
+def _fake_receipt(**overrides):
+    """Build a MagicMock ScannedReceipt-shape with sensible defaults."""
+    fields = {
+        "date": date(2026, 5, 28),
+        "total_amount": -72040,
+        "payee_name": "HEB",
+        "items": [],
+        "currency": "MXN",
+        "raw_text": "",
+        "confidence": 0.92,
+        "card_last4": None,
+        "iva_cents": None,
+    }
+    fields.update(overrides)
+    return MagicMock(**fields)
+
+
+@pytest.mark.asyncio
+async def test_pipeline_creates_tx_with_items_and_fx(
+    db, family, user, account_factory, monkeypatch,
+):
+    """Happy path: vision → card_last4 match → tx+item persisted."""
+    mxn = await account_factory(
+        family.id, name="MC MXN", card_last4="9222", currency="MXN",
+    )
+
+    fake_receipt = _fake_receipt(
+        card_last4="9222",
+        iva_cents=9683,
+        items=[
+            {"name": "Leche", "qty": 2, "unit_price_cents": 3200,
+             "total_cents": 6400, "raw_text": "LECHE 2x 64.00"},
+        ],
+    )
+
+    async def fake_scan(_b, _t):
+        return fake_receipt
+
+    monkeypatch.setattr(
+        "app.services.budget.receipt_scanner_service.scan_receipt", fake_scan,
+    )
+
+    result = await scan_and_create_transaction(
+        db=db,
+        family_id=family.id,
+        user_id=user.id,
+        account_id=None,
+        image_bytes=b"x",
+        media_type="image/jpeg",
+        force=False,
+    )
+    assert result["success"] is True
+    assert result["transaction_id"] is not None
+    assert len(result["items"]) == 1
+    assert result["account_match"]["strategy"] == "card_last4"
+
+    # Verify the transaction landed on the matched MXN account.
+    from sqlalchemy import select
+    from app.models.budget import BudgetTransaction
+    row = (await db.execute(
+        select(BudgetTransaction).where(
+            BudgetTransaction.id == result["transaction_id"]
+        )
+    )).scalar_one()
+    assert row.account_id == mxn.id
+    assert row.card_last4 == "9222"
+    assert row.iva_cents == 9683
+
+
+@pytest.mark.asyncio
+async def test_pipeline_returns_dup_warning_without_committing(
+    db, family, user, account_factory, payee,
+    transaction_factory_with_payee, monkeypatch,
+):
+    """Same-payee same-amount recent tx → returns dup_warning, no new tx persisted."""
+    await account_factory(
+        family.id, name="MC MXN", card_last4="9222", currency="MXN",
+    )
+    # Seed a recent matching transaction
+    await transaction_factory_with_payee(
+        family.id, payee.id, amount=-72040,
+    )
+
+    fake_receipt = _fake_receipt(
+        card_last4="9222",
+        payee_name=payee.name,
+    )
+
+    async def fake_scan(_b, _t):
+        return fake_receipt
+
+    monkeypatch.setattr(
+        "app.services.budget.receipt_scanner_service.scan_receipt", fake_scan,
+    )
+
+    # Count tx rows before the call
+    from sqlalchemy import func, select
+    from app.models.budget import BudgetTransaction
+    before = (await db.execute(
+        select(func.count()).select_from(BudgetTransaction).where(
+            BudgetTransaction.family_id == family.id,
+        )
+    )).scalar_one()
+
+    result = await scan_and_create_transaction(
+        db=db,
+        family_id=family.id,
+        user_id=user.id,
+        account_id=None,
+        image_bytes=b"x",
+        media_type="image/jpeg",
+        force=False,
+    )
+    assert result["success"] is False
+    assert result["dup_warning"] is not None
+    assert result["transaction_id"] is None
+
+    # No new transaction should have been persisted.
+    after = (await db.execute(
+        select(func.count()).select_from(BudgetTransaction).where(
+            BudgetTransaction.family_id == family.id,
+        )
+    )).scalar_one()
+    assert after == before
+
+
+@pytest.mark.asyncio
+async def test_force_true_bypasses_duplicate_guard(
+    db, family, user, account_factory, payee,
+    transaction_factory_with_payee, monkeypatch,
+):
+    """force=True skips the dup-guard check and commits the transaction."""
+    await account_factory(
+        family.id, name="MC MXN", card_last4="9222", currency="MXN",
+    )
+    await transaction_factory_with_payee(
+        family.id, payee.id, amount=-72040,
+    )
+
+    fake_receipt = _fake_receipt(
+        card_last4="9222",
+        payee_name=payee.name,
+    )
+
+    async def fake_scan(_b, _t):
+        return fake_receipt
+
+    monkeypatch.setattr(
+        "app.services.budget.receipt_scanner_service.scan_receipt", fake_scan,
+    )
+
+    result = await scan_and_create_transaction(
+        db=db,
+        family_id=family.id,
+        user_id=user.id,
+        account_id=None,
+        image_bytes=b"x",
+        media_type="image/jpeg",
+        force=True,
+    )
+    assert result["success"] is True
+    assert result["transaction_id"] is not None
+    assert result.get("dup_warning") is None
+
+
+@pytest.mark.asyncio
+async def test_pipeline_stores_fx_when_currencies_differ(
+    db, family, user, account_factory, monkeypatch,
+):
+    """USD receipt on a MXN account: rate stored, original amount preserved."""
+    mxn = await account_factory(
+        family.id, name="MC MXN", card_last4=None, currency="MXN",
+    )
+
+    fake_receipt = _fake_receipt(
+        total_amount=-4200,
+        payee_name="WALMART US",
+        currency="USD",
+        card_last4=None,
+    )
+
+    async def fake_scan(_b, _t):
+        return fake_receipt
+
+    monkeypatch.setattr(
+        "app.services.budget.receipt_scanner_service.scan_receipt", fake_scan,
+    )
+
+    from decimal import Decimal
+
+    async def fake_fx(*_a, **_k):
+        return Decimal("17.15")
+
+    monkeypatch.setattr(
+        "app.services.fx_service.FXService.get_rate", fake_fx,
+    )
+
+    # Pro plan: fx_cross_charge is allowed
+    monkeypatch.setattr(
+        "app.services.budget.receipt_scanner_service.is_feature_enabled",
+        AsyncMock(return_value=True),
+    )
+
+    result = await scan_and_create_transaction(
+        db=db,
+        family_id=family.id,
+        user_id=user.id,
+        account_id=mxn.id,
+        image_bytes=b"x",
+        media_type="image/jpeg",
+        force=False,
+    )
+    assert result["success"] is True
+    assert result["fx"] is not None
+    assert result["fx"]["rate"] == "17.15"
+    assert result["fx"]["original_currency"] == "USD"
+    assert result["fx"]["original_amount_cents"] == -4200
+
+    # Verify the persisted transaction reflects the converted amount + FX cols.
+    from sqlalchemy import select
+    from app.models.budget import BudgetTransaction
+    row = (await db.execute(
+        select(BudgetTransaction).where(
+            BudgetTransaction.id == result["transaction_id"]
+        )
+    )).scalar_one()
+    assert row.original_amount_cents == -4200
+    assert row.original_currency == "USD"
+    assert str(row.fx_rate) in ("17.150000", "17.15")  # numeric(12,6)
+    # -4200 * 17.15 = -72030 (with ROUND_HALF_UP)
+    assert row.amount in (-72030, -72031)

--- a/backend/tests/test_receipt_scanner_v2.py
+++ b/backend/tests/test_receipt_scanner_v2.py
@@ -483,12 +483,17 @@ async def test_endpoint_force_true_commits(client, auth_headers,
 async def test_endpoint_account_id_overrides_auto_detect(
     client, auth_headers, account_factory_authed,
 ):
-    """account_id query param flows to pipeline and strategy is 'override'."""
+    """account_id form-data flows to pipeline and strategy is 'override'."""
     a = await account_factory_authed(currency="MXN")
+    # account_id rides the multipart form (Form(...) on the endpoint), not
+    # the query string — pin that contract here so a regression to
+    # ?account_id=... gets caught.
     files = {"file": ("r.jpg", b"\xff\xd8\xff\xe0", "image/jpeg")}
+    data = {"account_id": str(a.id)}
     resp = await client.post(
-        f"/api/budget/transactions/scan-receipt?account_id={a.id}",
+        "/api/budget/transactions/scan-receipt",
         files=files,
+        data=data,
         headers=auth_headers,
     )
     assert resp.status_code == 200

--- a/backend/tests/test_receipt_scanner_v2.py
+++ b/backend/tests/test_receipt_scanner_v2.py
@@ -1,6 +1,7 @@
 from datetime import date
 from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
+import pytest_asyncio
 
 from app.services.budget.receipt_scanner_service import (
     scan_and_create_transaction,
@@ -292,3 +293,204 @@ async def test_pipeline_stores_fx_when_currencies_differ(
     assert str(row.fx_rate) in ("17.150000", "17.15")  # numeric(12,6)
     # -4200 * 17.15 = -72030 (with ROUND_HALF_UP)
     assert row.amount in (-72030, -72031)
+
+
+# ---------------------------------------------------------------------------
+# T10 — Endpoint tests: force, 409 dup_warning, account_id override
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def family_with_recent_heb_tx(
+    db_session, test_family, test_parent_user, monkeypatch,
+):
+    """Set up: a BudgetAccount in the test family, a recent HEB tx, and
+    monkeypatch scan_and_create_transaction so subsequent endpoint calls
+    see a dup_warning (or success on force=True).
+    """
+    from app.models.budget import BudgetAccount, BudgetTransaction, BudgetPayee
+    from datetime import date as date_type
+
+    # Create account + payee + recent tx
+    acct = BudgetAccount(
+        family_id=test_family.id, name="HEB Card", type="credit", currency="MXN",
+    )
+    db_session.add(acct)
+    await db_session.flush()
+
+    payee = BudgetPayee(family_id=test_family.id, name="HEB")
+    db_session.add(payee)
+    await db_session.flush()
+
+    tx = BudgetTransaction(
+        family_id=test_family.id, account_id=acct.id,
+        date=date_type.today(), amount=-72040, payee_id=payee.id,
+    )
+    db_session.add(tx)
+    await db_session.commit()
+    await db_session.refresh(tx)
+
+    dup_result = {
+        "success": False,
+        "transaction_id": None,
+        "dup_warning": {
+            "existing_transaction_id": str(tx.id),
+            "scanned_at": "2026-05-28T10:00:00",
+            "amount_cents": -72040,
+            "payee": "HEB",
+        },
+        "items": [],
+        "account_match": {"strategy": "card_last4", "matched_card_last4": None},
+        "fx": None,
+        "trends": [],
+        "confidence": 0.92,
+        "shopping_auto_checked": [],
+        "warnings": [],
+        "scanned_preview": None,
+        "draft_id": None,
+        "message": None,
+    }
+
+    success_result = {
+        "success": True,
+        "transaction_id": str(tx.id),
+        "draft_id": None,
+        "items": [],
+        "account_match": {"strategy": "card_last4", "matched_card_last4": None},
+        "fx": None,
+        "trends": [],
+        "confidence": 0.92,
+        "shopping_auto_checked": [],
+        "warnings": [],
+        "dup_warning": None,
+        "scanned_preview": None,
+        "scanned_data": {"payee_name": "HEB", "total_amount": -72040,
+                         "date": "2026-05-28", "items": [], "currency": "MXN"},
+        "message": "Transaction created from receipt scan.",
+    }
+
+    async def _fake_pipeline(db, family_id, user_id, account_id,
+                             image_bytes, media_type, force=False):
+        if force:
+            return success_result
+        return dup_result
+
+    monkeypatch.setattr(
+        "app.api.routes.budget.transactions.scan_and_create_transaction",
+        _fake_pipeline,
+    )
+    monkeypatch.setattr(
+        "app.api.routes.budget.transactions.require_feature",
+        AsyncMock(),
+    )
+    monkeypatch.setattr(
+        "app.api.routes.budget.transactions.UsageService.increment",
+        AsyncMock(),
+    )
+    return test_family
+
+
+@pytest_asyncio.fixture
+async def account_factory_authed(
+    db_session, test_family, monkeypatch,
+):
+    """Creates a BudgetAccount in the test family's context.
+    Also patches require_feature and scan_and_create_transaction with a
+    success result that echoes back 'override' strategy.
+    """
+    from app.models.budget import BudgetAccount
+
+    monkeypatch.setattr(
+        "app.api.routes.budget.transactions.require_feature",
+        AsyncMock(),
+    )
+    monkeypatch.setattr(
+        "app.api.routes.budget.transactions.UsageService.increment",
+        AsyncMock(),
+    )
+
+    async def _make(*, currency: str = "MXN"):
+        acct = BudgetAccount(
+            family_id=test_family.id, name=f"Acct {currency}",
+            type="checking", currency=currency,
+        )
+        db_session.add(acct)
+        await db_session.commit()
+        await db_session.refresh(acct)
+
+        success_result = {
+            "success": True,
+            "transaction_id": "00000000-0000-0000-0000-000000000001",
+            "draft_id": None,
+            "items": [],
+            "account_match": {"strategy": "override", "matched_card_last4": None},
+            "fx": None,
+            "trends": [],
+            "confidence": 0.90,
+            "shopping_auto_checked": [],
+            "warnings": [],
+            "dup_warning": None,
+            "scanned_preview": None,
+            "scanned_data": {"payee_name": "Test", "total_amount": -1000,
+                             "date": "2026-05-28", "items": [], "currency": currency},
+            "message": "Transaction created from receipt scan.",
+        }
+
+        async def _fake_pipeline(db, family_id, user_id, account_id,
+                                 image_bytes, media_type, force=False):
+            return success_result
+
+        monkeypatch.setattr(
+            "app.api.routes.budget.transactions.scan_and_create_transaction",
+            _fake_pipeline,
+        )
+        return acct
+
+    return _make
+
+
+@pytest.mark.asyncio
+async def test_endpoint_returns_409_on_dup(client, auth_headers,
+                                           family_with_recent_heb_tx):
+    """Endpoint returns 409 and dup_warning body when pipeline detects duplicate."""
+    files = {"file": ("r.jpg", b"\xff\xd8\xff\xe0", "image/jpeg")}
+    resp = await client.post(
+        "/api/budget/transactions/scan-receipt",
+        files=files,
+        headers=auth_headers,
+    )
+    assert resp.status_code == 409
+    body = resp.json()
+    assert "dup_warning" in body
+    assert body["dup_warning"] is not None
+
+
+@pytest.mark.asyncio
+async def test_endpoint_force_true_commits(client, auth_headers,
+                                           family_with_recent_heb_tx):
+    """force=true query param bypasses dup guard and returns 200 success."""
+    files = {"file": ("r.jpg", b"\xff\xd8\xff\xe0", "image/jpeg")}
+    resp = await client.post(
+        "/api/budget/transactions/scan-receipt?force=true",
+        files=files,
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_endpoint_account_id_overrides_auto_detect(
+    client, auth_headers, account_factory_authed,
+):
+    """account_id query param flows to pipeline and strategy is 'override'."""
+    a = await account_factory_authed(currency="MXN")
+    files = {"file": ("r.jpg", b"\xff\xd8\xff\xe0", "image/jpeg")}
+    resp = await client.post(
+        f"/api/budget/transactions/scan-receipt?account_id={a.id}",
+        files=files,
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["account_match"]["strategy"] == "override"

--- a/backend/tests/test_receipt_scanner_v2.py
+++ b/backend/tests/test_receipt_scanner_v2.py
@@ -1,0 +1,52 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+import pytest
+
+from app.services.budget.receipt_scanner_service import scan_receipt
+
+
+def _mock_vision_json(payload: dict):
+    """Build an OpenAI Chat completion mock returning JSON-as-text."""
+    import json as _json
+    msg = MagicMock()
+    msg.content = _json.dumps(payload)
+    choice = MagicMock()
+    choice.message = msg
+    completion = MagicMock()
+    completion.choices = [choice]
+    return completion
+
+
+@pytest.mark.asyncio
+async def test_scan_extracts_card_last4_iva_and_items(monkeypatch):
+    monkeypatch.setattr("app.core.config.settings.LITELLM_API_KEY", "test-key")
+    monkeypatch.setattr("app.core.config.settings.LITELLM_API_BASE",
+                        "http://litellm")
+
+    fake = _mock_vision_json({
+        "date": "2026-05-28",
+        "total_amount": -72040,
+        "iva_cents": 9683,
+        "payee_name": "HEB",
+        "card_last4": "9222",
+        "currency": "MXN",
+        "items": [
+            {"name": "Leche Alpura 1L", "qty": 2,
+             "unit_price_cents": 3200, "total_cents": 6400,
+             "brand": "Alpura", "raw_text": "LECHE ALPURA 1L 2 X 32.00 64.00"},
+        ],
+        "confidence": 0.92,
+    })
+    fake_client = MagicMock()
+    fake_client.chat.completions.create = MagicMock(return_value=fake)
+    with patch("app.services.budget.receipt_scanner_service.OpenAI",
+               return_value=fake_client):
+        result = await scan_receipt(b"jpegbytes", "image/jpeg")
+
+    assert result.card_last4 == "9222"
+    assert result.iva_cents == 9683
+    assert len(result.items) == 1
+    item = result.items[0]
+    assert item["brand"] == "Alpura"
+    assert item["qty"] == 2
+    assert item["unit_price_cents"] == 3200
+    assert item["raw_text"].startswith("LECHE ALPURA")

--- a/backend/tests/test_scanner_v2_schemas.py
+++ b/backend/tests/test_scanner_v2_schemas.py
@@ -14,6 +14,12 @@ def test_account_card_last4_validates_format():
         AccountCreate(name="x", type="credit", currency="MXN", card_last4="12a4")
     with pytest.raises(PydanticValidationError):
         AccountCreate(name="x", type="credit", currency="MXN", card_last4="12345")
+    # 3-digit should be rejected (min_length=4)
+    with pytest.raises(PydanticValidationError):
+        AccountCreate(name="x", type="credit", currency="MXN", card_last4="123")
+    # None is allowed (optional field)
+    a = AccountCreate(name="x", type="credit", currency="MXN", card_last4=None)
+    assert a.card_last4 is None
 
 
 def test_item_trend_round_trip():

--- a/backend/tests/test_scanner_v2_schemas.py
+++ b/backend/tests/test_scanner_v2_schemas.py
@@ -1,0 +1,38 @@
+import pytest
+from pydantic import ValidationError as PydanticValidationError
+
+from app.schemas.budget import (
+    AccountCreate, TransactionItemRead, ItemTrend,
+    AccountMatch, DupWarning, ScanReceiptResponse,
+)
+from app.schemas.a2a import A2AWebhookRead, A2AWebhookUpdate
+
+
+def test_account_card_last4_validates_format():
+    AccountCreate(name="x", type="credit", currency="MXN", card_last4="1234")
+    with pytest.raises(PydanticValidationError):
+        AccountCreate(name="x", type="credit", currency="MXN", card_last4="12a4")
+    with pytest.raises(PydanticValidationError):
+        AccountCreate(name="x", type="credit", currency="MXN", card_last4="12345")
+
+
+def test_item_trend_round_trip():
+    t = ItemTrend(normalized_name="leche alpura", avg_unit_cents=2800,
+                  last_unit_cents=3200, pct_change=0.142, sample_size=8)
+    assert t.pct_change == 0.142
+
+
+def test_a2a_webhook_url_must_be_https():
+    A2AWebhookUpdate(url="https://example.com/hook", enabled=True, rotate_secret=False)
+    with pytest.raises(PydanticValidationError):
+        A2AWebhookUpdate(url="http://example.com/hook", enabled=True, rotate_secret=False)
+
+
+def test_scan_receipt_response_minimal():
+    r = ScanReceiptResponse(
+        success=True, transaction_id="00000000-0000-0000-0000-000000000000",
+        confidence=0.9, items=[], trends=[], shopping_auto_checked=[],
+        account_match=AccountMatch(strategy="last_used"),
+    )
+    assert r.success is True
+    assert r.fx is None

--- a/backend/tests/test_transaction_item_service.py
+++ b/backend/tests/test_transaction_item_service.py
@@ -1,0 +1,83 @@
+"""TransactionItemService — normalize names + CRUD + trend."""
+
+from datetime import date, datetime, timedelta, timezone
+from uuid import uuid4
+
+import pytest
+
+from app.services.budget.transaction_item_service import (
+    TransactionItemService, normalize_name,
+)
+
+
+def test_normalize_strips_accents_and_units():
+    assert normalize_name("Leche Alpura 1L") == "leche alpura"
+    assert normalize_name("Aguacate Hass kg") == "aguacate hass"
+    assert normalize_name("PAN INTEGRAL 500g") == "pan integral"
+    assert normalize_name("Café molido 250 g") == "cafe molido"
+    assert normalize_name("Yogurt   griego  ") == "yogurt griego"
+    assert normalize_name("3 PZA Tomate") == "tomate"
+
+
+@pytest.mark.asyncio
+async def test_bulk_create_persists_items(db, family, transaction):
+    items = await TransactionItemService.bulk_create(
+        db, family.id, transaction.id,
+        items=[
+            {"name": "Leche Alpura 1L", "qty": 2, "unit_price_cents": 3200,
+             "total_cents": 6400, "brand": "Alpura"},
+            {"name": "Pan integral", "total_cents": 4850},
+        ],
+    )
+    assert len(items) == 2
+    assert items[0].normalized_name == "leche alpura"
+    assert items[1].normalized_name == "pan integral"
+
+
+@pytest.mark.asyncio
+async def test_get_trend_returns_none_below_sample_size(db, family):
+    trend = await TransactionItemService.get_trend(
+        db, family.id, normalized_name="leche alpura", window_days=90,
+    )
+    assert trend is None
+
+
+@pytest.mark.asyncio
+async def test_get_trend_computes_pct_change(db, family, transaction_factory):
+    """Seed 4 items across recent dates; verify avg and pct_change."""
+    from app.models.budget import BudgetTransactionItem
+    now = datetime.now(timezone.utc)
+    tx = await transaction_factory(family_id=family.id, date=date.today())
+    for unit_price, days_ago in [(2500, 80), (2800, 60), (2900, 30), (3200, 1)]:
+        db.add(BudgetTransactionItem(
+            family_id=family.id, transaction_id=tx.id,
+            name="leche", normalized_name="leche alpura",
+            qty=1, unit_price_cents=unit_price, total_cents=unit_price,
+            created_at=now - timedelta(days=days_ago),
+        ))
+    await db.commit()
+    trend = await TransactionItemService.get_trend(
+        db, family.id, normalized_name="leche alpura", window_days=90,
+    )
+    assert trend is not None
+    assert trend.sample_size == 4
+    assert trend.last_unit_cents == 3200
+    # avg of first 3 priors = (2500+2800+2900)/3 = 2733
+    assert trend.avg_unit_cents == 2733
+    # pct_change = (3200 - 2733) / 2733 ≈ 0.171
+    assert 0.16 < trend.pct_change < 0.18
+
+
+@pytest.mark.asyncio
+async def test_tenant_isolation_on_list(db, family, other_family, transaction):
+    """Family A cannot read Family B's items."""
+    from app.models.budget import BudgetTransactionItem
+    db.add(BudgetTransactionItem(
+        family_id=other_family.id, transaction_id=transaction.id,
+        name="bread", normalized_name="bread", total_cents=1000,
+    ))
+    await db.commit()
+    rows = await TransactionItemService.list_for_family(
+        db, family.id, normalized_name="bread",
+    )
+    assert rows == []

--- a/backend/tests/test_transaction_item_service.py
+++ b/backend/tests/test_transaction_item_service.py
@@ -142,8 +142,17 @@ async def test_list_items_filters_by_family(
 async def test_trend_returns_null_when_below_sample(
     client: AsyncClient,
     auth_headers: dict,
+    monkeypatch,
 ):
-    """GET /api/budget/items/trend for unknown name returns 200 with null body."""
+    """GET /api/budget/items/trend for unknown name returns 200 with null body.
+
+    The endpoint is gated behind the Pro-only ``item_trends`` feature, so
+    we patch the require_feature dependency to a no-op for this test.
+    """
+    from unittest.mock import AsyncMock
+    monkeypatch.setattr(
+        "app.api.routes.budget.items.require_feature", AsyncMock(),
+    )
     resp = await client.get(
         "/api/budget/items/trend?normalized_name=nonexistent",
         headers=auth_headers,

--- a/backend/tests/test_transaction_item_service.py
+++ b/backend/tests/test_transaction_item_service.py
@@ -1,9 +1,12 @@
-"""TransactionItemService — normalize names + CRUD + trend."""
+"""TransactionItemService — normalize names + CRUD + trend + HTTP endpoints."""
 
 from datetime import date, datetime, timedelta, timezone
 from uuid import uuid4
 
 import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.services.budget.transaction_item_service import (
     TransactionItemService, normalize_name,
@@ -81,3 +84,69 @@ async def test_tenant_isolation_on_list(db, family, other_family, transaction):
         db, family.id, normalized_name="bread",
     )
     assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# HTTP endpoint tests — /api/budget/items
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def seeded_items(db: AsyncSession, test_parent_user):
+    """A few BudgetTransactionItem rows under the authed user's (test_parent_user) family."""
+    from app.models.budget import BudgetAccount, BudgetTransaction, BudgetTransactionItem
+    family_id = test_parent_user.family_id
+    # Create a minimal account + transaction to satisfy the FK
+    acct = BudgetAccount(family_id=family_id, name="Cash", type="checking", currency="MXN")
+    db.add(acct)
+    await db.commit()
+    await db.refresh(acct)
+    tx = BudgetTransaction(
+        family_id=family_id, account_id=acct.id, date=date.today(), amount=-10000,
+    )
+    db.add(tx)
+    await db.commit()
+    await db.refresh(tx)
+    now = datetime.now(timezone.utc)
+    for i in range(2):
+        db.add(BudgetTransactionItem(
+            family_id=family_id,
+            transaction_id=tx.id,
+            name="Leche Alpura 1L",
+            normalized_name="leche alpura",
+            qty=1,
+            unit_price_cents=3200 + i * 100,
+            total_cents=3200 + i * 100,
+            created_at=now - timedelta(days=i),
+        ))
+    await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_list_items_filters_by_family(
+    client: AsyncClient,
+    auth_headers: dict,
+    seeded_items,
+):
+    """GET /api/budget/items?normalized_name=leche+alpura returns seeded rows."""
+    resp = await client.get(
+        "/api/budget/items/?normalized_name=leche+alpura",
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) >= 1
+
+
+@pytest.mark.asyncio
+async def test_trend_returns_null_when_below_sample(
+    client: AsyncClient,
+    auth_headers: dict,
+):
+    """GET /api/budget/items/trend for unknown name returns 200 with null body."""
+    resp = await client.get(
+        "/api/budget/items/trend?normalized_name=nonexistent",
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json() is None

--- a/backend/tests/test_wave4_scanner_v2_migration.py
+++ b/backend/tests/test_wave4_scanner_v2_migration.py
@@ -1,0 +1,80 @@
+"""Smoke test: wave4_scanner_v2 migration creates expected tables and columns."""
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+# ---------------------------------------------------------------------------
+# Local fixtures (Task 4 will promote these to conftest.py)
+# ---------------------------------------------------------------------------
+
+@pytest_asyncio.fixture
+async def family(db: AsyncSession):
+    from app.models.family import Family
+    fam = Family(name="Wave4 Test Family")
+    db.add(fam)
+    await db.commit()
+    await db.refresh(fam)
+    return fam
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_wave4_tables_exist(db: AsyncSession):
+    """budget_transaction_items, family_a2a_webhooks, a2a_webhook_deliveries exist."""
+    result = await db.execute(text(
+        "SELECT tablename FROM pg_tables WHERE schemaname = 'public' "
+        "AND tablename IN ('budget_transaction_items', 'family_a2a_webhooks', "
+        "'a2a_webhook_deliveries')"
+    ))
+    names = {row[0] for row in result.all()}
+    assert names == {
+        "budget_transaction_items",
+        "family_a2a_webhooks",
+        "a2a_webhook_deliveries",
+    }
+
+
+@pytest.mark.asyncio
+async def test_wave4_new_columns_exist(db: AsyncSession):
+    """Account + Transaction tables have new columns."""
+    cols = await db.execute(text(
+        "SELECT column_name FROM information_schema.columns "
+        "WHERE table_name = 'budget_accounts' AND column_name = 'card_last4'"
+    ))
+    assert cols.scalar() == "card_last4"
+
+    for col in ["card_last4", "iva_cents", "fx_rate",
+                "original_amount_cents", "original_currency"]:
+        r = await db.execute(text(
+            "SELECT column_name FROM information_schema.columns "
+            f"WHERE table_name = 'budget_transactions' AND column_name = '{col}'"
+        ))
+        assert r.scalar() == col, f"Missing column budget_transactions.{col}"
+
+
+@pytest.mark.asyncio
+async def test_card_last4_backfill_from_name(db: AsyncSession, family):
+    """Migration backfill regex captures **9222 / ***313 / 'terminada en 1234' patterns."""
+    from app.models.budget import BudgetAccount
+    a1 = BudgetAccount(family_id=family.id, name="Mastercard **9222", type="credit")
+    a2 = BudgetAccount(family_id=family.id, name="Cheques Banamex ***313", type="checking")
+    a3 = BudgetAccount(family_id=family.id, name="Tarjeta terminada en 1234", type="credit")
+    db.add_all([a1, a2, a3])
+    await db.commit()
+    # Re-run the backfill UPDATE the migration emits; it must be idempotent.
+    await db.execute(text(
+        "UPDATE budget_accounts SET card_last4 = "
+        "regexp_replace(name, '.*(?:\\*{2,}|terminada en )(\\d{4}).*', '\\1') "
+        "WHERE name ~* '(\\*{2,}|terminada en )\\d{4}' AND card_last4 IS NULL"
+    ))
+    await db.commit()
+    await db.refresh(a1); await db.refresh(a2); await db.refresh(a3)
+    assert a1.card_last4 == "9222"
+    assert a2.card_last4 == "313" or a2.card_last4 is None  # 3-digit suffix won't backfill (4 required)
+    assert a3.card_last4 == "1234"

--- a/backend/tests/test_wave4_scanner_v2_migration.py
+++ b/backend/tests/test_wave4_scanner_v2_migration.py
@@ -71,12 +71,12 @@ async def test_card_last4_backfill_from_name(db: AsyncSession, family):
     # Re-run the backfill UPDATE the migration emits; it must be idempotent.
     await db.execute(text(
         "UPDATE budget_accounts SET card_last4 = "
-        "regexp_replace(name, '.*(?:\\*{2,}|terminada en |XXXX|xxxx)(\\d{4}).*', '\\1') "
-        "WHERE name ~* '(\\*{2,}|terminada en |XXXX|xxxx)\\d{4}' AND card_last4 IS NULL"
+        "regexp_replace(name, '.*(?:\\*{2,}|terminada en |XXXX)(\\d{4}).*', '\\1') "
+        "WHERE name ~* '(\\*{2,}|terminada en |XXXX)\\d{4}' AND card_last4 IS NULL"
     ))
     await db.commit()
     await db.refresh(a1); await db.refresh(a2); await db.refresh(a3); await db.refresh(a4)
     assert a1.card_last4 == "9222"
-    assert a2.card_last4 == "313" or a2.card_last4 is None  # 3-digit suffix won't backfill (4 required)
+    assert a2.card_last4 is None  # ***313 is 3 digits; regex requires 4
     assert a3.card_last4 == "1234"
     assert a4.card_last4 == "4321"

--- a/backend/tests/test_wave4_scanner_v2_migration.py
+++ b/backend/tests/test_wave4_scanner_v2_migration.py
@@ -60,21 +60,23 @@ async def test_wave4_new_columns_exist(db: AsyncSession):
 
 @pytest.mark.asyncio
 async def test_card_last4_backfill_from_name(db: AsyncSession, family):
-    """Migration backfill regex captures **9222 / ***313 / 'terminada en 1234' patterns."""
+    """Migration backfill regex captures **9222 / ***313 / 'terminada en 1234' / XXXX4321 patterns."""
     from app.models.budget import BudgetAccount
     a1 = BudgetAccount(family_id=family.id, name="Mastercard **9222", type="credit")
     a2 = BudgetAccount(family_id=family.id, name="Cheques Banamex ***313", type="checking")
     a3 = BudgetAccount(family_id=family.id, name="Tarjeta terminada en 1234", type="credit")
-    db.add_all([a1, a2, a3])
+    a4 = BudgetAccount(family_id=family.id, name="XXXX4321", type="credit")
+    db.add_all([a1, a2, a3, a4])
     await db.commit()
     # Re-run the backfill UPDATE the migration emits; it must be idempotent.
     await db.execute(text(
         "UPDATE budget_accounts SET card_last4 = "
-        "regexp_replace(name, '.*(?:\\*{2,}|terminada en )(\\d{4}).*', '\\1') "
-        "WHERE name ~* '(\\*{2,}|terminada en )\\d{4}' AND card_last4 IS NULL"
+        "regexp_replace(name, '.*(?:\\*{2,}|terminada en |XXXX|xxxx)(\\d{4}).*', '\\1') "
+        "WHERE name ~* '(\\*{2,}|terminada en |XXXX|xxxx)\\d{4}' AND card_last4 IS NULL"
     ))
     await db.commit()
-    await db.refresh(a1); await db.refresh(a2); await db.refresh(a3)
+    await db.refresh(a1); await db.refresh(a2); await db.refresh(a3); await db.refresh(a4)
     assert a1.card_last4 == "9222"
     assert a2.card_last4 == "313" or a2.card_last4 is None  # 3-digit suffix won't backfill (4 required)
     assert a3.card_last4 == "1234"
+    assert a4.card_last4 == "4321"

--- a/docs/superpowers/plans/2026-05-28-receipt-scanner-v2.md
+++ b/docs/superpowers/plans/2026-05-28-receipt-scanner-v2.md
@@ -1,0 +1,3675 @@
+# Receipt Scanner v2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend the receipt scanner into a one-tap experience with auto-detected account, structured per-item rows, duplicate guard, FX cross-charge, IVA breakout, item price-history trends, and a per-family webhook fan-out to an external price-comparison agent.
+
+**Architecture:** Single Alembic migration (`wave4_scanner_v2`) introduces 3 new tables (`budget_transaction_items`, `family_a2a_webhooks`, `a2a_webhook_deliveries`) and 6 new columns. The existing single-call `POST /api/budget/transactions/scan-receipt` endpoint is extended with 7 server-side stages (vision → account auto-detect → duplicate guard → FX → persist → categorize → fan-out). New endpoints expose item history/trends and webhook configuration. Frontend redesigns the scan page into a snap-and-confirm flow.
+
+**Tech Stack:** Python 3.12 · FastAPI · SQLAlchemy 2.0 async · Alembic · Pydantic v2 · PostgreSQL 15 · Redis 7 · Astro 5 · Tailwind CSS v4 · Playwright · LiteLLM proxy (Claude Haiku for vision) · exchangerate.host (FX).
+
+**Spec:** `docs/superpowers/specs/2026-05-28-receipt-scanner-v2-design.md`
+
+---
+
+## File Map
+
+**Create:**
+- `backend/migrations/versions/2026_05_28_wave4_scanner_v2.py`
+- `backend/app/models/a2a.py`
+- `backend/app/services/fx_service.py`
+- `backend/app/services/budget/transaction_item_service.py`
+- `backend/app/services/budget/account_matching_service.py`
+- `backend/app/services/budget/duplicate_guard_service.py`
+- `backend/app/services/budget/a2a_webhook_service.py`
+- `backend/app/api/routes/budget/items.py`
+- `backend/app/api/routes/budget/a2a_webhook.py`
+- `backend/app/api/routes/internal/__init__.py`
+- `backend/app/api/routes/internal/a2a_retry.py`
+- `backend/tests/test_receipt_scanner_v2.py`
+- `backend/tests/test_fx_service.py`
+- `backend/tests/test_transaction_item_service.py`
+- `backend/tests/test_a2a_webhook_service.py`
+- `frontend/src/pages/budget/items/[normalized_name].astro`
+- `frontend/src/pages/parent/settings/a2a.astro`
+- `e2e-tests/tests/scanner-v2.spec.ts`
+
+**Modify:**
+- `backend/app/models/budget.py` (add `BudgetTransactionItem`, columns on `BudgetTransaction` + `BudgetAccount`)
+- `backend/app/models/__init__.py` (export new models)
+- `backend/app/schemas/budget.py` (new schemas + extend existing)
+- `backend/app/services/budget/receipt_scanner_service.py` (rewrite scan-and-create flow, extend prompt)
+- `backend/app/services/budget/categorization_rule_service.py` (accept `item_name` arg)
+- `backend/app/api/routes/budget/transactions.py` (extend scan-receipt endpoint with `force`, `account_id` optional, 409 path)
+- `backend/app/api/routes/budget/__init__.py` (register items + a2a routers)
+- `backend/app/main.py` (register internal router)
+- `backend/app/core/premium.py` (add `a2a_webhook`, `item_trends`, `fx_cross_charge` features)
+- `backend/requirements.txt` (add `httpx` if absent; `apscheduler` if used)
+- `frontend/src/pages/budget/scan-receipt.astro` (one-tap UX redesign)
+- `frontend/src/lib/api/budget.ts` (new client helpers)
+
+---
+
+## Phased Execution
+
+- **Phase 1 — Data layer:** Tasks 1–2
+- **Phase 2 — Pure services:** Tasks 3–7
+- **Phase 3 — Scanner integration:** Tasks 8–10
+- **Phase 4 — New endpoints:** Tasks 11–13
+- **Phase 5 — Premium gating:** Task 14
+- **Phase 6 — Frontend:** Tasks 15–18
+- **Phase 7 — E2E + deploy:** Tasks 19–20
+
+Run tests inside the running backend container:
+
+```
+podman exec -e PYTHONPATH=/app family_app_backend pytest <path> -v
+```
+
+---
+
+## Phase 1 — Data layer
+
+### Task 1: Wave 4 Alembic migration + ORM models
+
+**Files:**
+- Create: `backend/migrations/versions/2026_05_28_wave4_scanner_v2.py`
+- Create: `backend/app/models/a2a.py`
+- Modify: `backend/app/models/budget.py:91-129` (add columns to `BudgetAccount` + `BudgetTransaction`, add `BudgetTransactionItem` class)
+- Modify: `backend/app/models/__init__.py` (export `BudgetTransactionItem`, `FamilyA2AWebhook`, `A2AWebhookDelivery`)
+- Test: `backend/tests/test_wave4_scanner_v2_migration.py` (new)
+
+- [ ] **Step 1: Write the failing test for migration upgrade/downgrade idempotency**
+
+Create `backend/tests/test_wave4_scanner_v2_migration.py`:
+
+```python
+"""Smoke test: wave4_scanner_v2 migration creates expected tables and columns."""
+
+import pytest
+from sqlalchemy import inspect, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+@pytest.mark.asyncio
+async def test_wave4_tables_exist(db: AsyncSession):
+    """budget_transaction_items, family_a2a_webhooks, a2a_webhook_deliveries exist."""
+    result = await db.execute(text(
+        "SELECT tablename FROM pg_tables WHERE schemaname = 'public' "
+        "AND tablename IN ('budget_transaction_items', 'family_a2a_webhooks', "
+        "'a2a_webhook_deliveries')"
+    ))
+    names = {row[0] for row in result.all()}
+    assert names == {
+        "budget_transaction_items",
+        "family_a2a_webhooks",
+        "a2a_webhook_deliveries",
+    }
+
+
+@pytest.mark.asyncio
+async def test_wave4_new_columns_exist(db: AsyncSession):
+    """Account + Transaction tables have new columns."""
+    cols = await db.execute(text(
+        "SELECT column_name FROM information_schema.columns "
+        "WHERE table_name = 'budget_accounts' AND column_name = 'card_last4'"
+    ))
+    assert cols.scalar() == "card_last4"
+
+    for col in ["card_last4", "iva_cents", "fx_rate",
+                "original_amount_cents", "original_currency"]:
+        r = await db.execute(text(
+            "SELECT column_name FROM information_schema.columns "
+            f"WHERE table_name = 'budget_transactions' AND column_name = '{col}'"
+        ))
+        assert r.scalar() == col, f"Missing column budget_transactions.{col}"
+
+
+@pytest.mark.asyncio
+async def test_card_last4_backfill_from_name(db: AsyncSession, family):
+    """Migration backfill regex captures **9222 / ***313 / 'terminada en 1234' patterns."""
+    from app.models.budget import BudgetAccount
+    a1 = BudgetAccount(family_id=family.id, name="Mastercard **9222", type="credit")
+    a2 = BudgetAccount(family_id=family.id, name="Cheques Banamex ***313", type="checking")
+    a3 = BudgetAccount(family_id=family.id, name="Tarjeta terminada en 1234", type="credit")
+    db.add_all([a1, a2, a3])
+    await db.commit()
+    # Re-run the backfill UPDATE the migration emits; it must be idempotent.
+    await db.execute(text(
+        "UPDATE budget_accounts SET card_last4 = "
+        "regexp_replace(name, '.*(?:\\*{2,}|terminada en )(\\d{4}).*', '\\1') "
+        "WHERE name ~* '(\\*{2,}|terminada en )\\d{4}' AND card_last4 IS NULL"
+    ))
+    await db.commit()
+    await db.refresh(a1); await db.refresh(a2); await db.refresh(a3)
+    assert a1.card_last4 == "9222"
+    assert a2.card_last4 == "313" or a2.card_last4 is None  # 3-digit suffix won't backfill (4 required)
+    assert a3.card_last4 == "1234"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+podman exec -e PYTHONPATH=/app family_app_backend pytest tests/test_wave4_scanner_v2_migration.py -v
+```
+
+Expected: FAIL — tables / columns do not exist.
+
+- [ ] **Step 3: Create the Alembic migration**
+
+Create `backend/migrations/versions/2026_05_28_wave4_scanner_v2.py`:
+
+```python
+"""wave4_scanner_v2: item rows, account card_last4, FX/IVA cols, a2a webhooks
+
+Revision ID: wave4_scanner_v2
+Revises: drop_stripe_v1
+Create Date: 2026-05-28
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID, JSONB
+
+
+revision = "wave4_scanner_v2"
+down_revision = "drop_stripe_v1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # --- BudgetAccount.card_last4 -------------------------------------------------
+    op.add_column(
+        "budget_accounts",
+        sa.Column("card_last4", sa.CHAR(4), nullable=True),
+    )
+    op.create_index(
+        "ix_budget_accounts_family_card_last4",
+        "budget_accounts",
+        ["family_id", "card_last4"],
+        postgresql_where=sa.text("card_last4 IS NOT NULL"),
+    )
+
+    # Backfill from existing account names (e.g. "Mastercard **9222",
+    # "Cheques Banamex ***313", "Tarjeta terminada en 1234"). The regex
+    # requires exactly 4 trailing digits — 3-digit suffixes (e.g. "***313")
+    # are intentionally NOT backfilled and the user can edit the account
+    # later to set the correct last-4.
+    op.execute(sa.text(
+        "UPDATE budget_accounts SET card_last4 = "
+        "regexp_replace(name, '.*(?:\\*{2,}|terminada en |XXXX|xxxx)(\\d{4}).*', '\\1') "
+        "WHERE name ~* '(\\*{2,}|terminada en |XXXX|xxxx)\\d{4}' "
+        "AND card_last4 IS NULL"
+    ))
+
+    # --- BudgetTransaction extra columns -----------------------------------------
+    op.add_column("budget_transactions",
+                  sa.Column("card_last4", sa.CHAR(4), nullable=True))
+    op.add_column("budget_transactions",
+                  sa.Column("iva_cents", sa.BigInteger(), nullable=True))
+    op.add_column("budget_transactions",
+                  sa.Column("fx_rate", sa.Numeric(12, 6), nullable=True))
+    op.add_column("budget_transactions",
+                  sa.Column("original_amount_cents", sa.BigInteger(), nullable=True))
+    op.add_column("budget_transactions",
+                  sa.Column("original_currency", sa.CHAR(3), nullable=True))
+
+    # --- budget_transaction_items ------------------------------------------------
+    op.create_table(
+        "budget_transaction_items",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True,
+                  server_default=sa.text("gen_random_uuid()")),
+        sa.Column("family_id", UUID(as_uuid=True),
+                  sa.ForeignKey("families.id", ondelete="CASCADE"),
+                  nullable=False),
+        sa.Column("transaction_id", UUID(as_uuid=True),
+                  sa.ForeignKey("budget_transactions.id", ondelete="CASCADE"),
+                  nullable=False),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("normalized_name", sa.Text(), nullable=False),
+        sa.Column("qty", sa.Numeric(10, 3), nullable=True),
+        sa.Column("unit_price_cents", sa.BigInteger(), nullable=True),
+        sa.Column("total_cents", sa.BigInteger(), nullable=False),
+        sa.Column("category_id", UUID(as_uuid=True),
+                  sa.ForeignKey("budget_categories.id", ondelete="SET NULL"),
+                  nullable=True),
+        sa.Column("brand", sa.Text(), nullable=True),
+        sa.Column("raw_text", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True),
+                  server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True),
+                  server_default=sa.func.now(), nullable=False),
+    )
+    op.create_index("ix_bti_family_normalized_created",
+                    "budget_transaction_items",
+                    ["family_id", "normalized_name",
+                     sa.text("created_at DESC")])
+    op.create_index("ix_bti_transaction",
+                    "budget_transaction_items", ["transaction_id"])
+    op.create_index("ix_bti_family_category",
+                    "budget_transaction_items", ["family_id", "category_id"])
+
+    # --- family_a2a_webhooks -----------------------------------------------------
+    op.create_table(
+        "family_a2a_webhooks",
+        sa.Column("family_id", UUID(as_uuid=True),
+                  sa.ForeignKey("families.id", ondelete="CASCADE"),
+                  primary_key=True),
+        sa.Column("url", sa.Text(), nullable=False),
+        sa.Column("secret", sa.Text(), nullable=False),
+        sa.Column("enabled", sa.Boolean(), nullable=False,
+                  server_default=sa.text("false")),
+        sa.Column("last_success_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_error", sa.Text(), nullable=True),
+        sa.Column("failure_count", sa.Integer(), nullable=False,
+                  server_default=sa.text("0")),
+        sa.Column("created_at", sa.DateTime(timezone=True),
+                  server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True),
+                  server_default=sa.func.now(), nullable=False),
+    )
+
+    # --- a2a_webhook_deliveries --------------------------------------------------
+    op.create_table(
+        "a2a_webhook_deliveries",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True,
+                  server_default=sa.text("gen_random_uuid()")),
+        sa.Column("family_id", UUID(as_uuid=True),
+                  sa.ForeignKey("families.id", ondelete="CASCADE"),
+                  nullable=False),
+        sa.Column("transaction_id", UUID(as_uuid=True),
+                  sa.ForeignKey("budget_transactions.id", ondelete="CASCADE"),
+                  nullable=False),
+        sa.Column("payload_json", JSONB, nullable=False),
+        sa.Column("status", sa.String(16), nullable=False,
+                  server_default="pending"),
+        sa.Column("attempts", sa.Integer(), nullable=False,
+                  server_default=sa.text("0")),
+        sa.Column("next_retry_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_error", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True),
+                  server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True),
+                  server_default=sa.func.now(), nullable=False),
+    )
+    op.create_index("ix_a2a_deliveries_due",
+                    "a2a_webhook_deliveries",
+                    ["next_retry_at"],
+                    postgresql_where=sa.text("status IN ('pending', 'failed')"))
+    op.create_index("ix_a2a_deliveries_family",
+                    "a2a_webhook_deliveries", ["family_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_a2a_deliveries_family", table_name="a2a_webhook_deliveries")
+    op.drop_index("ix_a2a_deliveries_due", table_name="a2a_webhook_deliveries")
+    op.drop_table("a2a_webhook_deliveries")
+    op.drop_table("family_a2a_webhooks")
+
+    op.drop_index("ix_bti_family_category", table_name="budget_transaction_items")
+    op.drop_index("ix_bti_transaction", table_name="budget_transaction_items")
+    op.drop_index("ix_bti_family_normalized_created",
+                  table_name="budget_transaction_items")
+    op.drop_table("budget_transaction_items")
+
+    op.drop_column("budget_transactions", "original_currency")
+    op.drop_column("budget_transactions", "original_amount_cents")
+    op.drop_column("budget_transactions", "fx_rate")
+    op.drop_column("budget_transactions", "iva_cents")
+    op.drop_column("budget_transactions", "card_last4")
+
+    op.drop_index("ix_budget_accounts_family_card_last4",
+                  table_name="budget_accounts")
+    op.drop_column("budget_accounts", "card_last4")
+```
+
+- [ ] **Step 4: Add ORM column attrs on existing models**
+
+Modify `backend/app/models/budget.py`. In `class BudgetAccount`, after line 105 (`currency` col), add:
+
+```python
+    card_last4: Mapped[Optional[str]] = mapped_column(
+        CHAR(4), nullable=True,
+        comment="Last 4 digits of the card associated with this account; used for receipt auto-match",
+    )
+```
+
+Add `CHAR` to the imports at the top of the file (it lives in `sqlalchemy`).
+
+In `class BudgetTransaction` (find via `grep -n "class BudgetTransaction" backend/app/models/budget.py`), after the existing `amount` column, add:
+
+```python
+    card_last4: Mapped[Optional[str]] = mapped_column(CHAR(4), nullable=True)
+    iva_cents: Mapped[Optional[int]] = mapped_column(BigInteger, nullable=True)
+    fx_rate: Mapped[Optional[Decimal]] = mapped_column(Numeric(12, 6), nullable=True)
+    original_amount_cents: Mapped[Optional[int]] = mapped_column(BigInteger, nullable=True)
+    original_currency: Mapped[Optional[str]] = mapped_column(CHAR(3), nullable=True)
+```
+
+Ensure `Numeric` and `Decimal` are imported (`from sqlalchemy import Numeric`, `from decimal import Decimal`).
+
+- [ ] **Step 5: Add `BudgetTransactionItem` ORM class**
+
+In `backend/app/models/budget.py`, add at the end of the file (before any trailing module exports):
+
+```python
+class BudgetTransactionItem(Base):
+    """Line items extracted from a receipt scan or manual transaction edit."""
+
+    __tablename__ = "budget_transaction_items"
+
+    id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), primary_key=True, default=uuid4)
+    family_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("families.id", ondelete="CASCADE"),
+        nullable=False, index=True,
+    )
+    transaction_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("budget_transactions.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    normalized_name: Mapped[str] = mapped_column(Text, nullable=False)
+    qty: Mapped[Optional[Decimal]] = mapped_column(Numeric(10, 3), nullable=True)
+    unit_price_cents: Mapped[Optional[int]] = mapped_column(BigInteger, nullable=True)
+    total_cents: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    category_id: Mapped[Optional[UUID]] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("budget_categories.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    brand: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    raw_text: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(),
+        onupdate=func.now(), nullable=False,
+    )
+
+    transaction: Mapped["BudgetTransaction"] = relationship(
+        "BudgetTransaction", back_populates="items"
+    )
+    category: Mapped[Optional["BudgetCategory"]] = relationship("BudgetCategory")
+```
+
+Then in `class BudgetTransaction`, add the inverse relationship (after existing relationships):
+
+```python
+    items: Mapped[list["BudgetTransactionItem"]] = relationship(
+        "BudgetTransactionItem",
+        back_populates="transaction",
+        cascade="all, delete-orphan",
+    )
+```
+
+- [ ] **Step 6: Create `backend/app/models/a2a.py` for webhook tables**
+
+```python
+"""A2A webhook configuration and delivery log."""
+
+from datetime import datetime
+from typing import Any, Optional
+from uuid import UUID, uuid4
+
+from sqlalchemy import (
+    Boolean, DateTime, ForeignKey, Integer, String, Text, func,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base
+
+
+class FamilyA2AWebhook(Base):
+    """One row per family. Per-family opt-in to the external price-agent."""
+
+    __tablename__ = "family_a2a_webhooks"
+
+    family_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("families.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    url: Mapped[str] = mapped_column(Text, nullable=False)
+    secret: Mapped[str] = mapped_column(Text, nullable=False)
+    enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    last_success_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    last_error: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    failure_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(),
+        onupdate=func.now(), nullable=False,
+    )
+
+
+class A2AWebhookDelivery(Base):
+    """Retry log for a2a webhook deliveries."""
+
+    __tablename__ = "a2a_webhook_deliveries"
+
+    id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), primary_key=True, default=uuid4)
+    family_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("families.id", ondelete="CASCADE"),
+        nullable=False, index=True,
+    )
+    transaction_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("budget_transactions.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    payload_json: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
+    status: Mapped[str] = mapped_column(String(16), nullable=False, default="pending")
+    attempts: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    next_retry_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    last_error: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(),
+        onupdate=func.now(), nullable=False,
+    )
+```
+
+- [ ] **Step 7: Wire models into `backend/app/models/__init__.py`**
+
+Append to `backend/app/models/__init__.py`:
+
+```python
+from app.models.budget import BudgetTransactionItem  # noqa: F401
+from app.models.a2a import FamilyA2AWebhook, A2AWebhookDelivery  # noqa: F401
+```
+
+- [ ] **Step 8: Run migration against test DB and rerun tests**
+
+```
+podman exec family_app_backend alembic upgrade head
+podman exec -e PYTHONPATH=/app family_app_backend pytest tests/test_wave4_scanner_v2_migration.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add backend/migrations/versions/2026_05_28_wave4_scanner_v2.py \
+        backend/app/models/budget.py \
+        backend/app/models/a2a.py \
+        backend/app/models/__init__.py \
+        backend/tests/test_wave4_scanner_v2_migration.py
+git commit -m "feat(scanner-v2): wave4 migration + ORM for items, a2a webhooks, FX/IVA cols"
+```
+
+---
+
+### Task 2: Pydantic schemas
+
+**Files:**
+- Modify: `backend/app/schemas/budget.py` (add `TransactionItemRead`, `ItemTrend`, `AccountMatch`, `DupWarning`, `ScanReceiptResponse`; extend `AccountBase`/`AccountUpdate`/`AccountResponse` with `card_last4`; extend `TransactionResponse` with new columns)
+- Create: `backend/app/schemas/a2a.py`
+- Test: `backend/tests/test_scanner_v2_schemas.py`
+
+- [ ] **Step 1: Write failing schema tests**
+
+Create `backend/tests/test_scanner_v2_schemas.py`:
+
+```python
+import pytest
+from pydantic import ValidationError as PydanticValidationError
+
+from app.schemas.budget import (
+    AccountCreate, TransactionItemRead, ItemTrend,
+    AccountMatch, DupWarning, ScanReceiptResponse,
+)
+from app.schemas.a2a import A2AWebhookRead, A2AWebhookUpdate
+
+
+def test_account_card_last4_validates_format():
+    AccountCreate(name="x", type="credit", currency="MXN", card_last4="1234")
+    with pytest.raises(PydanticValidationError):
+        AccountCreate(name="x", type="credit", currency="MXN", card_last4="12a4")
+    with pytest.raises(PydanticValidationError):
+        AccountCreate(name="x", type="credit", currency="MXN", card_last4="12345")
+
+
+def test_item_trend_round_trip():
+    t = ItemTrend(normalized_name="leche alpura", avg_unit_cents=2800,
+                  last_unit_cents=3200, pct_change=0.142, sample_size=8)
+    assert t.pct_change == 0.142
+
+
+def test_a2a_webhook_url_must_be_https():
+    A2AWebhookUpdate(url="https://example.com/hook", enabled=True, rotate_secret=False)
+    with pytest.raises(PydanticValidationError):
+        A2AWebhookUpdate(url="http://example.com/hook", enabled=True, rotate_secret=False)
+
+
+def test_scan_receipt_response_minimal():
+    r = ScanReceiptResponse(
+        success=True, transaction_id="00000000-0000-0000-0000-000000000000",
+        confidence=0.9, items=[], trends=[], shopping_auto_checked=[],
+        account_match=AccountMatch(strategy="last_used"),
+    )
+    assert r.success is True
+    assert r.fx is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+podman exec -e PYTHONPATH=/app family_app_backend pytest tests/test_scanner_v2_schemas.py -v
+```
+
+Expected: FAIL — schemas not yet defined.
+
+- [ ] **Step 3: Extend `AccountBase`/`AccountUpdate`/`AccountResponse`**
+
+In `backend/app/schemas/budget.py`, locate `class AccountBase` (line 93). Add field:
+
+```python
+    card_last4: Optional[str] = Field(
+        None, min_length=4, max_length=4, pattern=r"^\d{4}$",
+        description="Last 4 digits of the card; used for receipt scanner auto-detect",
+    )
+```
+
+Add the same field to `class AccountUpdate` (line 129). Add to `class AccountResponse` (line 157).
+
+- [ ] **Step 4: Add new schemas at end of `backend/app/schemas/budget.py`**
+
+```python
+class TransactionItemRead(BaseModel):
+    id: UUID
+    transaction_id: UUID
+    name: str
+    normalized_name: str
+    qty: Optional[Decimal] = None
+    unit_price_cents: Optional[int] = None
+    total_cents: int
+    category_id: Optional[UUID] = None
+    brand: Optional[str] = None
+    raw_text: Optional[str] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ItemTrend(BaseModel):
+    normalized_name: str
+    avg_unit_cents: int
+    last_unit_cents: int
+    pct_change: float  # e.g. 0.142 = +14.2%
+    sample_size: int
+
+
+class AccountMatch(BaseModel):
+    strategy: str  # "card_last4" | "last_used" | "override"
+    matched_card_last4: Optional[str] = None
+
+
+class DupWarning(BaseModel):
+    existing_transaction_id: UUID
+    scanned_at: datetime
+    payee: Optional[str] = None
+    amount_cents: int
+
+
+class FXInfo(BaseModel):
+    rate: Decimal
+    original_amount_cents: int
+    original_currency: str
+
+
+class ScanReceiptResponse(BaseModel):
+    success: bool
+    transaction_id: Optional[UUID] = None
+    transaction: Optional[TransactionResponse] = None
+    items: list[TransactionItemRead] = []
+    account_match: Optional[AccountMatch] = None
+    fx: Optional[FXInfo] = None
+    trends: list[ItemTrend] = []
+    confidence: float = 0.0
+    shopping_auto_checked: list[str] = []
+    warnings: list[str] = []
+    dup_warning: Optional[DupWarning] = None
+    scanned_preview: Optional[dict] = None
+    draft_id: Optional[UUID] = None
+    message: Optional[str] = None
+```
+
+Ensure imports at top of file include: `from datetime import datetime`, `from decimal import Decimal`, `from pydantic import ConfigDict`. (Most already present; verify.)
+
+- [ ] **Step 5: Create `backend/app/schemas/a2a.py`**
+
+```python
+"""Pydantic schemas for the per-family a2a webhook."""
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl, field_validator
+
+
+class A2AWebhookRead(BaseModel):
+    url: Optional[str] = None
+    enabled: bool = False
+    last_success_at: Optional[datetime] = None
+    failure_count: int = 0
+    # secret is intentionally NOT exposed here
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class A2AWebhookUpdate(BaseModel):
+    url: str = Field(..., description="HTTPS endpoint to POST receipt events to")
+    enabled: bool = False
+    rotate_secret: bool = False
+
+    @field_validator("url")
+    @classmethod
+    def must_be_https(cls, v: str) -> str:
+        if not v.startswith("https://"):
+            raise ValueError("webhook URL must use https://")
+        # Pydantic HttpUrl validates the rest
+        HttpUrl(v)
+        return v
+
+
+class A2AWebhookSaveResult(BaseModel):
+    config: A2AWebhookRead
+    secret: Optional[str] = Field(
+        None,
+        description="Plaintext secret. Returned ONLY when rotate_secret=true on save.",
+    )
+```
+
+- [ ] **Step 6: Run tests, expect PASS**
+
+```
+podman exec -e PYTHONPATH=/app family_app_backend pytest tests/test_scanner_v2_schemas.py -v
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/schemas/budget.py backend/app/schemas/a2a.py \
+        backend/tests/test_scanner_v2_schemas.py
+git commit -m "feat(scanner-v2): pydantic schemas for items, trends, account match, a2a webhook"
+```
+
+---
+
+## Phase 2 — Pure services
+
+### Task 3: FXService
+
+**Files:**
+- Create: `backend/app/services/fx_service.py`
+- Create: `backend/tests/test_fx_service.py`
+- Modify: `backend/requirements.txt` (ensure `httpx` present; it already is — verify)
+
+- [ ] **Step 1: Write failing FXService tests**
+
+Create `backend/tests/test_fx_service.py`:
+
+```python
+"""FXService — historical rate lookup via exchangerate.host with Redis cache."""
+
+import json
+from datetime import date
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.fx_service import FXService
+
+
+@pytest.mark.asyncio
+async def test_returns_one_for_same_currency():
+    rate = await FXService.get_rate("MXN", "MXN", date(2026, 5, 28))
+    assert rate == Decimal("1")
+
+
+@pytest.mark.asyncio
+async def test_fetches_and_caches(monkeypatch):
+    """First call hits HTTP; second hits Redis cache."""
+    fake_redis = MagicMock()
+    fake_redis.get = AsyncMock(side_effect=[None, b"17.15"])
+    fake_redis.set = AsyncMock()
+    monkeypatch.setattr("app.services.fx_service._get_redis",
+                        lambda: fake_redis)
+
+    fake_response = MagicMock()
+    fake_response.json.return_value = {
+        "success": True,
+        "rates": {"MXN": 17.15},
+    }
+    fake_response.raise_for_status = MagicMock()
+
+    fake_client = AsyncMock()
+    fake_client.get = AsyncMock(return_value=fake_response)
+    fake_client.__aenter__.return_value = fake_client
+    fake_client.__aexit__.return_value = False
+
+    with patch("app.services.fx_service.httpx.AsyncClient", return_value=fake_client):
+        rate = await FXService.get_rate("USD", "MXN", date(2026, 5, 28))
+        assert rate == Decimal("17.15")
+        fake_redis.set.assert_awaited_once()
+
+        # Second call: redis returns cached
+        rate2 = await FXService.get_rate("USD", "MXN", date(2026, 5, 28))
+        assert rate2 == Decimal("17.15")
+
+
+@pytest.mark.asyncio
+async def test_returns_none_on_http_failure(monkeypatch):
+    fake_redis = MagicMock()
+    fake_redis.get = AsyncMock(return_value=None)
+    fake_redis.set = AsyncMock()
+    monkeypatch.setattr("app.services.fx_service._get_redis",
+                        lambda: fake_redis)
+
+    fake_client = AsyncMock()
+    fake_client.get = AsyncMock(side_effect=RuntimeError("boom"))
+    fake_client.__aenter__.return_value = fake_client
+    fake_client.__aexit__.return_value = False
+
+    with patch("app.services.fx_service.httpx.AsyncClient", return_value=fake_client):
+        rate = await FXService.get_rate("USD", "MXN", date(2026, 5, 28))
+        assert rate is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+podman exec -e PYTHONPATH=/app family_app_backend pytest tests/test_fx_service.py -v
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `backend/app/services/fx_service.py`**
+
+```python
+"""Foreign-exchange rate lookup with Redis cache.
+
+Public surface: FXService.get_rate(from_ccy, to_ccy, on_date) -> Decimal | None
+
+Source: https://exchangerate.host (free, no API key). Historical endpoint
+returns rates as of a given date. We cache (from, to, date) → rate in Redis
+for 24h since historical rates are immutable.
+"""
+
+from datetime import date
+from decimal import Decimal
+from typing import Optional
+
+import httpx
+import redis.asyncio as aioredis
+
+from app.core.config import settings
+
+
+_REDIS_TTL_SECONDS = 24 * 3600
+
+
+def _get_redis():
+    return aioredis.from_url(settings.REDIS_URL, decode_responses=False)
+
+
+def _cache_key(from_ccy: str, to_ccy: str, on_date: date) -> str:
+    return f"fx:{from_ccy}:{to_ccy}:{on_date.isoformat()}"
+
+
+class FXService:
+
+    @staticmethod
+    async def get_rate(
+        from_ccy: str,
+        to_ccy: str,
+        on_date: date,
+    ) -> Optional[Decimal]:
+        """Return the rate to convert 1 unit of from_ccy into to_ccy on on_date.
+
+        Returns None on any upstream failure — caller decides fallback.
+        """
+        from_ccy = from_ccy.upper()
+        to_ccy = to_ccy.upper()
+        if from_ccy == to_ccy:
+            return Decimal("1")
+
+        redis = _get_redis()
+        key = _cache_key(from_ccy, to_ccy, on_date)
+        try:
+            cached = await redis.get(key)
+            if cached is not None:
+                return Decimal(cached.decode("utf-8"))
+        except Exception:
+            cached = None
+
+        url = f"https://api.exchangerate.host/{on_date.isoformat()}"
+        params = {"base": from_ccy, "symbols": to_ccy}
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                resp = await client.get(url, params=params)
+                resp.raise_for_status()
+                data = resp.json()
+        except Exception:
+            return None
+
+        if not data.get("success", True):  # exchangerate.host omits 'success' on OK
+            return None
+        rate_val = data.get("rates", {}).get(to_ccy)
+        if rate_val is None:
+            return None
+
+        rate = Decimal(str(rate_val))
+        try:
+            await redis.set(key, str(rate), ex=_REDIS_TTL_SECONDS)
+        except Exception:
+            pass
+        return rate
+```
+
+- [ ] **Step 4: Run tests, expect PASS**
+
+```
+podman exec -e PYTHONPATH=/app family_app_backend pytest tests/test_fx_service.py -v
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/fx_service.py backend/tests/test_fx_service.py
+git commit -m "feat(scanner-v2): FXService with Redis-cached historical rate lookup"
+```
+
+---
+
+### Task 4: TransactionItemService
+
+**Files:**
+- Create: `backend/app/services/budget/transaction_item_service.py`
+- Create: `backend/tests/test_transaction_item_service.py`
+
+- [ ] **Step 1: Write failing tests for normalization + CRUD + trend**
+
+Create `backend/tests/test_transaction_item_service.py`:
+
+```python
+"""TransactionItemService — normalize names + CRUD + trend."""
+
+from datetime import date, datetime, timedelta, timezone
+from uuid import uuid4
+
+import pytest
+
+from app.services.budget.transaction_item_service import (
+    TransactionItemService, normalize_name,
+)
+
+
+def test_normalize_strips_accents_and_units():
+    assert normalize_name("Leche Alpura 1L") == "leche alpura"
+    assert normalize_name("Aguacate Hass kg") == "aguacate hass"
+    assert normalize_name("PAN INTEGRAL 500g") == "pan integral"
+    assert normalize_name("Café molido 250 g") == "cafe molido"
+    assert normalize_name("Yogurt   griego  ") == "yogurt griego"
+    assert normalize_name("3 PZA Tomate") == "tomate"
+
+
+@pytest.mark.asyncio
+async def test_bulk_create_persists_items(db, family, transaction):
+    items = await TransactionItemService.bulk_create(
+        db, family.id, transaction.id,
+        items=[
+            {"name": "Leche Alpura 1L", "qty": 2, "unit_price_cents": 3200,
+             "total_cents": 6400, "brand": "Alpura"},
+            {"name": "Pan integral", "total_cents": 4850},
+        ],
+    )
+    assert len(items) == 2
+    assert items[0].normalized_name == "leche alpura"
+    assert items[1].normalized_name == "pan integral"
+
+
+@pytest.mark.asyncio
+async def test_get_trend_returns_none_below_sample_size(db, family):
+    trend = await TransactionItemService.get_trend(
+        db, family.id, normalized_name="leche alpura", window_days=90,
+    )
+    assert trend is None
+
+
+@pytest.mark.asyncio
+async def test_get_trend_computes_pct_change(db, family, transaction_factory):
+    """Seed 4 items across recent dates; verify avg and pct_change."""
+    from app.models.budget import BudgetTransactionItem
+    now = datetime.now(timezone.utc)
+    tx = await transaction_factory(family_id=family.id, date=date.today())
+    for unit_price, days_ago in [(2500, 80), (2800, 60), (2900, 30), (3200, 1)]:
+        db.add(BudgetTransactionItem(
+            family_id=family.id, transaction_id=tx.id,
+            name="leche", normalized_name="leche alpura",
+            qty=1, unit_price_cents=unit_price, total_cents=unit_price,
+            created_at=now - timedelta(days=days_ago),
+        ))
+    await db.commit()
+    trend = await TransactionItemService.get_trend(
+        db, family.id, normalized_name="leche alpura", window_days=90,
+    )
+    assert trend is not None
+    assert trend.sample_size == 4
+    assert trend.last_unit_cents == 3200
+    # avg of first 3 priors = (2500+2800+2900)/3 = 2733
+    assert trend.avg_unit_cents == 2733
+    # pct_change = (3200 - 2733) / 2733 ≈ 0.171
+    assert 0.16 < trend.pct_change < 0.18
+
+
+@pytest.mark.asyncio
+async def test_tenant_isolation_on_list(db, family, other_family, transaction):
+    """Family A cannot read Family B's items."""
+    from app.models.budget import BudgetTransactionItem
+    db.add(BudgetTransactionItem(
+        family_id=other_family.id, transaction_id=transaction.id,
+        name="bread", normalized_name="bread", total_cents=1000,
+    ))
+    await db.commit()
+    rows = await TransactionItemService.list_for_family(
+        db, family.id, normalized_name="bread",
+    )
+    assert rows == []
+```
+
+- [ ] **Step 2: Add fixtures `family`, `other_family`, `transaction`, `transaction_factory` to `backend/tests/conftest.py`**
+
+Locate the existing fixtures section. Add:
+
+```python
+@pytest_asyncio.fixture
+async def family(db):
+    from app.models.family import Family
+    fam = Family(name="Test Family")
+    db.add(fam)
+    await db.commit()
+    await db.refresh(fam)
+    return fam
+
+
+@pytest_asyncio.fixture
+async def other_family(db):
+    from app.models.family import Family
+    fam = Family(name="Other Family")
+    db.add(fam)
+    await db.commit()
+    await db.refresh(fam)
+    return fam
+
+
+@pytest_asyncio.fixture
+async def transaction(db, family):
+    from app.models.budget import BudgetAccount, BudgetTransaction
+    from datetime import date
+    acct = BudgetAccount(family_id=family.id, name="Cash", type="checking",
+                         currency="MXN")
+    db.add(acct)
+    await db.commit()
+    await db.refresh(acct)
+    tx = BudgetTransaction(
+        family_id=family.id, account_id=acct.id, date=date.today(),
+        amount=-10000,
+    )
+    db.add(tx)
+    await db.commit()
+    await db.refresh(tx)
+    return tx
+
+
+@pytest_asyncio.fixture
+async def transaction_factory(db, family):
+    from app.models.budget import BudgetAccount, BudgetTransaction
+    acct = BudgetAccount(family_id=family.id, name="F", type="checking",
+                         currency="MXN")
+    db.add(acct)
+    await db.commit()
+    await db.refresh(acct)
+
+    async def _make(**kwargs):
+        tx = BudgetTransaction(
+            family_id=kwargs.get("family_id", family.id),
+            account_id=acct.id,
+            date=kwargs.get("date"),
+            amount=kwargs.get("amount", -10000),
+        )
+        db.add(tx)
+        await db.commit()
+        await db.refresh(tx)
+        return tx
+    return _make
+```
+
+(If `family`/`db` fixtures already exist, do not duplicate. Check `backend/tests/conftest.py` first.)
+
+- [ ] **Step 3: Run tests, expect FAIL on missing module**
+
+```
+podman exec -e PYTHONPATH=/app family_app_backend pytest tests/test_transaction_item_service.py -v
+```
+
+- [ ] **Step 4: Implement `backend/app/services/budget/transaction_item_service.py`**
+
+```python
+"""Transaction item CRUD + price-trend lookup.
+
+Items are first-class child rows of a BudgetTransaction. They power:
+- per-item categorization
+- price-trend badges on the confirm card
+- the a2a webhook payload to the external price-comparison agent
+"""
+
+import re
+import unicodedata
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+from uuid import UUID
+
+from sqlalchemy import and_, desc, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.budget import BudgetTransactionItem
+from app.schemas.budget import ItemTrend
+
+
+_UNIT_SUFFIX_RE = re.compile(
+    r"\s*\b(\d+\s*(?:kg|g|lt|l|ml|pza|pzas|pieza|piezas|pkg|pack))\b\s*",
+    flags=re.IGNORECASE,
+)
+_LEADING_QTY_RE = re.compile(r"^\s*\d+\s*(?:x|pza|pzas|pieza|piezas)?\s+", re.IGNORECASE)
+_TRAILING_UNIT_RE = re.compile(
+    r"\s*\b\d+\s*(?:kg|g|lt|l|ml|pza|pzas)\b\s*$", re.IGNORECASE
+)
+
+
+def normalize_name(raw: str) -> str:
+    """Lowercase, strip accents, strip unit suffixes + leading quantities."""
+    s = unicodedata.normalize("NFKD", raw)
+    s = "".join(c for c in s if not unicodedata.combining(c))
+    s = s.lower()
+    s = _LEADING_QTY_RE.sub("", s)
+    s = _TRAILING_UNIT_RE.sub("", s)
+    s = _UNIT_SUFFIX_RE.sub(" ", s)
+    s = re.sub(r"\s+", " ", s).strip()
+    return s
+
+
+class TransactionItemService:
+
+    @staticmethod
+    async def bulk_create(
+        db: AsyncSession,
+        family_id: UUID,
+        transaction_id: UUID,
+        items: list[dict],
+    ) -> list[BudgetTransactionItem]:
+        """Insert a batch of items as children of a transaction."""
+        rows: list[BudgetTransactionItem] = []
+        for it in items:
+            name = (it.get("name") or "").strip()
+            if not name:
+                continue
+            row = BudgetTransactionItem(
+                family_id=family_id,
+                transaction_id=transaction_id,
+                name=name,
+                normalized_name=normalize_name(name),
+                qty=it.get("qty"),
+                unit_price_cents=it.get("unit_price_cents"),
+                total_cents=int(it.get("total_cents") or 0),
+                category_id=it.get("category_id"),
+                brand=it.get("brand"),
+                raw_text=it.get("raw_text"),
+            )
+            db.add(row)
+            rows.append(row)
+        await db.commit()
+        for r in rows:
+            await db.refresh(r)
+        return rows
+
+    @staticmethod
+    async def list_for_family(
+        db: AsyncSession,
+        family_id: UUID,
+        normalized_name: Optional[str] = None,
+        since: Optional[datetime] = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[BudgetTransactionItem]:
+        stmt = select(BudgetTransactionItem).where(
+            BudgetTransactionItem.family_id == family_id
+        )
+        if normalized_name:
+            stmt = stmt.where(BudgetTransactionItem.normalized_name == normalized_name)
+        if since:
+            stmt = stmt.where(BudgetTransactionItem.created_at >= since)
+        stmt = stmt.order_by(desc(BudgetTransactionItem.created_at)).limit(limit).offset(offset)
+        result = await db.execute(stmt)
+        return list(result.scalars().all())
+
+    @staticmethod
+    async def get_trend(
+        db: AsyncSession,
+        family_id: UUID,
+        normalized_name: str,
+        window_days: int = 90,
+        min_sample: int = 3,
+    ) -> Optional[ItemTrend]:
+        """Return price trend for an item over the last window_days.
+
+        avg_unit_cents = mean of all PRIOR items (excludes the most recent)
+        last_unit_cents = the most recent item's unit_price_cents
+        pct_change = (last - avg) / avg
+        Returns None when sample_size < min_sample OR no priors with unit_price_cents.
+        """
+        since = datetime.now(timezone.utc) - timedelta(days=window_days)
+        stmt = (
+            select(BudgetTransactionItem)
+            .where(and_(
+                BudgetTransactionItem.family_id == family_id,
+                BudgetTransactionItem.normalized_name == normalized_name,
+                BudgetTransactionItem.created_at >= since,
+                BudgetTransactionItem.unit_price_cents.isnot(None),
+            ))
+            .order_by(desc(BudgetTransactionItem.created_at))
+        )
+        rows = list((await db.execute(stmt)).scalars().all())
+        if len(rows) < min_sample:
+            return None
+        last = rows[0]
+        priors = rows[1:]
+        avg = sum(int(p.unit_price_cents) for p in priors) // len(priors)
+        if avg == 0:
+            return None
+        last_v = int(last.unit_price_cents)
+        pct = (last_v - avg) / avg
+        return ItemTrend(
+            normalized_name=normalized_name,
+            avg_unit_cents=avg,
+            last_unit_cents=last_v,
+            pct_change=round(pct, 4),
+            sample_size=len(rows),
+        )
+```
+
+- [ ] **Step 5: Run tests, expect PASS**
+
+```
+podman exec -e PYTHONPATH=/app family_app_backend pytest tests/test_transaction_item_service.py -v
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/services/budget/transaction_item_service.py \
+        backend/tests/test_transaction_item_service.py \
+        backend/tests/conftest.py
+git commit -m "feat(scanner-v2): TransactionItemService with normalize + trend"
+```
+
+---
+
+### Task 5: AccountMatchingService
+
+**Files:**
+- Create: `backend/app/services/budget/account_matching_service.py`
+- Create: `backend/tests/test_account_matching_service.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+"""AccountMatchingService — pick an account from card_last4 + fallbacks."""
+
+from uuid import uuid4
+import pytest
+
+from app.services.budget.account_matching_service import AccountMatchingService
+
+
+@pytest.mark.asyncio
+async def test_exact_card_last4_match(db, family, account_factory):
+    a = await account_factory(family.id, name="MC 9222", card_last4="9222",
+                               currency="MXN")
+    pick = await AccountMatchingService.match(
+        db, family.id, user_id=uuid4(),
+        card_last4="9222", receipt_currency="MXN",
+    )
+    assert pick.strategy == "card_last4"
+    assert pick.account_id == a.id
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_card_last4_narrows_by_currency(db, family, account_factory):
+    mxn = await account_factory(family.id, name="MC 9222 MXN",
+                                 card_last4="9222", currency="MXN")
+    usd = await account_factory(family.id, name="MC 9222 USD",
+                                 card_last4="9222", currency="USD")
+    pick = await AccountMatchingService.match(
+        db, family.id, user_id=uuid4(),
+        card_last4="9222", receipt_currency="USD",
+    )
+    assert pick.strategy == "card_last4"
+    assert pick.account_id == usd.id
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_last_used_when_no_match(db, family, user, account_factory,
+                                                     transaction_factory_for_account):
+    a1 = await account_factory(family.id, name="A1", currency="MXN")
+    a2 = await account_factory(family.id, name="A2", currency="MXN")
+    # Most recent tx by this user is on a2
+    await transaction_factory_for_account(a2.id, user_id=user.id)
+    pick = await AccountMatchingService.match(
+        db, family.id, user_id=user.id,
+        card_last4=None, receipt_currency="MXN",
+    )
+    assert pick.strategy == "last_used"
+    assert pick.account_id == a2.id
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_no_accounts_at_all(db, family, user):
+    pick = await AccountMatchingService.match(
+        db, family.id, user_id=user.id,
+        card_last4=None, receipt_currency="MXN",
+    )
+    assert pick.account_id is None
+```
+
+- [ ] **Step 2: Add `account_factory` + `user` + `transaction_factory_for_account` fixtures to `conftest.py`** (similar pattern to Task 4 fixtures; include `created_by_id` on the transaction if model supports it; otherwise inject `user_id` via the transaction's `user_id` column — verify which exists in `app/models/budget.py` first).
+
+- [ ] **Step 3: Run tests — FAIL on missing module**
+
+```
+podman exec -e PYTHONPATH=/app family_app_backend pytest tests/test_account_matching_service.py -v
+```
+
+- [ ] **Step 4: Implement `backend/app/services/budget/account_matching_service.py`**
+
+```python
+"""Pick a target account for a scanned receipt.
+
+Strategy order:
+1. Caller-supplied account_id (validated to belong to family) → strategy="override"
+2. Match BudgetAccount.card_last4 → narrow by receipt currency if >1
+3. Most-recent transaction created by the authenticated user → "last_used"
+4. Most-recent transaction in the family (any user) → "last_used"
+5. None
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+from uuid import UUID
+
+from sqlalchemy import and_, desc, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.budget import BudgetAccount, BudgetTransaction
+
+
+@dataclass
+class AccountMatchResult:
+    account_id: Optional[UUID]
+    strategy: str  # "card_last4" | "last_used" | "override" | "none"
+    matched_card_last4: Optional[str] = None
+    matched_account_currency: Optional[str] = None
+
+
+class AccountMatchingService:
+
+    @staticmethod
+    async def match(
+        db: AsyncSession,
+        family_id: UUID,
+        user_id: UUID,
+        card_last4: Optional[str],
+        receipt_currency: Optional[str],
+        override_account_id: Optional[UUID] = None,
+    ) -> AccountMatchResult:
+        if override_account_id:
+            stmt = select(BudgetAccount).where(and_(
+                BudgetAccount.id == override_account_id,
+                BudgetAccount.family_id == family_id,
+            ))
+            row = (await db.execute(stmt)).scalar_one_or_none()
+            if row is not None:
+                return AccountMatchResult(
+                    account_id=row.id, strategy="override",
+                    matched_account_currency=row.currency,
+                )
+
+        if card_last4:
+            stmt = select(BudgetAccount).where(and_(
+                BudgetAccount.family_id == family_id,
+                BudgetAccount.card_last4 == card_last4,
+                BudgetAccount.closed.is_(False),
+                BudgetAccount.deleted_at.is_(None),
+            ))
+            hits = list((await db.execute(stmt)).scalars().all())
+            if len(hits) == 1:
+                return AccountMatchResult(
+                    account_id=hits[0].id, strategy="card_last4",
+                    matched_card_last4=card_last4,
+                    matched_account_currency=hits[0].currency,
+                )
+            if len(hits) > 1 and receipt_currency:
+                by_ccy = [h for h in hits if h.currency == receipt_currency.upper()]
+                if len(by_ccy) == 1:
+                    return AccountMatchResult(
+                        account_id=by_ccy[0].id, strategy="card_last4",
+                        matched_card_last4=card_last4,
+                        matched_account_currency=by_ccy[0].currency,
+                    )
+
+        # Fallback: most-recent tx by this user in this family
+        stmt = (
+            select(BudgetTransaction.account_id, BudgetAccount.currency)
+            .join(BudgetAccount, BudgetAccount.id == BudgetTransaction.account_id)
+            .where(and_(
+                BudgetTransaction.family_id == family_id,
+                BudgetTransaction.created_by_id == user_id,
+            ))
+            .order_by(desc(BudgetTransaction.created_at))
+            .limit(1)
+        )
+        result = (await db.execute(stmt)).first()
+        if result:
+            return AccountMatchResult(
+                account_id=result[0], strategy="last_used",
+                matched_account_currency=result[1],
+            )
+
+        # Fallback: any recent tx in family
+        stmt = (
+            select(BudgetTransaction.account_id, BudgetAccount.currency)
+            .join(BudgetAccount, BudgetAccount.id == BudgetTransaction.account_id)
+            .where(BudgetTransaction.family_id == family_id)
+            .order_by(desc(BudgetTransaction.created_at))
+            .limit(1)
+        )
+        result = (await db.execute(stmt)).first()
+        if result:
+            return AccountMatchResult(
+                account_id=result[0], strategy="last_used",
+                matched_account_currency=result[1],
+            )
+
+        return AccountMatchResult(account_id=None, strategy="none")
+```
+
+> **Note:** If `BudgetTransaction.created_by_id` does not exist in the model, replace with whichever column tracks the creator (verify via `grep "created_by_id\|user_id" backend/app/models/budget.py`). If neither exists, ship the fallback as "most-recent tx in family" only — and add a follow-up task to introduce `created_by_id` on transactions.
+
+- [ ] **Step 5: Run tests, expect PASS**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/services/budget/account_matching_service.py \
+        backend/tests/test_account_matching_service.py \
+        backend/tests/conftest.py
+git commit -m "feat(scanner-v2): AccountMatchingService — card_last4 + last-used fallback"
+```
+
+---
+
+### Task 6: DuplicateGuardService
+
+**Files:**
+- Create: `backend/app/services/budget/duplicate_guard_service.py`
+- Create: `backend/tests/test_duplicate_guard_service.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+"""DuplicateGuardService — flag same-payee same-amount recent receipts."""
+
+from datetime import datetime, timedelta, timezone
+import pytest
+
+from app.services.budget.duplicate_guard_service import DuplicateGuardService
+
+
+@pytest.mark.asyncio
+async def test_flags_same_payee_same_amount_within_60s(
+    db, family, payee, transaction_factory_with_payee,
+):
+    recent = await transaction_factory_with_payee(
+        family.id, payee.id, amount=-72040,
+        created_at=datetime.now(timezone.utc) - timedelta(seconds=30),
+    )
+    dup = await DuplicateGuardService.check(
+        db, family.id, payee_id=payee.id, amount_cents=-72040,
+    )
+    assert dup is not None
+    assert dup.existing_transaction_id == recent.id
+
+
+@pytest.mark.asyncio
+async def test_does_not_flag_after_60s(
+    db, family, payee, transaction_factory_with_payee,
+):
+    await transaction_factory_with_payee(
+        family.id, payee.id, amount=-72040,
+        created_at=datetime.now(timezone.utc) - timedelta(seconds=90),
+    )
+    dup = await DuplicateGuardService.check(
+        db, family.id, payee_id=payee.id, amount_cents=-72040,
+    )
+    assert dup is None
+
+
+@pytest.mark.asyncio
+async def test_does_not_flag_when_amount_differs_more_than_1pct(
+    db, family, payee, transaction_factory_with_payee,
+):
+    await transaction_factory_with_payee(
+        family.id, payee.id, amount=-72040,
+        created_at=datetime.now(timezone.utc) - timedelta(seconds=10),
+    )
+    dup = await DuplicateGuardService.check(
+        db, family.id, payee_id=payee.id, amount_cents=-80000,
+    )
+    assert dup is None
+
+
+@pytest.mark.asyncio
+async def test_does_not_cross_families(
+    db, family, other_family, payee, transaction_factory_with_payee,
+):
+    await transaction_factory_with_payee(
+        other_family.id, payee.id, amount=-72040,
+        created_at=datetime.now(timezone.utc) - timedelta(seconds=10),
+    )
+    dup = await DuplicateGuardService.check(
+        db, family.id, payee_id=payee.id, amount_cents=-72040,
+    )
+    assert dup is None
+```
+
+- [ ] **Step 2: Add `payee` + `transaction_factory_with_payee` fixtures to conftest.py.**
+
+- [ ] **Step 3: Run, FAIL on missing module**
+
+- [ ] **Step 4: Implement `backend/app/services/budget/duplicate_guard_service.py`**
+
+```python
+"""Detect a likely duplicate receipt scan within a short time window."""
+
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+from uuid import UUID
+
+from sqlalchemy import and_, desc, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.budget import BudgetTransaction
+from app.schemas.budget import DupWarning
+
+
+class DuplicateGuardService:
+
+    WINDOW_SECONDS = 60
+    AMOUNT_TOLERANCE = 0.01  # 1%
+
+    @classmethod
+    async def check(
+        cls,
+        db: AsyncSession,
+        family_id: UUID,
+        payee_id: Optional[UUID],
+        amount_cents: int,
+    ) -> Optional[DupWarning]:
+        if payee_id is None:
+            return None
+        cutoff = datetime.now(timezone.utc) - timedelta(seconds=cls.WINDOW_SECONDS)
+        tol = max(1, int(abs(amount_cents) * cls.AMOUNT_TOLERANCE))
+        stmt = (
+            select(BudgetTransaction)
+            .where(and_(
+                BudgetTransaction.family_id == family_id,
+                BudgetTransaction.payee_id == payee_id,
+                BudgetTransaction.created_at >= cutoff,
+                BudgetTransaction.amount.between(amount_cents - tol, amount_cents + tol),
+            ))
+            .order_by(desc(BudgetTransaction.created_at))
+            .limit(1)
+        )
+        row = (await db.execute(stmt)).scalar_one_or_none()
+        if row is None:
+            return None
+        return DupWarning(
+            existing_transaction_id=row.id,
+            scanned_at=row.created_at,
+            amount_cents=int(row.amount),
+        )
+```
+
+- [ ] **Step 5: Run tests, expect PASS**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/services/budget/duplicate_guard_service.py \
+        backend/tests/test_duplicate_guard_service.py \
+        backend/tests/conftest.py
+git commit -m "feat(scanner-v2): DuplicateGuardService — 60s/1% same-payee guard"
+```
+
+---
+
+### Task 7: A2AWebhookService
+
+**Files:**
+- Create: `backend/app/services/budget/a2a_webhook_service.py`
+- Create: `backend/tests/test_a2a_webhook_service.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+"""A2AWebhookService — enqueue, dispatch, signature, retry sweep."""
+
+import hashlib
+import hmac
+import json
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.services.budget.a2a_webhook_service import A2AWebhookService
+from app.models.a2a import FamilyA2AWebhook, A2AWebhookDelivery
+
+
+@pytest.mark.asyncio
+async def test_enqueue_skips_when_family_has_no_webhook(db, family, transaction):
+    delivery = await A2AWebhookService.enqueue(
+        db, family.id, transaction.id, payload={"hello": "world"},
+    )
+    assert delivery is None
+
+
+@pytest.mark.asyncio
+async def test_enqueue_skips_when_disabled(db, family, transaction):
+    db.add(FamilyA2AWebhook(
+        family_id=family.id, url="https://x", secret="s", enabled=False,
+    ))
+    await db.commit()
+    delivery = await A2AWebhookService.enqueue(
+        db, family.id, transaction.id, payload={"a": 1},
+    )
+    assert delivery is None
+
+
+@pytest.mark.asyncio
+async def test_enqueue_creates_delivery_row(db, family, transaction):
+    db.add(FamilyA2AWebhook(
+        family_id=family.id, url="https://x", secret="s", enabled=True,
+    ))
+    await db.commit()
+    delivery = await A2AWebhookService.enqueue(
+        db, family.id, transaction.id, payload={"k": "v"},
+    )
+    assert delivery is not None
+    assert delivery.status == "pending"
+    assert delivery.payload_json == {"k": "v"}
+
+
+@pytest.mark.asyncio
+async def test_dispatch_once_signs_and_marks_sent(db, family, transaction):
+    secret = "abc123"
+    db.add(FamilyA2AWebhook(
+        family_id=family.id, url="https://hook.example/x",
+        secret=secret, enabled=True,
+    ))
+    await db.commit()
+    delivery = await A2AWebhookService.enqueue(
+        db, family.id, transaction.id, payload={"foo": "bar"},
+    )
+
+    fake_resp = MagicMock()
+    fake_resp.status_code = 202
+    fake_resp.text = "ok"
+
+    fake_client = AsyncMock()
+    fake_client.post = AsyncMock(return_value=fake_resp)
+    fake_client.__aenter__.return_value = fake_client
+    fake_client.__aexit__.return_value = False
+
+    with patch("app.services.budget.a2a_webhook_service.httpx.AsyncClient",
+               return_value=fake_client):
+        await A2AWebhookService.dispatch_once(db, delivery.id)
+
+    await db.refresh(delivery)
+    assert delivery.status == "sent"
+    assert delivery.attempts == 1
+
+    sent_headers = fake_client.post.await_args.kwargs["headers"]
+    body = fake_client.post.await_args.kwargs["content"]
+    expected = "sha256=" + hmac.new(
+        secret.encode(), body, hashlib.sha256
+    ).hexdigest()
+    assert sent_headers["X-A2A-Signature"] == expected
+
+
+@pytest.mark.asyncio
+async def test_dispatch_failure_schedules_retry(db, family, transaction):
+    db.add(FamilyA2AWebhook(
+        family_id=family.id, url="https://x", secret="s", enabled=True,
+    ))
+    await db.commit()
+    delivery = await A2AWebhookService.enqueue(
+        db, family.id, transaction.id, payload={"a": 1},
+    )
+
+    fake_client = AsyncMock()
+    fake_client.post = AsyncMock(side_effect=RuntimeError("net"))
+    fake_client.__aenter__.return_value = fake_client
+    fake_client.__aexit__.return_value = False
+
+    with patch("app.services.budget.a2a_webhook_service.httpx.AsyncClient",
+               return_value=fake_client):
+        await A2AWebhookService.dispatch_once(db, delivery.id)
+
+    await db.refresh(delivery)
+    assert delivery.status == "failed"
+    assert delivery.attempts == 1
+    assert delivery.next_retry_at is not None
+    assert delivery.next_retry_at > datetime.now(timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_sweep_picks_up_due_failed(db, family, transaction):
+    db.add(FamilyA2AWebhook(
+        family_id=family.id, url="https://x", secret="s", enabled=True,
+    ))
+    db.add(A2AWebhookDelivery(
+        family_id=family.id, transaction_id=transaction.id,
+        payload_json={"a": 1}, status="failed", attempts=1,
+        next_retry_at=datetime.now(timezone.utc) - timedelta(seconds=5),
+    ))
+    await db.commit()
+
+    ids: list = []
+
+    async def fake_dispatch(_db, _id):
+        ids.append(_id)
+
+    with patch.object(A2AWebhookService, "dispatch_once",
+                      side_effect=fake_dispatch):
+        n = await A2AWebhookService.sweep_retries(db, limit=10)
+
+    assert n == 1
+    assert len(ids) == 1
+```
+
+- [ ] **Step 2: Run — FAIL on missing module**
+
+- [ ] **Step 3: Implement `backend/app/services/budget/a2a_webhook_service.py`**
+
+```python
+"""Per-family a2a webhook: enqueue, sign, dispatch, retry."""
+
+import hashlib
+import hmac
+import json
+import secrets
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+from uuid import UUID
+
+import httpx
+from sqlalchemy import and_, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.a2a import A2AWebhookDelivery, FamilyA2AWebhook
+
+
+# Exponential backoff schedule for failed deliveries.
+_BACKOFF_SCHEDULE = [
+    timedelta(minutes=1),
+    timedelta(minutes=5),
+    timedelta(minutes=30),
+    timedelta(hours=2),
+    timedelta(hours=12),
+]
+_MAX_ATTEMPTS = len(_BACKOFF_SCHEDULE)
+_DISPATCH_TIMEOUT_SECONDS = 10.0
+
+
+def generate_secret() -> str:
+    return secrets.token_hex(32)
+
+
+class A2AWebhookService:
+
+    @staticmethod
+    async def get_config(
+        db: AsyncSession, family_id: UUID
+    ) -> Optional[FamilyA2AWebhook]:
+        result = await db.execute(
+            select(FamilyA2AWebhook).where(
+                FamilyA2AWebhook.family_id == family_id
+            )
+        )
+        return result.scalar_one_or_none()
+
+    @staticmethod
+    async def upsert_config(
+        db: AsyncSession,
+        family_id: UUID,
+        url: str,
+        enabled: bool,
+        rotate_secret: bool,
+    ) -> tuple[FamilyA2AWebhook, Optional[str]]:
+        existing = await A2AWebhookService.get_config(db, family_id)
+        plaintext_secret: Optional[str] = None
+        if existing is None:
+            plaintext_secret = generate_secret()
+            row = FamilyA2AWebhook(
+                family_id=family_id, url=url,
+                secret=plaintext_secret, enabled=enabled,
+            )
+            db.add(row)
+            await db.commit()
+            await db.refresh(row)
+            return row, plaintext_secret
+
+        existing.url = url
+        existing.enabled = enabled
+        if rotate_secret:
+            plaintext_secret = generate_secret()
+            existing.secret = plaintext_secret
+        await db.commit()
+        await db.refresh(existing)
+        return existing, plaintext_secret
+
+    @staticmethod
+    async def enqueue(
+        db: AsyncSession,
+        family_id: UUID,
+        transaction_id: UUID,
+        payload: dict,
+    ) -> Optional[A2AWebhookDelivery]:
+        cfg = await A2AWebhookService.get_config(db, family_id)
+        if cfg is None or not cfg.enabled:
+            return None
+        delivery = A2AWebhookDelivery(
+            family_id=family_id,
+            transaction_id=transaction_id,
+            payload_json=payload,
+            status="pending",
+        )
+        db.add(delivery)
+        await db.commit()
+        await db.refresh(delivery)
+        return delivery
+
+    @staticmethod
+    async def dispatch_once(db: AsyncSession, delivery_id: UUID) -> None:
+        delivery = await db.get(A2AWebhookDelivery, delivery_id)
+        if delivery is None:
+            return
+        cfg = await A2AWebhookService.get_config(db, delivery.family_id)
+        if cfg is None or not cfg.enabled:
+            delivery.status = "dead"
+            delivery.last_error = "no enabled webhook config"
+            await db.commit()
+            return
+
+        body = json.dumps(delivery.payload_json, separators=(",", ":"),
+                          sort_keys=True).encode("utf-8")
+        signature = "sha256=" + hmac.new(
+            cfg.secret.encode("utf-8"), body, hashlib.sha256
+        ).hexdigest()
+        headers = {
+            "Content-Type": "application/json",
+            "X-A2A-Signature": signature,
+            "X-A2A-Delivery": str(delivery.id),
+            "X-A2A-Schema": "family-budget.receipt.v1",
+        }
+
+        delivery.attempts += 1
+        try:
+            async with httpx.AsyncClient(timeout=_DISPATCH_TIMEOUT_SECONDS) as client:
+                resp = await client.post(cfg.url, content=body, headers=headers)
+            if 200 <= resp.status_code < 300:
+                delivery.status = "sent"
+                delivery.last_error = None
+                delivery.next_retry_at = None
+                cfg.last_success_at = datetime.now(timezone.utc)
+                cfg.failure_count = 0
+                cfg.last_error = None
+            else:
+                raise RuntimeError(f"HTTP {resp.status_code}: {resp.text[:200]}")
+        except Exception as exc:
+            delivery.last_error = str(exc)[:500]
+            if delivery.attempts >= _MAX_ATTEMPTS:
+                delivery.status = "dead"
+                delivery.next_retry_at = None
+            else:
+                delivery.status = "failed"
+                delay = _BACKOFF_SCHEDULE[delivery.attempts - 1]
+                delivery.next_retry_at = datetime.now(timezone.utc) + delay
+            cfg.failure_count += 1
+            cfg.last_error = delivery.last_error
+        await db.commit()
+
+    @staticmethod
+    async def sweep_retries(db: AsyncSession, limit: int = 50) -> int:
+        now = datetime.now(timezone.utc)
+        result = await db.execute(
+            select(A2AWebhookDelivery.id).where(and_(
+                A2AWebhookDelivery.status.in_(["pending", "failed"]),
+                A2AWebhookDelivery.next_retry_at.isnot(None),
+                A2AWebhookDelivery.next_retry_at <= now,
+            )).limit(limit)
+        )
+        ids = [r[0] for r in result.all()]
+        for _id in ids:
+            await A2AWebhookService.dispatch_once(db, _id)
+        return len(ids)
+```
+
+- [ ] **Step 4: Run tests, expect PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/budget/a2a_webhook_service.py \
+        backend/tests/test_a2a_webhook_service.py
+git commit -m "feat(scanner-v2): A2AWebhookService — enqueue, HMAC sign, dispatch, retry sweep"
+```
+
+---
+
+## Phase 3 — Scanner integration
+
+### Task 8: Vision prompt update
+
+**Files:**
+- Modify: `backend/app/services/budget/receipt_scanner_service.py` (replace `RECEIPT_PROMPT`, extend `ScannedReceipt` dataclass + `scan_receipt` parser)
+- Test: extend `backend/tests/test_receipt_scanner.py` OR new `backend/tests/test_receipt_scanner_v2.py`
+
+- [ ] **Step 1: Write failing tests for new vision fields**
+
+Create/append `backend/tests/test_receipt_scanner_v2.py`:
+
+```python
+from unittest.mock import AsyncMock, MagicMock, patch
+import pytest
+
+from app.services.budget.receipt_scanner_service import scan_receipt
+
+
+def _mock_vision_json(payload: dict):
+    """Build an OpenAI Chat completion mock returning JSON-as-text."""
+    import json as _json
+    msg = MagicMock()
+    msg.content = _json.dumps(payload)
+    choice = MagicMock()
+    choice.message = msg
+    completion = MagicMock()
+    completion.choices = [choice]
+    return completion
+
+
+@pytest.mark.asyncio
+async def test_scan_extracts_card_last4_iva_and_items(monkeypatch):
+    monkeypatch.setattr("app.core.config.settings.LITELLM_API_KEY", "test-key")
+    monkeypatch.setattr("app.core.config.settings.LITELLM_API_BASE",
+                        "http://litellm")
+
+    fake = _mock_vision_json({
+        "date": "2026-05-28",
+        "total_amount": -72040,
+        "iva_cents": 9683,
+        "payee_name": "HEB",
+        "card_last4": "9222",
+        "currency": "MXN",
+        "items": [
+            {"name": "Leche Alpura 1L", "qty": 2,
+             "unit_price_cents": 3200, "total_cents": 6400,
+             "brand": "Alpura", "raw_text": "LECHE ALPURA 1L 2 X 32.00 64.00"},
+        ],
+        "confidence": 0.92,
+    })
+    fake_client = MagicMock()
+    fake_client.chat.completions.create = MagicMock(return_value=fake)
+    with patch("app.services.budget.receipt_scanner_service.OpenAI",
+               return_value=fake_client):
+        result = await scan_receipt(b"jpegbytes", "image/jpeg")
+
+    assert result.card_last4 == "9222"
+    assert result.iva_cents == 9683
+    assert len(result.items) == 1
+    item = result.items[0]
+    assert item["brand"] == "Alpura"
+    assert item["qty"] == 2
+    assert item["unit_price_cents"] == 3200
+    assert item["raw_text"].startswith("LECHE ALPURA")
+```
+
+- [ ] **Step 2: Run, FAIL — fields not parsed**
+
+- [ ] **Step 3: Replace `RECEIPT_PROMPT` in `receipt_scanner_service.py`**
+
+```python
+RECEIPT_PROMPT = """Analyze this receipt image and extract the following information. Return ONLY valid JSON, no markdown or explanation.
+
+{
+  "date": "YYYY-MM-DD or null if unreadable",
+  "total_amount": <total in the receipt's smallest currency unit (cents/centavos), as integer, NEGATIVE for expenses>,
+  "iva_cents": <tax/IVA line as positive integer cents, or null if not present>,
+  "payee_name": "store/business name or null",
+  "card_last4": "4-digit string (last 4 of the card used) or null",
+  "currency": "MXN or USD or other ISO code",
+  "items": [
+    {
+      "name": "item description",
+      "qty": <number or null>,
+      "unit_price_cents": <positive integer cents per unit, or null>,
+      "total_cents": <positive integer cents for the line>,
+      "brand": "string or null",
+      "raw_text": "the original line as printed on the receipt"
+    }
+  ],
+  "confidence": <0.0-1.0 how confident you are in the extraction>
+}
+
+Rules:
+- total_amount MUST be negative (it's an expense)
+- If the receipt shows MXN $150.50, total_amount = -15050
+- If the receipt shows $42.99 USD, total_amount = -4299
+- card_last4: look for "**1234", "XXXX1234", "terminada en 1234", "Card: ...1234"
+- iva_cents: look for "IVA", "Tax", "Impuesto" line; extract as POSITIVE cents
+- Per item: extract qty when explicit ("2 x", "2 PZA"), brand when present
+- Set confidence based on image clarity and readability
+- If you cannot read the receipt at all, set confidence to 0 and all values to null"""
+```
+
+- [ ] **Step 4: Extend `ScannedReceipt` dataclass**
+
+```python
+@dataclass
+class ScannedReceipt:
+    date: Optional[date]
+    total_amount: Optional[int]
+    payee_name: Optional[str]
+    items: list
+    currency: str = "MXN"
+    raw_text: str = ""
+    confidence: float = 0.0
+    # new in v2
+    card_last4: Optional[str] = None
+    iva_cents: Optional[int] = None
+```
+
+In `scan_receipt`, after `data = json.loads(...)`, populate `card_last4` and `iva_cents` from the parsed dict and pass them when constructing the return value:
+
+```python
+    return ScannedReceipt(
+        date=parsed_date,
+        total_amount=data.get("total_amount"),
+        payee_name=data.get("payee_name"),
+        items=data.get("items", []),
+        currency=data.get("currency", "MXN"),
+        raw_text=response_text,
+        confidence=data.get("confidence", 0.0),
+        card_last4=(data.get("card_last4") or None) if (
+            isinstance(data.get("card_last4"), str)
+            and len(data.get("card_last4", "")) == 4
+            and data.get("card_last4", "").isdigit()
+        ) else None,
+        iva_cents=data.get("iva_cents") if isinstance(data.get("iva_cents"), int) else None,
+    )
+```
+
+- [ ] **Step 5: Run tests, expect PASS**
+
+```
+podman exec -e PYTHONPATH=/app family_app_backend pytest tests/test_receipt_scanner_v2.py::test_scan_extracts_card_last4_iva_and_items -v
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/services/budget/receipt_scanner_service.py \
+        backend/tests/test_receipt_scanner_v2.py
+git commit -m "feat(scanner-v2): vision prompt + parser extract card_last4 + iva + qty/brand"
+```
+
+---
+
+### Task 9: Rewrite `scan_and_create_transaction` pipeline
+
+**Files:**
+- Modify: `backend/app/services/budget/receipt_scanner_service.py` (rewrite `scan_and_create_transaction` to run the 7 stages: vision → account match → dup-guard → FX → persist tx+items → categorize → enqueue webhook)
+- Modify: `backend/app/services/budget/categorization_rule_service.py` (extend `suggest_category` to accept optional `item_name`)
+- Test: extend `backend/tests/test_receipt_scanner_v2.py`
+
+- [ ] **Step 1: Write failing pipeline integration tests**
+
+Append to `backend/tests/test_receipt_scanner_v2.py`:
+
+```python
+from datetime import date
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.services.budget.receipt_scanner_service import (
+    scan_and_create_transaction,
+)
+
+
+@pytest.mark.asyncio
+async def test_pipeline_creates_tx_with_items_and_fx(
+    db, family, user, account_factory, monkeypatch,
+):
+    mxn = await account_factory(family.id, name="MC MXN",
+                                 card_last4="9222", currency="MXN")
+
+    fake_receipt = MagicMock(
+        date=date(2026, 5, 28), total_amount=-72040,
+        payee_name="HEB", currency="MXN",
+        card_last4="9222", iva_cents=9683, confidence=0.92,
+        items=[{"name": "Leche", "qty": 2, "unit_price_cents": 3200,
+                 "total_cents": 6400, "raw_text": "LECHE 2x 64.00"}],
+    )
+    async def fake_scan(_b, _t): return fake_receipt
+    monkeypatch.setattr("app.services.budget.receipt_scanner_service.scan_receipt",
+                        fake_scan)
+
+    result = await scan_and_create_transaction(
+        db=db, family_id=family.id, user_id=user.id,
+        account_id=None, image_bytes=b"x", media_type="image/jpeg",
+        force=False,
+    )
+    assert result["success"] is True
+    assert result["transaction_id"] is not None
+    assert len(result["items"]) == 1
+    assert result["account_match"]["strategy"] == "card_last4"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_returns_dup_warning_without_committing(
+    db, family, user, account_factory, payee, transaction_factory_with_payee,
+    monkeypatch,
+):
+    mxn = await account_factory(family.id, card_last4="9222", currency="MXN")
+    # Recent same-payee same-amount tx
+    await transaction_factory_with_payee(
+        family.id, payee.id, amount=-72040,
+        created_at=None,  # default now
+    )
+
+    fake_receipt = MagicMock(
+        date=date(2026, 5, 28), total_amount=-72040,
+        payee_name=payee.name, currency="MXN",
+        card_last4="9222", iva_cents=None, confidence=0.92,
+        items=[],
+    )
+    async def fake_scan(_b, _t): return fake_receipt
+    monkeypatch.setattr("app.services.budget.receipt_scanner_service.scan_receipt",
+                        fake_scan)
+
+    result = await scan_and_create_transaction(
+        db=db, family_id=family.id, user_id=user.id,
+        account_id=None, image_bytes=b"x", media_type="image/jpeg",
+        force=False,
+    )
+    assert result["success"] is False
+    assert result["dup_warning"] is not None
+    assert result["transaction_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_force_true_bypasses_duplicate_guard(
+    db, family, user, account_factory, payee, transaction_factory_with_payee,
+    monkeypatch,
+):
+    mxn = await account_factory(family.id, card_last4="9222", currency="MXN")
+    await transaction_factory_with_payee(
+        family.id, payee.id, amount=-72040,
+    )
+    fake_receipt = MagicMock(
+        date=date(2026, 5, 28), total_amount=-72040,
+        payee_name=payee.name, currency="MXN",
+        card_last4="9222", iva_cents=None, confidence=0.92, items=[],
+    )
+    async def fake_scan(_b, _t): return fake_receipt
+    monkeypatch.setattr("app.services.budget.receipt_scanner_service.scan_receipt",
+                        fake_scan)
+    result = await scan_and_create_transaction(
+        db=db, family_id=family.id, user_id=user.id,
+        account_id=None, image_bytes=b"x", media_type="image/jpeg",
+        force=True,
+    )
+    assert result["success"] is True
+    assert result["transaction_id"] is not None
+
+
+@pytest.mark.asyncio
+async def test_pipeline_stores_fx_when_currencies_differ(
+    db, family, user, account_factory, monkeypatch,
+):
+    mxn = await account_factory(family.id, card_last4=None, currency="MXN")
+
+    fake_receipt = MagicMock(
+        date=date(2026, 5, 28), total_amount=-4200,
+        payee_name="WALMART US", currency="USD",
+        card_last4=None, iva_cents=None, confidence=0.92, items=[],
+    )
+    async def fake_scan(_b, _t): return fake_receipt
+    monkeypatch.setattr("app.services.budget.receipt_scanner_service.scan_receipt",
+                        fake_scan)
+
+    from decimal import Decimal
+    async def fake_fx(*_a, **_k): return Decimal("17.15")
+    monkeypatch.setattr("app.services.fx_service.FXService.get_rate", fake_fx)
+
+    # User has Pro plan so fx_cross_charge is enabled
+    async def allow_feature(*_a, **_k): return MagicMock(name="pro")
+    monkeypatch.setattr("app.services.budget.receipt_scanner_service.is_feature_enabled",
+                        AsyncMock(return_value=True))
+
+    result = await scan_and_create_transaction(
+        db=db, family_id=family.id, user_id=user.id,
+        account_id=mxn.id, image_bytes=b"x", media_type="image/jpeg",
+        force=False,
+    )
+    assert result["success"] is True
+    assert result["fx"]["rate"] == "17.15"
+    assert result["fx"]["original_currency"] == "USD"
+    assert result["fx"]["original_amount_cents"] == -4200
+```
+
+- [ ] **Step 2: Add `is_feature_enabled` import + helper to `receipt_scanner_service.py`**
+
+At top of file:
+
+```python
+from fastapi import BackgroundTasks  # optional; pass through if caller provides one
+from app.core.premium import get_family_plan, FEATURE_LIMIT_MAP, FEATURE_MIN_PLAN
+
+_PLAN_ORDER = {"free": 0, "plus": 1, "pro": 2}
+
+async def is_feature_enabled(db, family_id, feature: str) -> bool:
+    """Cheap boolean check (no usage increment, no HTTPException). For
+    optional features inside the pipeline (fx_cross_charge, item_trends,
+    a2a_webhook). Resolves the family's plan and compares to the minimum
+    plan required for the feature.
+    """
+    from app.models.user import User
+    from sqlalchemy import select
+    r = await db.execute(select(User).where(User.family_id == family_id).limit(1))
+    user = r.scalar_one_or_none()
+    if user is None:
+        return False
+    plan = await get_family_plan(db, user)
+    min_plan = FEATURE_MIN_PLAN.get(feature, "free")
+    return _PLAN_ORDER.get(plan.name, 0) >= _PLAN_ORDER.get(min_plan, 0)
+```
+
+- [ ] **Step 3: Rewrite `scan_and_create_transaction`**
+
+Replace the existing function body with:
+
+```python
+async def scan_and_create_transaction(
+    db: AsyncSession,
+    family_id: UUID,
+    user_id: UUID,
+    account_id: Optional[UUID],
+    image_bytes: bytes,
+    media_type: str,
+    force: bool = False,
+) -> dict:
+    """Run the 7-stage scanner v2 pipeline.
+
+    Stages: vision → account match → duplicate guard → FX cross-charge →
+    persist transaction+items → auto-categorize → fan-out (shopping
+    auto-check, a2a webhook enqueue).
+    """
+    from app.services.budget.account_matching_service import AccountMatchingService
+    from app.services.budget.duplicate_guard_service import DuplicateGuardService
+    from app.services.budget.transaction_item_service import (
+        TransactionItemService, normalize_name,
+    )
+    from app.services.budget.a2a_webhook_service import A2AWebhookService
+    from app.services.fx_service import FXService
+
+    # (1) Vision extract
+    receipt = await scan_receipt(image_bytes, media_type)
+
+    scanned_dict = {
+        "date": receipt.date.isoformat() if receipt.date else None,
+        "total_amount": receipt.total_amount,
+        "payee_name": receipt.payee_name,
+        "items": receipt.items,
+        "currency": receipt.currency,
+        "card_last4": receipt.card_last4,
+        "iva_cents": receipt.iva_cents,
+    }
+
+    # HITL: low confidence routes to the drafts queue (unchanged from v1)
+    if receipt.confidence < 0.3 or receipt.total_amount is None:
+        return await _route_to_drafts(
+            db, family_id, account_id, image_bytes, receipt, scanned_dict
+        )
+
+    # (2) Account auto-detect
+    match = await AccountMatchingService.match(
+        db, family_id, user_id=user_id,
+        card_last4=receipt.card_last4,
+        receipt_currency=receipt.currency,
+        override_account_id=account_id,
+    )
+    if match.account_id is None:
+        # No accounts at all → drafts queue
+        return await _route_to_drafts(
+            db, family_id, None, image_bytes, receipt, scanned_dict,
+            reason="no_accounts",
+        )
+
+    # FX gating: non-Pro and currency mismatch → drafts queue
+    fx_allowed = await is_feature_enabled(db, family_id, "fx_cross_charge")
+    if (match.matched_account_currency != receipt.currency
+            and not fx_allowed):
+        return await _route_to_drafts(
+            db, family_id, match.account_id, image_bytes, receipt,
+            scanned_dict, reason="currency_mismatch",
+        )
+
+    # Resolve payee (needed for dup-guard)
+    payee_id = await _find_or_create_payee(db, family_id, receipt.payee_name)
+
+    # (3) Duplicate guard
+    if not force:
+        dup = await DuplicateGuardService.check(
+            db, family_id, payee_id=payee_id, amount_cents=receipt.total_amount,
+        )
+        if dup is not None:
+            # Roll back the just-created payee if it was new — leaving an
+            # unused payee row is acceptable noise for v1 (find-or-create
+            # is idempotent on a re-scan with force=true).
+            return {
+                "success": False,
+                "transaction_id": None,
+                "dup_warning": {
+                    "existing_transaction_id": str(dup.existing_transaction_id),
+                    "scanned_at": dup.scanned_at.isoformat(),
+                    "amount_cents": dup.amount_cents,
+                    "payee": receipt.payee_name,
+                },
+                "scanned_preview": scanned_dict,
+                "confidence": receipt.confidence,
+            }
+
+    # (4) FX cross-charge
+    fx_info = None
+    final_amount = receipt.total_amount
+    original_amount = None
+    original_currency = None
+    fx_rate = None
+    warnings: list[str] = []
+    if match.matched_account_currency != receipt.currency and fx_allowed:
+        rate = await FXService.get_rate(
+            receipt.currency, match.matched_account_currency,
+            on_date=receipt.date or date.today(),
+        )
+        if rate is None:
+            warnings.append("fx_unavailable")
+        else:
+            original_amount = receipt.total_amount
+            original_currency = receipt.currency
+            fx_rate = rate
+            # Convert (signed)
+            from decimal import ROUND_HALF_UP, Decimal
+            final_amount = int(
+                (Decimal(receipt.total_amount) * rate).quantize(
+                    Decimal("1"), rounding=ROUND_HALF_UP
+                )
+            )
+            fx_info = {
+                "rate": str(rate),
+                "original_amount_cents": original_amount,
+                "original_currency": original_currency,
+            }
+
+    # (5) Persist transaction
+    from app.models.budget import BudgetTransaction
+    txn_date = receipt.date or date.today()
+    txn = BudgetTransaction(
+        family_id=family_id,
+        account_id=match.account_id,
+        date=txn_date,
+        amount=final_amount,
+        payee_id=payee_id,
+        notes=_build_notes(receipt.payee_name, receipt.items, receipt.currency),
+        cleared=False,
+        reconciled=False,
+        card_last4=receipt.card_last4,
+        iva_cents=receipt.iva_cents,
+        fx_rate=fx_rate,
+        original_amount_cents=original_amount,
+        original_currency=original_currency,
+    )
+    db.add(txn)
+    await db.flush()
+
+    # (5b) Persist items
+    items_persisted = await TransactionItemService.bulk_create(
+        db, family_id, txn.id, items=receipt.items,
+    )
+
+    # (6) Auto-categorize (transaction header + each item)
+    header_cat = await CategorizationRuleService.suggest_category(
+        db, family_id, payee=receipt.payee_name, description=None,
+    )
+    if header_cat:
+        txn.category_id = header_cat
+    for it in items_persisted:
+        it.category_id = await CategorizationRuleService.suggest_category(
+            db, family_id, payee=receipt.payee_name,
+            description=None, item_name=it.name,
+        )
+    await db.commit()
+    await db.refresh(txn)
+
+    # (7a) Shopping auto-check
+    shopping_auto_checked: list[str] = []
+    try:
+        shopping_auto_checked = await _auto_check_shopping_items(
+            db, family_id, [i.get("name", "") for i in receipt.items]
+        )
+    except Exception:
+        import logging
+        logging.getLogger(__name__).exception("shopping auto-check failed")
+
+    # (7b) Trends per item (only if feature allowed and items present)
+    trends: list[dict] = []
+    if await is_feature_enabled(db, family_id, "item_trends"):
+        seen = set()
+        for it in items_persisted:
+            if it.normalized_name in seen:
+                continue
+            seen.add(it.normalized_name)
+            trend = await TransactionItemService.get_trend(
+                db, family_id, normalized_name=it.normalized_name,
+            )
+            if trend:
+                trends.append(trend.model_dump())
+
+    # (7c) A2A webhook enqueue
+    if await is_feature_enabled(db, family_id, "a2a_webhook"):
+        payload = _build_webhook_payload(
+            family_id, txn, items_persisted, receipt.currency,
+        )
+        try:
+            delivery = await A2AWebhookService.enqueue(
+                db, family_id, txn.id, payload=payload,
+            )
+            if delivery is not None:
+                # Best-effort first attempt inline; sweep handles retries.
+                await A2AWebhookService.dispatch_once(db, delivery.id)
+        except Exception:
+            import logging
+            logging.getLogger(__name__).exception("a2a enqueue/dispatch failed")
+
+    return {
+        "success": True,
+        "transaction_id": str(txn.id),
+        "items": [
+            {
+                "id": str(it.id),
+                "name": it.name,
+                "normalized_name": it.normalized_name,
+                "qty": float(it.qty) if it.qty is not None else None,
+                "unit_price_cents": it.unit_price_cents,
+                "total_cents": it.total_cents,
+                "brand": it.brand,
+                "category_id": str(it.category_id) if it.category_id else None,
+            }
+            for it in items_persisted
+        ],
+        "account_match": {
+            "strategy": match.strategy,
+            "matched_card_last4": match.matched_card_last4,
+        },
+        "fx": fx_info,
+        "trends": trends,
+        "confidence": receipt.confidence,
+        "shopping_auto_checked": shopping_auto_checked,
+        "warnings": warnings,
+        "dup_warning": None,
+        "scanned_preview": None,
+    }
+
+
+async def _find_or_create_payee(
+    db: AsyncSession, family_id: UUID, payee_name: Optional[str]
+) -> Optional[UUID]:
+    if not payee_name:
+        return None
+    stmt = select(BudgetPayee).where(
+        BudgetPayee.family_id == family_id,
+        BudgetPayee.name == payee_name,
+    )
+    payee = (await db.execute(stmt)).scalars().first()
+    if payee:
+        return payee.id
+    new_payee = BudgetPayee(family_id=family_id, name=payee_name)
+    db.add(new_payee)
+    await db.flush()
+    return new_payee.id
+
+
+async def _route_to_drafts(
+    db, family_id, account_id, image_bytes, receipt, scanned_dict,
+    reason: str = "low_confidence",
+):
+    draft = await ReceiptDraftService.create(
+        db=db, family_id=family_id, account_id=account_id,
+        scanned_data=scanned_dict, confidence=receipt.confidence,
+    )
+    try:
+        os.makedirs(RECEIPT_UPLOADS_DIR, exist_ok=True)
+        img_path = os.path.join(RECEIPT_UPLOADS_DIR, f"{draft.id}.jpg")
+        with open(img_path, "wb") as f:
+            f.write(image_bytes)
+        draft.image_url = f"/api/budget/receipt-drafts/{draft.id}/image"
+        await db.commit()
+    except Exception:
+        pass
+    return {
+        "success": False,
+        "draft_id": str(draft.id),
+        "confidence": receipt.confidence,
+        "scanned_data": scanned_dict,
+        "message": f"Routed to drafts queue: {reason}",
+        "transaction_id": None,
+    }
+
+
+def _build_webhook_payload(family_id, txn, items, currency) -> dict:
+    return {
+        "schema": "family-budget.receipt.v1",
+        "family_id": str(family_id),
+        "transaction_id": str(txn.id),
+        "occurred_at": txn.created_at.isoformat() if txn.created_at else None,
+        "payee": None,  # populated by caller before enqueue if needed
+        "currency": currency,
+        "total_cents": int(txn.amount),
+        "iva_cents": txn.iva_cents,
+        "items": [
+            {
+                "name": it.name,
+                "normalized_name": it.normalized_name,
+                "qty": float(it.qty) if it.qty is not None else None,
+                "unit_price_cents": it.unit_price_cents,
+                "total_cents": it.total_cents,
+                "category": None,
+                "brand": it.brand,
+            }
+            for it in items
+        ],
+        "location_hint": None,
+    }
+```
+
+- [ ] **Step 4: Extend `CategorizationRuleService.suggest_category` with optional `item_name`**
+
+In `backend/app/services/budget/categorization_rule_service.py`, add `item_name: Optional[str] = None` to the `suggest_category` signature. Use it as an additional match field against any rule whose `description_pattern` regex matches `item_name` (read existing rule matching logic to find the exact insertion point — keep payee match first, then description fallback, then item_name fallback).
+
+- [ ] **Step 5: Run pipeline tests**
+
+```
+podman exec -e PYTHONPATH=/app family_app_backend pytest tests/test_receipt_scanner_v2.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/services/budget/receipt_scanner_service.py \
+        backend/app/services/budget/categorization_rule_service.py \
+        backend/tests/test_receipt_scanner_v2.py
+git commit -m "feat(scanner-v2): 7-stage pipeline — account match, dup-guard, FX, items, webhook"
+```
+
+---
+
+### Task 10: Extend `scan-receipt` endpoint
+
+**Files:**
+- Modify: `backend/app/api/routes/budget/transactions.py:434-510` (endpoint signature, 409 path, return shape)
+- Test: extend `backend/tests/test_receipt_scanner_v2.py`
+
+- [ ] **Step 1: Write failing endpoint tests**
+
+```python
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_endpoint_returns_409_on_dup(client, auth_headers,
+                                            family_with_recent_heb_tx):
+    files = {"file": ("r.jpg", b"\xff\xd8\xff\xe0", "image/jpeg")}
+    # The fixture sets up a 1-min-old HEB tx for the same amount;
+    # the mocked scan_receipt returns same payee + amount.
+    resp = await client.post("/api/budget/transactions/scan-receipt",
+                             files=files, headers=auth_headers)
+    assert resp.status_code == 409
+    body = resp.json()
+    assert "dup_warning" in body
+
+
+@pytest.mark.asyncio
+async def test_endpoint_force_true_commits(client, auth_headers,
+                                            family_with_recent_heb_tx):
+    files = {"file": ("r.jpg", b"\xff\xd8\xff\xe0", "image/jpeg")}
+    resp = await client.post(
+        "/api/budget/transactions/scan-receipt?force=true",
+        files=files, headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_endpoint_account_id_overrides_auto_detect(
+    client, auth_headers, account_factory_authed,
+):
+    a = await account_factory_authed(currency="MXN")
+    files = {"file": ("r.jpg", b"\xff\xd8\xff\xe0", "image/jpeg")}
+    resp = await client.post(
+        f"/api/budget/transactions/scan-receipt?account_id={a.id}",
+        files=files, headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["account_match"]["strategy"] == "override"
+```
+
+(Add the fixtures `family_with_recent_heb_tx`, `account_factory_authed`, `client`, `auth_headers` to conftest.py; `client` uses `httpx.AsyncClient` + `ASGITransport` already wired up in the existing conftest.)
+
+- [ ] **Step 2: Run, FAIL on signature / status code**
+
+- [ ] **Step 3: Modify the endpoint in `backend/app/api/routes/budget/transactions.py`**
+
+Replace the existing `scan_receipt_endpoint` with:
+
+```python
+@router.post("/scan-receipt", status_code=status.HTTP_200_OK)
+async def scan_receipt_endpoint(
+    file: UploadFile = File(...),
+    account_id: Optional[UUID] = Form(None),
+    force: bool = Query(False),
+    current_user: User = Depends(require_parent_role),
+    db: AsyncSession = Depends(get_db),
+    response: Response = None,
+):
+    family_id = to_uuid_required(current_user.family_id)
+    await require_feature("ai_features", db, current_user)
+    await require_feature("receipt_scan", db, current_user)
+    await UsageService.increment(db, family_id, "receipt_scan")
+
+    if account_id is not None:
+        from app.services.budget.account_service import AccountService
+        await AccountService.get_by_id(db, account_id, family_id)
+
+    allowed_types = {
+        "image/jpeg", "image/png", "image/webp", "image/gif", "application/pdf",
+    }
+    content_type = file.content_type or "image/jpeg"
+    if content_type not in allowed_types:
+        return {
+            "success": False,
+            "message": f"Unsupported file type: {content_type}.",
+            "transaction_id": None,
+        }
+
+    file_bytes = await file.read()
+    if len(file_bytes) > 10 * 1024 * 1024:
+        return {
+            "success": False,
+            "message": "File too large. Maximum size is 10MB.",
+            "transaction_id": None,
+        }
+
+    result = await scan_and_create_transaction(
+        db=db, family_id=family_id, user_id=current_user.id,
+        account_id=account_id, image_bytes=file_bytes,
+        media_type=content_type, force=force,
+    )
+
+    if result.get("dup_warning") is not None:
+        response.status_code = status.HTTP_409_CONFLICT
+
+    return result
+```
+
+Add to imports at top of file:
+```python
+from fastapi import Response, Query
+from typing import Optional
+```
+
+- [ ] **Step 4: Run tests, expect PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/api/routes/budget/transactions.py \
+        backend/tests/test_receipt_scanner_v2.py \
+        backend/tests/conftest.py
+git commit -m "feat(scanner-v2): extend scan-receipt endpoint with force + 409 dup_warning"
+```
+
+---
+
+## Phase 4 — New endpoints
+
+### Task 11: Items endpoints
+
+**Files:**
+- Create: `backend/app/api/routes/budget/items.py`
+- Modify: `backend/app/api/routes/budget/__init__.py` (register router)
+- Test: extend `backend/tests/test_transaction_item_service.py` with HTTP tests OR new file
+
+- [ ] **Step 1: Write failing endpoint tests**
+
+```python
+@pytest.mark.asyncio
+async def test_list_items_filters_by_family(client, auth_headers, family,
+                                              seeded_items):
+    resp = await client.get("/api/budget/items?normalized_name=leche+alpura",
+                            headers=auth_headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) >= 1
+
+
+@pytest.mark.asyncio
+async def test_trend_returns_null_when_below_sample(client, auth_headers):
+    resp = await client.get(
+        "/api/budget/items/trend?normalized_name=nonexistent",
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json() is None
+```
+
+- [ ] **Step 2: Implement `backend/app/api/routes/budget/items.py`**
+
+```python
+"""Item history + price-trend endpoints."""
+
+from datetime import datetime
+from typing import Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_db
+from app.core.dependencies import get_current_user
+from app.core.type_utils import to_uuid_required
+from app.models import User
+from app.schemas.budget import TransactionItemRead, ItemTrend
+from app.services.budget.transaction_item_service import TransactionItemService
+
+
+router = APIRouter()
+
+
+@router.get("/", response_model=list[TransactionItemRead])
+async def list_items(
+    normalized_name: Optional[str] = Query(None),
+    since: Optional[datetime] = Query(None),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    family_id = to_uuid_required(current_user.family_id)
+    rows = await TransactionItemService.list_for_family(
+        db, family_id,
+        normalized_name=normalized_name, since=since,
+        limit=limit, offset=offset,
+    )
+    return rows
+
+
+@router.get("/trend", response_model=Optional[ItemTrend])
+async def get_trend(
+    normalized_name: str = Query(...),
+    window_days: int = Query(90, ge=7, le=365),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    family_id = to_uuid_required(current_user.family_id)
+    return await TransactionItemService.get_trend(
+        db, family_id, normalized_name=normalized_name,
+        window_days=window_days,
+    )
+```
+
+- [ ] **Step 3: Register the router in `backend/app/api/routes/budget/__init__.py`**
+
+```python
+from app.api.routes.budget import items as _items
+budget_router.include_router(_items.router, prefix="/items", tags=["budget-items"])
+```
+
+(Match existing include style in that file.)
+
+- [ ] **Step 4: Run, PASS, commit**
+
+```bash
+git add backend/app/api/routes/budget/items.py \
+        backend/app/api/routes/budget/__init__.py \
+        backend/tests/test_transaction_item_service.py
+git commit -m "feat(scanner-v2): /api/budget/items list + trend endpoints"
+```
+
+---
+
+### Task 12: A2A webhook config endpoints
+
+**Files:**
+- Create: `backend/app/api/routes/budget/a2a_webhook.py`
+- Modify: `backend/app/api/routes/budget/__init__.py`
+- Test: extend `backend/tests/test_a2a_webhook_service.py` with HTTP tests
+
+- [ ] **Step 1: Write failing endpoint tests** for GET / PUT (parent-only, rotate_secret returns plaintext once, https-only validation).
+
+```python
+@pytest.mark.asyncio
+async def test_put_webhook_returns_secret_on_rotate(client, parent_auth_headers):
+    resp = await client.put(
+        "/api/budget/a2a-webhook",
+        json={"url": "https://hook.example/x",
+              "enabled": True, "rotate_secret": True},
+        headers=parent_auth_headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["secret"] is not None
+
+
+@pytest.mark.asyncio
+async def test_put_rejects_http(client, parent_auth_headers):
+    resp = await client.put(
+        "/api/budget/a2a-webhook",
+        json={"url": "http://hook.example/x",
+              "enabled": True, "rotate_secret": True},
+        headers=parent_auth_headers,
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_get_webhook_hides_secret(client, parent_auth_headers,
+                                          enabled_webhook):
+    resp = await client.get("/api/budget/a2a-webhook",
+                            headers=parent_auth_headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "secret" not in body
+```
+
+- [ ] **Step 2: Implement `backend/app/api/routes/budget/a2a_webhook.py`**
+
+```python
+"""Per-family a2a webhook configuration."""
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_db
+from app.core.dependencies import require_parent_role
+from app.core.type_utils import to_uuid_required
+from app.models import User
+from app.schemas.a2a import A2AWebhookRead, A2AWebhookUpdate, A2AWebhookSaveResult
+from app.services.budget.a2a_webhook_service import A2AWebhookService
+
+
+router = APIRouter()
+
+
+@router.get("/", response_model=A2AWebhookRead)
+async def get_webhook(
+    current_user: User = Depends(require_parent_role),
+    db: AsyncSession = Depends(get_db),
+):
+    family_id = to_uuid_required(current_user.family_id)
+    cfg = await A2AWebhookService.get_config(db, family_id)
+    if cfg is None:
+        return A2AWebhookRead(enabled=False)
+    return cfg
+
+
+@router.put("/", response_model=A2AWebhookSaveResult)
+async def put_webhook(
+    payload: A2AWebhookUpdate,
+    current_user: User = Depends(require_parent_role),
+    db: AsyncSession = Depends(get_db),
+):
+    family_id = to_uuid_required(current_user.family_id)
+    cfg, plaintext = await A2AWebhookService.upsert_config(
+        db, family_id, url=payload.url, enabled=payload.enabled,
+        rotate_secret=payload.rotate_secret,
+    )
+    return A2AWebhookSaveResult(
+        config=A2AWebhookRead.model_validate(cfg),
+        secret=plaintext,
+    )
+```
+
+- [ ] **Step 3: Register** in `backend/app/api/routes/budget/__init__.py`:
+
+```python
+from app.api.routes.budget import a2a_webhook as _a2a
+budget_router.include_router(_a2a.router, prefix="/a2a-webhook", tags=["budget-a2a"])
+```
+
+- [ ] **Step 4: Run, PASS, commit**
+
+```bash
+git add backend/app/api/routes/budget/a2a_webhook.py \
+        backend/app/api/routes/budget/__init__.py \
+        backend/tests/test_a2a_webhook_service.py
+git commit -m "feat(scanner-v2): GET/PUT /api/budget/a2a-webhook (parent only)"
+```
+
+---
+
+### Task 13: Internal retry sweep endpoint
+
+**Files:**
+- Create: `backend/app/api/routes/internal/__init__.py`
+- Create: `backend/app/api/routes/internal/a2a_retry.py`
+- Modify: `backend/app/main.py` (register internal router under `/api/internal`)
+- Modify: `backend/app/core/config.py` (add `INTERNAL_API_TOKEN` setting)
+- Test: extend `backend/tests/test_a2a_webhook_service.py`
+
+- [ ] **Step 1: Write failing test for the sweep endpoint guarded by token**
+
+```python
+@pytest.mark.asyncio
+async def test_internal_retry_requires_token(client):
+    resp = await client.post("/api/internal/a2a/retry")
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_internal_retry_calls_sweep(client, monkeypatch):
+    monkeypatch.setattr("app.core.config.settings.INTERNAL_API_TOKEN", "tkn")
+    called = {}
+    async def fake_sweep(db, limit=50): called["n"] = limit; return 3
+    monkeypatch.setattr(
+        "app.services.budget.a2a_webhook_service.A2AWebhookService.sweep_retries",
+        fake_sweep,
+    )
+    resp = await client.post(
+        "/api/internal/a2a/retry",
+        headers={"X-Internal-Token": "tkn"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["processed"] == 3
+```
+
+- [ ] **Step 2: Add `INTERNAL_API_TOKEN` to `backend/app/core/config.py`** (one new line in the Settings class).
+
+```python
+    INTERNAL_API_TOKEN: str = ""
+```
+
+- [ ] **Step 3: Create `backend/app/api/routes/internal/__init__.py`** (empty), and `a2a_retry.py`:
+
+```python
+"""Internal retry sweep — invoked by external cron / scheduler."""
+
+from fastapi import APIRouter, Depends, Header, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.core.database import get_db
+from app.services.budget.a2a_webhook_service import A2AWebhookService
+
+
+router = APIRouter()
+
+
+def _require_token(x_internal_token: str = Header(None)):
+    if not settings.INTERNAL_API_TOKEN or x_internal_token != settings.INTERNAL_API_TOKEN:
+        raise HTTPException(status.HTTP_403_FORBIDDEN, "invalid internal token")
+
+
+@router.post("/a2a/retry")
+async def retry_sweep(
+    _t: None = Depends(_require_token),
+    db: AsyncSession = Depends(get_db),
+):
+    n = await A2AWebhookService.sweep_retries(db, limit=50)
+    return {"processed": n}
+```
+
+- [ ] **Step 4: Register router in `backend/app/main.py`**
+
+After existing budget router includes:
+
+```python
+from app.api.routes.internal import a2a_retry as _internal_a2a
+app.include_router(_internal_a2a.router, prefix="/api/internal", tags=["internal"])
+```
+
+- [ ] **Step 5: Run, PASS, commit**
+
+```bash
+git add backend/app/api/routes/internal/__init__.py \
+        backend/app/api/routes/internal/a2a_retry.py \
+        backend/app/main.py \
+        backend/app/core/config.py \
+        backend/tests/test_a2a_webhook_service.py
+git commit -m "feat(scanner-v2): /api/internal/a2a/retry sweep endpoint (token-guarded)"
+```
+
+---
+
+## Phase 5 — Premium gating
+
+### Task 14: Plan feature flags
+
+**Files:**
+- Modify: `backend/app/core/premium.py` (add `a2a_webhook`, `item_trends`, `fx_cross_charge` boolean features)
+- Modify: `backend/app/core/premium.py` `DEFAULT_FREE_LIMITS` (add new keys = False)
+- Test: extend `backend/tests/test_subscription.py` OR new `backend/tests/test_premium_v2.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+@pytest.mark.asyncio
+async def test_free_plan_blocks_a2a_webhook(db, free_user):
+    from app.core.premium import require_feature
+    with pytest.raises(Exception):
+        await require_feature("a2a_webhook", db, free_user)
+
+
+@pytest.mark.asyncio
+async def test_pro_plan_allows_fx_cross_charge(db, pro_user):
+    from app.core.premium import require_feature
+    await require_feature("fx_cross_charge", db, pro_user)  # no raise
+```
+
+- [ ] **Step 2: Edit `backend/app/core/premium.py`**
+
+Update `DEFAULT_FREE_LIMITS`:
+
+```python
+DEFAULT_FREE_LIMITS: dict[str, Any] = {
+    # ... existing ...
+    "a2a_webhook": False,
+    "item_trends": False,
+    "fx_cross_charge": False,
+}
+```
+
+Update `FEATURE_LIMIT_MAP`:
+
+```python
+FEATURE_LIMIT_MAP: dict[str, str] = {
+    # ... existing ...
+    "a2a_webhook": "a2a_webhook",
+    "item_trends": "item_trends",
+    "fx_cross_charge": "fx_cross_charge",
+}
+```
+
+Update `FEATURE_MIN_PLAN`:
+
+```python
+FEATURE_MIN_PLAN: dict[str, str] = {
+    # ... existing ...
+    "a2a_webhook": "plus",
+    "item_trends": "plus",
+    "fx_cross_charge": "pro",
+}
+```
+
+If the `subscription_plans` table is seeded with rows whose `limits` JSON drives `plus`/`pro`, update the seed (`backend/seed_data.py` or whichever file initializes the rows) so the new keys appear in the Plus + Pro limits dicts as `True`. Run the seed in the test container so the flags propagate.
+
+- [ ] **Step 3: Run tests, PASS, commit**
+
+```bash
+git add backend/app/core/premium.py backend/tests/test_premium_v2.py
+git commit -m "feat(scanner-v2): premium flags a2a_webhook, item_trends, fx_cross_charge"
+```
+
+---
+
+## Phase 6 — Frontend
+
+### Task 15: Redesign `/budget/scan-receipt` — confirm card
+
+**Files:**
+- Modify: `frontend/src/pages/budget/scan-receipt.astro` (drop pre-pick account dropdown; add scan animation overlay; render new confirm card)
+- Modify: `frontend/src/lib/api/budget.ts` (add `scanReceipt(file, opts)` with `force`, `account_id` and the new response shape)
+
+- [ ] **Step 1: Update client helper `frontend/src/lib/api/budget.ts`**
+
+Append:
+
+```ts
+export interface ScanReceiptResponse {
+  success: boolean;
+  transaction_id: string | null;
+  transaction?: any;
+  items: Array<{
+    id: string; name: string; normalized_name: string;
+    qty: number | null; unit_price_cents: number | null;
+    total_cents: number; brand: string | null;
+    category_id: string | null;
+  }>;
+  account_match?: { strategy: string; matched_card_last4: string | null };
+  fx?: { rate: string; original_amount_cents: number; original_currency: string } | null;
+  trends: Array<{
+    normalized_name: string; avg_unit_cents: number;
+    last_unit_cents: number; pct_change: number; sample_size: number;
+  }>;
+  confidence: number;
+  shopping_auto_checked: string[];
+  warnings: string[];
+  dup_warning: {
+    existing_transaction_id: string;
+    scanned_at: string;
+    amount_cents: number;
+    payee: string | null;
+  } | null;
+  scanned_preview?: Record<string, unknown> | null;
+  draft_id?: string | null;
+  message?: string | null;
+}
+
+export async function scanReceipt(
+  token: string,
+  file: File,
+  opts: { force?: boolean; account_id?: string } = {},
+): Promise<{ status: number; body: ScanReceiptResponse }> {
+  const form = new FormData();
+  form.append("file", file);
+  const q = new URLSearchParams();
+  if (opts.force) q.set("force", "true");
+  if (opts.account_id) q.set("account_id", opts.account_id);
+  const url = `/api/budget/transactions/scan-receipt${q.toString() ? "?" + q : ""}`;
+  const resp = await fetch(url, {
+    method: "POST", body: form,
+    headers: { "Authorization": `Bearer ${token}` },
+  });
+  const body = await resp.json();
+  return { status: resp.status, body };
+}
+```
+
+- [ ] **Step 2: Replace the body of `frontend/src/pages/budget/scan-receipt.astro`**
+
+Strip the account dropdown from server-rendered HTML. Render:
+
+```astro
+<Layout title={l.title} lang={lang}>
+  <DrawerMenu lang={lang} />
+  <BudgetNavNew lang={lang} active="scan" draftsCount={pendingDraftsCount} />
+
+  <main class="px-4 pb-32 pt-6 max-w-md mx-auto">
+    <h1 class="text-3xl font-display mb-2">{lang === "es" ? "Escanear ticket" : "Scan receipt"}</h1>
+    <p class="text-sm text-fg/60 mb-8">
+      {lang === "es"
+        ? "Toma una foto y deja que la IA llene todo."
+        : "Snap a photo and let AI fill in the rest."}
+    </p>
+
+    <div class="flex flex-col gap-3" id="scan-actions">
+      <label class="brand-btn brand-btn-primary text-center cursor-pointer">
+        {lang === "es" ? "📷 Tomar foto" : "📷 Snap receipt"}
+        <input id="cam-input" type="file" accept="image/*,application/pdf"
+               capture="environment" class="hidden" />
+      </label>
+      <label class="brand-btn brand-btn-secondary text-center cursor-pointer">
+        {lang === "es" ? "⬆ Subir imagen" : "⬆ Upload image"}
+        <input id="up-input" type="file"
+               accept="image/jpeg,image/png,image/webp,image/gif,application/pdf"
+               class="hidden" />
+      </label>
+    </div>
+
+    <div id="scan-overlay" class="hidden fixed inset-0 z-50 bg-bg/95 flex flex-col items-center justify-center p-6">
+      <div class="size-32 rounded-2xl bg-fg/5 mb-6 animate-pulse"></div>
+      <ul id="scan-stages" class="text-fg/80 text-sm space-y-1 text-center">
+        <li data-stage="0">{lang === "es" ? "Leyendo…" : "Reading…"}</li>
+        <li data-stage="1" class="opacity-30">{lang === "es" ? "Detectando cuenta…" : "Matching account…"}</li>
+        <li data-stage="2" class="opacity-30">{lang === "es" ? "Categorizando…" : "Categorizing…"}</li>
+        <li data-stage="3" class="opacity-30">{lang === "es" ? "Buscando duplicados…" : "Checking duplicates…"}</li>
+      </ul>
+    </div>
+
+    <section id="confirm-card" class="hidden mt-8"></section>
+
+    <dialog id="dup-modal" class="modal"></dialog>
+  </main>
+  <BottomNav lang={lang} active="budget" />
+</Layout>
+
+<script type="module" define:vars={{ lang, token, accounts }}>
+  import { scanReceipt } from "@lib/api/budget";
+
+  const stages = document.querySelectorAll("#scan-stages li");
+  function tick() {
+    let i = 0;
+    return setInterval(() => {
+      if (i > 0) stages[i - 1].classList.remove("opacity-30");
+      if (i < stages.length) stages[i].classList.remove("opacity-30");
+      i = Math.min(stages.length, i + 1);
+    }, 700);
+  }
+
+  async function runScan(file) {
+    document.getElementById("scan-overlay").classList.remove("hidden");
+    const ticker = tick();
+    try {
+      const { status, body } = await scanReceipt(token, file);
+      clearInterval(ticker);
+      document.getElementById("scan-overlay").classList.add("hidden");
+      if (status === 409 && body.dup_warning) {
+        showDupModal(file, body);
+        return;
+      }
+      if (body.draft_id) {
+        location.href = `/budget/receipt-drafts`;
+        return;
+      }
+      showConfirmCard(body);
+    } catch (e) {
+      clearInterval(ticker);
+      document.getElementById("scan-overlay").classList.add("hidden");
+      alert(lang === "es" ? "Error escaneando." : "Scan failed.");
+    }
+  }
+
+  function showConfirmCard(body) {
+    const root = document.getElementById("confirm-card");
+    const fxLine = body.fx
+      ? `<div class="text-sm text-fg/60">≈ ${money(body.fx.original_amount_cents, body.fx.original_currency)} @ ${body.fx.rate}</div>`
+      : "";
+    const iva = body.transaction && body.transaction.iva_cents
+      ? `<div class="inline-block px-2 py-1 rounded bg-fg/5 text-xs">IVA ${money(body.transaction.iva_cents, "MXN")}</div>`
+      : "";
+    const trendsMap = new Map(body.trends.map(t => [t.normalized_name, t]));
+    const itemsHtml = body.items.map(it => {
+      const t = trendsMap.get(it.normalized_name);
+      let badge = "";
+      if (t && Math.abs(t.pct_change) >= 0.05) {
+        const up = t.pct_change > 0;
+        badge = `<span class="ml-2 text-xs ${up ? "text-red-500" : "text-green-600"}">${up ? "📈" : "📉"} ${(t.pct_change*100).toFixed(0)}%</span>`;
+      }
+      return `<li class="flex justify-between py-1 text-sm">
+        <span>${esc(it.name)}${badge}</span>
+        <span>${money(it.total_cents, body.transaction.currency || "MXN")}</span>
+      </li>`;
+    }).join("");
+
+    const matchBadge = body.account_match.strategy === "card_last4"
+      ? "✓" : body.account_match.strategy === "override" ? "●" : "◐";
+
+    root.innerHTML = `
+      <div class="card p-5 space-y-4">
+        <div>
+          <h2 class="text-xl font-display">${esc(body.transaction.payee_name || "")}</h2>
+          <div class="text-3xl">${money(body.transaction.amount, body.transaction.currency || "MXN")}</div>
+          ${fxLine}
+        </div>
+        <div class="text-sm">
+          <span class="text-fg/60">${lang === "es" ? "Cuenta" : "Account"}</span><br/>
+          ${matchBadge} ${esc(body.transaction.account_name || "")}
+        </div>
+        ${iva}
+        <ul class="border-t border-fg/10 pt-3">${itemsHtml}</ul>
+        <div class="flex flex-col gap-2 pt-3">
+          <a href="/budget/transactions" class="brand-btn brand-btn-primary text-center">
+            ${lang === "es" ? "✓ Listo, guardar" : "✓ Looks good — save"}
+          </a>
+          <button id="del-tx" class="brand-btn brand-btn-secondary">
+            ${lang === "es" ? "Borrar y re-escanear" : "Delete & re-scan"}
+          </button>
+        </div>
+      </div>`;
+    root.classList.remove("hidden");
+    document.getElementById("del-tx").onclick = async () => {
+      await fetch(`/api/budget/transactions/${body.transaction_id}`, {
+        method: "DELETE", headers: { "Authorization": `Bearer ${token}` },
+      });
+      location.reload();
+    };
+  }
+
+  function showDupModal(file, body) {
+    const d = document.getElementById("dup-modal");
+    d.innerHTML = `
+      <form method="dialog" class="card p-5 space-y-3 max-w-sm mx-auto">
+        <h3 class="text-lg font-display">${lang === "es" ? "⚠ Ya escaneado" : "⚠ Already scanned"}</h3>
+        <p class="text-sm">
+          ${esc(body.dup_warning.payee || "")},
+          ${money(body.dup_warning.amount_cents, body.transaction?.currency || "MXN")},
+          ${timeAgo(body.dup_warning.scanned_at, lang)}.
+        </p>
+        <div class="flex gap-2 justify-end">
+          <a href="/budget/transactions/${body.dup_warning.existing_transaction_id}"
+             class="brand-btn brand-btn-secondary">${lang === "es" ? "Ver original" : "Open original"}</a>
+          <button id="force-save" class="brand-btn brand-btn-primary">
+            ${lang === "es" ? "Guardar de todas formas" : "Save anyway"}
+          </button>
+        </div>
+      </form>`;
+    d.showModal();
+    document.getElementById("force-save").addEventListener("click", async (e) => {
+      e.preventDefault();
+      d.close();
+      document.getElementById("scan-overlay").classList.remove("hidden");
+      const { body: r2 } = await scanReceipt(token, file, { force: true });
+      document.getElementById("scan-overlay").classList.add("hidden");
+      showConfirmCard(r2);
+    });
+  }
+
+  function money(c, ccy) {
+    const sign = c < 0 ? "-" : "";
+    const abs = Math.abs(c) / 100;
+    return `${sign}${ccy === "USD" ? "$" : "$"}${abs.toFixed(2)} ${ccy}`;
+  }
+  function esc(s) { return (s || "").replace(/[<>&"']/g, c => ({"<":"&lt;",">":"&gt;","&":"&amp;","\"":"&quot;","'":"&#39;"}[c])); }
+  function timeAgo(iso, l) {
+    const sec = Math.round((Date.now() - new Date(iso).getTime()) / 1000);
+    if (sec < 60) return l === "es" ? `hace ${sec}s` : `${sec}s ago`;
+    return l === "es" ? `hace ${Math.round(sec/60)}m` : `${Math.round(sec/60)}m ago`;
+  }
+
+  document.getElementById("cam-input").addEventListener("change", e => {
+    const f = e.target.files[0]; if (f) runScan(f);
+  });
+  document.getElementById("up-input").addEventListener("change", e => {
+    const f = e.target.files[0]; if (f) runScan(f);
+  });
+</script>
+```
+
+- [ ] **Step 2: Manual smoke test**
+
+```
+podman compose up -d
+# Open http://localhost:3003/budget/scan-receipt
+# Use any test JPG of a receipt.
+```
+
+Verify: snap → overlay → confirm card. No pre-pick dropdown.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/pages/budget/scan-receipt.astro \
+        frontend/src/lib/api/budget.ts
+git commit -m "feat(scanner-v2): one-tap snap UX + confirm card + dup modal"
+```
+
+---
+
+### Task 16: Items detail page
+
+**Files:**
+- Create: `frontend/src/pages/budget/items/[normalized_name].astro`
+
+- [ ] **Step 1: Implement page**
+
+```astro
+---
+import Layout from "@layouts/Layout.astro";
+import BudgetNavNew from "@components/BudgetNavNew.astro";
+import BottomNav from "@components/BottomNav.astro";
+import DrawerMenu from "@components/DrawerMenu.astro";
+import { apiFetch } from "@lib/api";
+
+const token = Astro.cookies.get("access_token")?.value;
+if (!token) return Astro.redirect("/login");
+const lang = Astro.cookies.get("lang")?.value ?? "en";
+const { normalized_name } = Astro.params;
+
+const { data: items } = await apiFetch<any[]>(
+  `/api/budget/items?normalized_name=${encodeURIComponent(normalized_name || "")}&limit=100`,
+  { token },
+);
+const { data: trend } = await apiFetch<any>(
+  `/api/budget/items/trend?normalized_name=${encodeURIComponent(normalized_name || "")}`,
+  { token },
+);
+---
+
+<Layout title={normalized_name} lang={lang}>
+  <DrawerMenu lang={lang} />
+  <BudgetNavNew lang={lang} active="transactions" draftsCount={0} />
+  <main class="px-4 pb-32 pt-6 max-w-md mx-auto">
+    <h1 class="text-2xl font-display capitalize">{normalized_name}</h1>
+    {trend && (
+      <div class="card p-3 my-3 text-sm">
+        <div>{lang === "es" ? "Promedio 90 días" : "90-day average"}:
+          ${(trend.avg_unit_cents / 100).toFixed(2)}</div>
+        <div>{lang === "es" ? "Último" : "Last"}:
+          ${(trend.last_unit_cents / 100).toFixed(2)}
+          ({(trend.pct_change * 100).toFixed(1)}%)</div>
+      </div>
+    )}
+    <ul class="divide-y divide-fg/10">
+      {(items || []).map(it => (
+        <li class="py-2 flex justify-between">
+          <a href={`/budget/transactions/${it.transaction_id}`} class="flex-1">
+            <div class="text-sm">{it.name}</div>
+            <div class="text-xs text-fg/60">{it.qty ?? 1} × ${(it.unit_price_cents ?? it.total_cents) / 100}</div>
+          </a>
+          <span class="text-sm">${(it.total_cents / 100).toFixed(2)}</span>
+        </li>
+      ))}
+    </ul>
+  </main>
+  <BottomNav lang={lang} active="budget" />
+</Layout>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add frontend/src/pages/budget/items/
+git commit -m "feat(scanner-v2): item history page /budget/items/[normalized_name]"
+```
+
+---
+
+### Task 17: Parent settings — a2a webhook page
+
+**Files:**
+- Create: `frontend/src/pages/parent/settings/a2a.astro`
+
+- [ ] **Step 1: Implement page** (auth gate, parent-only, GET current config, PUT to save; show plaintext secret only when rotate_secret returns it).
+
+```astro
+---
+import Layout from "@layouts/Layout.astro";
+import BottomNav from "@components/BottomNav.astro";
+import DrawerMenu from "@components/DrawerMenu.astro";
+import { apiFetch } from "@lib/api";
+
+const token = Astro.cookies.get("access_token")?.value;
+if (!token) return Astro.redirect("/login");
+const lang = Astro.cookies.get("lang")?.value ?? "en";
+const { data: user } = await apiFetch<any>("/api/auth/me", { token });
+if (user?.role !== "parent") return Astro.redirect("/dashboard");
+const { data: cfg } = await apiFetch<any>("/api/budget/a2a-webhook", { token });
+---
+
+<Layout title={lang === "es" ? "Agente de precios" : "Price Agent"} lang={lang}>
+  <DrawerMenu lang={lang} />
+  <main class="px-4 pb-32 pt-6 max-w-md mx-auto">
+    <h1 class="text-2xl font-display mb-4">{lang === "es" ? "Agente de precios" : "Price Agent"}</h1>
+
+    <form id="form" class="card p-4 space-y-3">
+      <label class="block">
+        <span class="text-sm">URL</span>
+        <input id="url" type="url" required pattern="https://.*"
+               value={cfg?.url ?? ""} class="brand-input w-full" />
+      </label>
+      <label class="flex items-center gap-2">
+        <input id="enabled" type="checkbox" checked={cfg?.enabled} />
+        <span>{lang === "es" ? "Activo" : "Enabled"}</span>
+      </label>
+      <label class="flex items-center gap-2">
+        <input id="rotate" type="checkbox" />
+        <span>{lang === "es" ? "Rotar secreto" : "Rotate secret"}</span>
+      </label>
+      <div class="text-xs text-fg/60">
+        {lang === "es" ? "Último éxito" : "Last success"}: {cfg?.last_success_at ?? "—"}<br/>
+        {lang === "es" ? "Fallas" : "Failures"}: {cfg?.failure_count ?? 0}
+      </div>
+      <button class="brand-btn brand-btn-primary w-full">
+        {lang === "es" ? "Guardar" : "Save"}
+      </button>
+      <pre id="secret-out" class="hidden text-xs bg-fg/5 p-2 rounded"></pre>
+    </form>
+  </main>
+  <BottomNav lang={lang} active="manage" />
+</Layout>
+
+<script type="module" define:vars={{ token, lang }}>
+  document.getElementById("form").addEventListener("submit", async (e) => {
+    e.preventDefault();
+    const resp = await fetch("/api/budget/a2a-webhook", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json",
+                 "Authorization": `Bearer ${token}` },
+      body: JSON.stringify({
+        url: document.getElementById("url").value,
+        enabled: document.getElementById("enabled").checked,
+        rotate_secret: document.getElementById("rotate").checked,
+      }),
+    });
+    const body = await resp.json();
+    if (body.secret) {
+      const out = document.getElementById("secret-out");
+      out.classList.remove("hidden");
+      out.textContent = (lang === "es" ? "Secreto nuevo (cópialo): " : "New secret (copy now): ") + body.secret;
+    } else {
+      alert(lang === "es" ? "Guardado." : "Saved.");
+    }
+  });
+</script>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add frontend/src/pages/parent/settings/a2a.astro
+git commit -m "feat(scanner-v2): parent settings page for a2a webhook"
+```
+
+---
+
+### Task 18: Wire scan page item rows to detail page
+
+**Files:**
+- Modify: `frontend/src/pages/budget/scan-receipt.astro` (anchor each item row to `/budget/items/[normalized_name]`)
+
+- [ ] **Step 1:** In the items list builder in the script block, wrap the name span in an anchor:
+
+```js
+const link = `/budget/items/${encodeURIComponent(it.normalized_name)}`;
+// inside the template:
+`<a href="${link}" class="underline-offset-4 hover:underline">${esc(it.name)}</a>${badge}`
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add frontend/src/pages/budget/scan-receipt.astro
+git commit -m "feat(scanner-v2): link scan items to item history page"
+```
+
+---
+
+## Phase 7 — E2E + deploy
+
+### Task 19: Playwright E2E tests
+
+**Files:**
+- Create: `e2e-tests/tests/scanner-v2.spec.ts`
+
+- [ ] **Step 1: Implement five tests**
+
+```ts
+import { test, expect } from "@playwright/test";
+import { loginAsParent } from "./helpers/auth";
+
+test.describe("Scanner v2", () => {
+  test("one-tap snap → confirm card", async ({ page }) => {
+    await loginAsParent(page);
+    await page.goto("/budget/scan-receipt");
+    await expect(page.locator("text=Snap receipt")).toBeVisible();
+    // The native camera input cannot be driven; assert UI scaffolding.
+    await expect(page.locator("#confirm-card.hidden")).toHaveCount(1);
+  });
+
+  test("duplicate modal flow", async ({ page }) => {
+    // requires a backend stub or pre-seeded recent tx; left as a fixture spec
+    test.skip(true, "needs backend stub for dup-flow; covered by API test 26");
+  });
+
+  test("FX display when accounts differ", async ({ page }) => {
+    test.skip(true, "needs backend stub; covered by API test 14");
+  });
+
+  test("IVA pill renders when present", async ({ page }) => {
+    test.skip(true, "needs backend stub; covered by API test 16");
+  });
+
+  test("trend badges only when sample_size >= 3", async ({ page }) => {
+    test.skip(true, "needs seeded item history");
+  });
+});
+```
+
+(The realistic-looking page test asserts UI scaffolding; the rest are skipped with a pointer to the API tests that cover the logic. A later wave can replace skips with real mocks once the API mock layer is wired into the e2e suite.)
+
+- [ ] **Step 2: Run**
+
+```
+cd e2e-tests && npm run test:scanner || npx playwright test scanner-v2
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e-tests/tests/scanner-v2.spec.ts
+git commit -m "test(scanner-v2): playwright scaffolding for one-tap flow"
+```
+
+---
+
+### Task 20: Deploy to GCP
+
+- [ ] **Step 1: Verify all tests green locally**
+
+```
+podman exec -e PYTHONPATH=/app family_app_backend pytest tests/ -v -x
+```
+
+- [ ] **Step 2: Set INTERNAL_API_TOKEN on the VM**
+
+```
+gcloud --account=info@agent-ia.mx --project=agentia-prod-497016 \
+  compute ssh agentia-family-hub --zone=us-central1-a \
+  --command='grep -q INTERNAL_API_TOKEN /home/jc/family-task-manager/.env || \
+             echo "INTERNAL_API_TOKEN=$(openssl rand -hex 32)" \
+             | sudo tee -a /home/jc/family-task-manager/.env'
+```
+
+- [ ] **Step 3: Deploy**
+
+```
+./scripts/deploy-gcp.sh -y
+```
+
+- [ ] **Step 4: Verify migration ran**
+
+```
+gcloud --account=info@agent-ia.mx --project=agentia-prod-497016 \
+  compute ssh agentia-family-hub --zone=us-central1-a \
+  --command='cd /home/jc/family-task-manager && \
+             sudo docker compose --env-file .env -f docker-compose.gcp.yml \
+             exec -T backend alembic current'
+```
+
+Expected: `wave4_scanner_v2 (head)`.
+
+- [ ] **Step 5: Smoke test the live app**
+
+- Open `https://gcp-family.agent-ia.mx/budget/scan-receipt`
+- Tap Snap; upload a test receipt (a real one if available — e.g., the user's HEB receipt with `**9222`).
+- Verify confirm card shows account checkmark, items, IVA pill (if present).
+
+- [ ] **Step 6: Schedule the retry sweep**
+
+Add a one-line cron on the VM that POSTs to the internal sweep endpoint every 5 min:
+
+```
+gcloud --account=info@agent-ia.mx --project=agentia-prod-497016 \
+  compute ssh agentia-family-hub --zone=us-central1-a \
+  --command='(crontab -l 2>/dev/null; echo "*/5 * * * * curl -fsS -X POST -H \"X-Internal-Token: $(grep ^INTERNAL_API_TOKEN= /home/jc/family-task-manager/.env | cut -d= -f2)\" http://localhost:8000/api/internal/a2a/retry > /dev/null") | crontab -'
+```
+
+- [ ] **Step 7: Final commit (if any deploy-only files were touched)**
+
+```bash
+git status
+# commit anything intentional, leave .deploy.gcp.env / .claude untouched
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §1 Goal — covered across the plan.
+- §3 Architecture — Tasks 8, 9, 10 implement the 7-stage pipeline; Task 7 implements the post-commit fan-out.
+- §4 Data model — Task 1 (migration + ORM), Task 2 (schemas).
+- §5 API surface — Task 10 (extended scan-receipt), Task 11 (items), Task 12 (webhook config), Task 13 (internal retry).
+- §6 Frontend UX — Tasks 15–18.
+- §7 Webhook contract — Task 7 (signing + headers), Task 9 (payload build).
+- §8 Vision prompt change — Task 8.
+- §9 Services list — covered task-by-task in Phase 2 + 3.
+- §10 Premium gating — Task 14.
+- §11 Error handling — covered in pipeline (Task 9) and unit tests (Tasks 5–7).
+- §12 Testing — ~25 backend tests across Tasks 1–13, 5 Playwright tests in Task 19 (some skipped with traceability notes).
+- §15 Rollout — Task 20.
+
+**Placeholder scan:** No "TBD" / "implement later" / "handle edge cases" found. The Playwright file has 4 skipped tests pointing at the API tests that cover their logic — this is an explicit limitation, not a placeholder.
+
+**Type consistency:** `ScanReceiptResponse` is the single response shape used end-to-end. `AccountMatch.strategy` values (`card_last4`, `last_used`, `override`, `none`) used consistently in service + endpoint + frontend. `DupWarning` shape (`existing_transaction_id`, `scanned_at`, `payee`, `amount_cents`) matches between Task 6 service, Task 9 endpoint response, and Task 15 frontend modal.
+
+**One known caveat surfaced in Task 5** — `BudgetTransaction.created_by_id` may not exist in the current model. The plan includes a verification step + fallback ("most-recent tx in family") so the task is not blocked.
+
+---
+
+## Execution Handoff
+
+Plan saved to `docs/superpowers/plans/2026-05-28-receipt-scanner-v2.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** — dispatch a fresh subagent per task, review between tasks.
+2. **Inline Execution** — execute tasks in this session via `superpowers:executing-plans`, batched with checkpoints.
+
+Which approach?

--- a/docs/superpowers/specs/2026-05-28-receipt-scanner-v2-design.md
+++ b/docs/superpowers/specs/2026-05-28-receipt-scanner-v2-design.md
@@ -1,0 +1,525 @@
+# Receipt Scanner v2 — Zero-Friction One-Tap + Structured Items
+
+**Date:** 2026-05-28
+**Status:** Design — pending user approval
+**Author:** Brainstormed via Claude Code (Opus 4.7)
+**Supersedes:** `docs/2026-04-01-ux-enhancements-design.md` §receipt-scanner only. Original scanner spec `docs/2026-04-02-receipt-scanner-design.md` remains the v1 reference.
+
+---
+
+## 1. Goal
+
+Turn the receipt scanner from a "snap then fill in the rest" form into a one-tap experience where the user snaps and confirms. Everything else — account, payee, per-item categorization, duplicate detection, FX cross-charge, tax breakout, price-history trend — is inferred from the image. Side-effects (shopping list reconciliation, external price-comparison agent) fan out automatically.
+
+Non-goal: replace the human-in-the-loop (HITL) draft review queue. Low-confidence scans still route there unchanged.
+
+## 2. User-visible outcome
+
+1. Tap `Snap Receipt` → camera opens. No account dropdown to pre-pick.
+2. Take photo. Full-screen scan animation, ~3–5 s.
+3. Confirm card slides up with merchant logo, total (with FX line if cross-currency), auto-picked account (`Mastercard **9222 ✓` or `(last used)` amber dot if fallback), itemized list with inline price-trend badges (`📈 +14%` / `📉 -8%`), and an IVA pill when applicable.
+4. Default action: `Looks good — save`. Single tap. Done.
+5. If the system thinks it's a duplicate of a scan made in the last 60 s: modal with `Open original` / `Save anyway`.
+
+A side-channel webhook fires asynchronously to an external price-comparison agent (configured per family).
+
+## 3. Architecture
+
+Single-call extension of the current `POST /api/budget/transactions/scan-receipt` endpoint. No two-stage commit, no optimistic write. All stages execute server-side inside the request, except the webhook fan-out which is dispatched to a background task after commit.
+
+```
+[client]
+   │  multipart upload (image|pdf) + optional account_id override + force=bool
+   ▼
+POST /api/budget/transactions/scan-receipt
+   │
+   ├─► (1) Vision extract  (LiteLLM → claude-haiku)
+   │         richer prompt: + card_last4, + iva_cents, + per-item qty/unit_price,
+   │         + brand, + currency (already), + fx_hint
+   │
+   ├─► (2) Account auto-detect
+   │         match BudgetAccount.card_last4 within family
+   │         on >1 hit → narrow by currency (receipt.currency == account.currency)
+   │         on 0 hits → fallback: account from the most-recent transaction created
+   │                     by the currently-authenticated user within this family
+   │         on 0 hits AND non-Pro caller AND receipt.currency ≠ fallback.currency:
+   │           route to HITL drafts queue with reason "currency_mismatch"
+   │         caller's account_id override (when valid for the family) always wins
+   │
+   ├─► (3) Duplicate guard
+   │         payee_name from vision is first resolved to a payee_id via the
+   │         existing find-or-create step. Then:
+   │         same family + same resolved payee_id + |total| within 1% + within 60s
+   │         → return 409 { dup_warning: {existing_transaction_id, scanned_at} }
+   │           with the scanned blob (no commit; payee is rolled back) so the
+   │           client can show the modal
+   │         → caller re-POSTs with ?force=true to commit anyway
+   │
+   ├─► (4) FX cross-charge
+   │         when receipt.currency != account.currency:
+   │           fx_rate = FXService.get(receipt.currency → account.currency, on=receipt.date)
+   │           account_total = round(receipt.total * fx_rate)
+   │         on FX failure: keep receipt currency, set fx_rate=null, attach soft warning
+   │
+   ├─► (5) Persist
+   │         BudgetTransaction (existing + new cols: card_last4, iva_cents,
+   │                            fx_rate, original_amount_cents, original_currency)
+   │         BudgetTransactionItem[] (new table, see §4)
+   │
+   ├─► (6) Auto-categorize
+   │         CategorizationRuleService.suggest_category on (payee, item.name)
+   │         applied per item AND for the transaction header (header = most common item category)
+   │
+   └─► (7) Post-commit fan-out (BackgroundTasks):
+           ├─ shopping auto-check (existing _auto_check_shopping_items)
+           └─ a2a webhook enqueue (new) — write row to a2a_webhook_deliveries,
+              dispatch HTTP POST inline once, schedule retries if it fails
+```
+
+Low-confidence path (`confidence < 0.3` OR no detectable total) keeps the existing HITL `BudgetReceiptDraft` route — none of the above stages run for those.
+
+## 4. Data model
+
+### 4.1 New table — `budget_transaction_items`
+
+| column | type | nullable | notes |
+|---|---|---|---|
+| `id` | `uuid` | no | pk, default `uuid4()` |
+| `family_id` | `uuid` | no | fk `families.id` ON DELETE CASCADE — tenant guard, indexed |
+| `transaction_id` | `uuid` | no | fk `budget_transactions.id` ON DELETE CASCADE |
+| `name` | `text` | no | as printed on receipt |
+| `normalized_name` | `text` | no | lowercased, accents stripped, unit suffixes (`kg`, `lt`, `pza`, `g`) trimmed; used for cross-transaction trend lookups |
+| `qty` | `numeric(10,3)` | yes | |
+| `unit_price_cents` | `bigint` | yes | absolute value (positive). `null` when receipt only printed line totals |
+| `total_cents` | `bigint` | no | absolute value (positive). `transaction.amount` remains the single source of truth for net effect; item totals are display + analytics |
+| `category_id` | `uuid` | yes | fk `budget_categories.id` ON DELETE SET NULL — per-item category (independent of header) |
+| `brand` | `text` | yes | when vision can guess |
+| `raw_text` | `text` | yes | original line as printed (preserved for audit / future re-parse) |
+| `created_at` | `timestamptz` | no | `default now()` |
+| `updated_at` | `timestamptz` | no | `default now()`, `onupdate now()` |
+
+Indexes:
+- `(family_id, normalized_name, created_at desc)` — trend lookup
+- `(transaction_id)` — join
+- `(family_id, category_id)` — per-category rollups
+
+### 4.2 New columns on `budget_transactions`
+
+| column | type | nullable | notes |
+|---|---|---|---|
+| `card_last4` | `char(4)` | yes | what vision saw, kept for audit even when auto-detect missed |
+| `iva_cents` | `bigint` | yes | Mexican tax line, absolute value |
+| `fx_rate` | `numeric(12,6)` | yes | rate from `original_currency` → `transaction.account.currency`, on the date of the receipt |
+| `original_amount_cents` | `bigint` | yes | total before FX, in `original_currency`. negative for expenses, like `transaction.amount` |
+| `original_currency` | `char(3)` | yes | ISO 4217 |
+
+### 4.3 New column on `budget_accounts`
+
+| column | type | nullable | notes |
+|---|---|---|---|
+| `card_last4` | `char(4)` | yes | partial index: `WHERE card_last4 IS NOT NULL` |
+
+Composite index `(family_id, card_last4)` (partial, `card_last4 IS NOT NULL`).
+
+Backfill in migration: regex `(?:\*{2,}|terminada en )(\d{4})` against `BudgetAccount.name`. Hits go into `card_last4`. The 17 real-prod accounts (e.g. `Cheques Banamex ***313`, `Mastercard **9222 (USD)`) cover the format we see in the wild.
+
+### 4.4 New table — `family_a2a_webhooks`
+
+One row per family. Per-family opt-in.
+
+| column | type | notes |
+|---|---|---|
+| `family_id` | `uuid` | pk, fk `families.id` ON DELETE CASCADE |
+| `url` | `text` | https only, validated on PUT |
+| `secret` | `text` | random 32-byte hex; used for HMAC-SHA256 signature header |
+| `enabled` | `bool` | default `false` |
+| `last_success_at` | `timestamptz` | nullable |
+| `last_error` | `text` | nullable, truncated to 500 chars |
+| `failure_count` | `int` | rolling, reset on success |
+| `created_at`, `updated_at` | `timestamptz` | |
+
+### 4.5 New table — `a2a_webhook_deliveries` (retry log)
+
+| column | type | notes |
+|---|---|---|
+| `id` | `uuid` | pk |
+| `family_id` | `uuid` | fk + tenant guard, indexed |
+| `transaction_id` | `uuid` | fk `budget_transactions.id` ON DELETE CASCADE |
+| `payload_json` | `jsonb` | webhook body |
+| `status` | `text` | `pending` / `sent` / `failed` / `dead` |
+| `attempts` | `int` | default 0, max 5 → `dead` |
+| `next_retry_at` | `timestamptz` | indexed `WHERE status IN ('pending','failed')` |
+| `last_error` | `text` | nullable |
+| `created_at`, `updated_at` | `timestamptz` | |
+
+Backoff schedule: `+1m, +5m, +30m, +2h, +12h`. After the 5th attempt, status → `dead`.
+
+### 4.6 Alembic migration
+
+`backend/alembic/versions/wave4_scanner_v2.py`. Adds all five table/column changes above and backfills `budget_accounts.card_last4` in the upgrade body.
+
+## 5. API surface
+
+### 5.1 Extended — `POST /api/budget/transactions/scan-receipt`
+
+Request: multipart `image` (existing) + new query/form params:
+
+| param | type | default | notes |
+|---|---|---|---|
+| `account_id` | `uuid?` | inferred | override auto-detect |
+| `force` | `bool` | `false` | skip duplicate guard |
+
+Response (`200 OK`, success commit):
+
+```json
+{
+  "success": true,
+  "transaction_id": "uuid",
+  "transaction": { ...existing TransactionRead... },
+  "items": [ ...TransactionItemRead[]... ],
+  "account_match": { "strategy": "card_last4" | "last_used" | "override",
+                     "matched_card_last4": "9222" | null },
+  "fx": { "rate": 17.15, "original_amount_cents": -4200,
+          "original_currency": "USD" } | null,
+  "trends": [ { "normalized_name": "leche alpura", "avg_unit_cents": 2800,
+                 "last_unit_cents": 3200, "pct_change": 0.142,
+                 "sample_size": 8 } ],
+  // trends array contains one entry per item where sample_size >= 3;
+  // items below threshold are omitted, not included with nulls
+  "confidence": 0.91,
+  "shopping_auto_checked": ["Leche", "Pan integral"]
+}
+```
+
+Response (`409 Conflict`, duplicate detected, no commit):
+
+```json
+{
+  "success": false,
+  "dup_warning": {
+    "existing_transaction_id": "uuid",
+    "scanned_at": "2026-05-28T20:14:08Z",
+    "payee": "HEB",
+    "amount_cents": -72040
+  },
+  "scanned_preview": { ...what would have been written... }
+}
+```
+
+Response (`200 OK`, low confidence → HITL draft): unchanged from today.
+
+### 5.2 New — items endpoints
+
+- `GET /api/budget/items?normalized_name=...&since=YYYY-MM-DD&limit=50` — paged history
+- `GET /api/budget/items/trend?normalized_name=...&window_days=90` — `{ avg_unit_cents, last_unit_cents, pct_change, sample_size }`. `sample_size < 3` → `null` returned (no badge).
+- `GET /api/budget/items/{id}` — single item
+- Items are not directly editable (they reflect what was scanned). Re-scanning a transaction is the path to fix them; a follow-up release can add inline edit.
+
+### 5.3 New — webhook config
+
+- `GET /api/budget/a2a-webhook` — parent only. Returns `{ url, enabled, last_success_at, failure_count }` (secret is write-only).
+- `PUT /api/budget/a2a-webhook` — parent only. Body `{ url, enabled, rotate_secret: bool }`. On `rotate_secret=true`, generate a new secret and return it once in the response (the only time it's exposed in plaintext).
+
+### 5.4 New — internal retry sweep
+
+- `POST /api/internal/a2a/retry` — protected by an internal token. Sweeps `a2a_webhook_deliveries WHERE status IN ('pending','failed') AND next_retry_at <= now()`. Called by an external cron OR a FastAPI background scheduler (`apscheduler` is already in deps — check `backend/requirements.txt`; add if missing).
+
+### 5.5 Schema additions
+
+`BudgetAccount` Pydantic schemas (`Create`, `Update`, `Read`) gain `card_last4: Optional[str]` with pattern `^\d{4}$`.
+
+New schemas:
+- `TransactionItemRead`
+- `ItemTrend`
+- `A2AWebhookRead`, `A2AWebhookUpdate`
+- `DupWarning`
+
+## 6. Frontend UX
+
+### 6.1 `/budget/scan-receipt` redesign
+
+Initial state: no account picker. Two CTAs only.
+
+```
+┌──────────────────────────────┐
+│   Scan Receipt               │
+│                              │
+│   [   📷  Snap Receipt   ]   │ ← primary, orange, full-width
+│   [   ⬆️  Upload Image   ]   │ ← secondary
+└──────────────────────────────┘
+```
+
+Snap → `<input type=file accept="image/*,application/pdf" capture=environment>` opens native camera immediately.
+
+While the request is in flight, full-screen overlay:
+
+```
+   [thumbnail with shimmer]
+
+   Reading…
+   Matching account…
+   Categorizing items…
+   Checking duplicates…
+```
+
+Stages tick forward at fixed intervals (~700 ms each) regardless of actual server timing — UX-only animation.
+
+### 6.2 Confirm card (post-success)
+
+```
+┌────────────────────────────────────────┐
+│  [HEB logo]   HEB                      │
+│                                        │
+│  $720.40 MXN                           │
+│  ≈ $42.00 USD  @ 17.15 (May 28)        │  ← only if FX
+│                                        │
+│  Account                               │
+│   ✓ Mastercard **9222                  │
+│                                        │
+│  IVA  $96.83                           │  ← pill, only if iva_cents
+│                                        │
+│  ─ Items ───────────────────────       │
+│   Leche Alpura 1L   2 × $32.00  $64.00 │
+│     📈 +14% vs 90d avg                 │
+│   Pan integral      1 × $48.50  $48.50 │
+│   Aguacate Hass     3 × $24.00  $72.00 │
+│     📉 -8% vs 90d avg                  │
+│   …                                    │
+│                                        │
+│  [  ✓ Looks good — save  ]             │ ← primary (no-op, already saved)
+│  [ Edit ]   [ Delete & re-scan ]       │
+└────────────────────────────────────────┘
+```
+
+Important: the transaction is already committed at this point. `Looks good — save` is a no-op that returns to `/budget/transactions`. `Delete & re-scan` issues `DELETE /api/budget/transactions/{id}` and pops the user back to the snap screen.
+
+Trend badges only render when `trends[]` includes an entry for that `normalized_name` AND `sample_size >= 3`. Color: red `+`, green `−`, gray neutral (`|pct_change| < 5%`).
+
+Account row shows a checkmark when `account_match.strategy == "card_last4"`, an amber dot + `(last used)` when `last_used`, and a black filled dot + `(you picked)` when `override`.
+
+### 6.3 Duplicate modal
+
+When `409 dup_warning` returns, the client shows:
+
+```
+   ⚠ Already scanned
+
+   HEB, $720.40, 30 seconds ago.
+
+   [ Open original ]   [ Save anyway ]
+```
+
+`Save anyway` re-POSTs the same FormData with `?force=true`.
+
+### 6.4 New page — `/budget/items/[normalized_name]`
+
+List view of every `BudgetTransactionItem` matching `normalized_name` for the family. Mini sparkline of `unit_price_cents` over time at the top. Tap any row → its parent transaction. Reached by tapping any item line in the confirm card or from transaction detail.
+
+### 6.5 New settings page — `/parent/settings/a2a`
+
+Parent-only.
+
+```
+┌──────────────────────────────────────┐
+│  Price Agent (external)              │
+│                                      │
+│  Webhook URL  [ https://…         ]  │
+│  [ x ] Enabled                       │
+│                                      │
+│  Secret  ••••••••••  [ Rotate ]      │
+│  Last success: 2 min ago             │
+│  Failures (rolling): 0               │
+│                                      │
+│              [ Save ]                │
+└──────────────────────────────────────┘
+```
+
+### 6.6 Nav
+
+No new top-level nav entry. The items list page is reached contextually from the confirm card and transaction detail. The webhook setting lives under existing `/parent/settings/`.
+
+### 6.7 i18n
+
+All new strings go through the existing i18n bundles (`frontend/src/i18n/*`). The W1–W6 inline-ternary debt called out in `project_i18n_debt.md` is NOT addressed here; new strings use the same inline ternary pattern as the rest of `/budget/*` for consistency, with a TODO referencing that memo.
+
+## 7. Webhook contract — `family-budget.receipt.v1`
+
+`POST {url}` with headers:
+
+| header | value |
+|---|---|
+| `Content-Type` | `application/json` |
+| `X-A2A-Signature` | `sha256=<hex(hmac-sha256(secret, body))>` |
+| `X-A2A-Delivery` | `<a2a_webhook_deliveries.id>` |
+| `X-A2A-Schema` | `family-budget.receipt.v1` |
+
+Body:
+
+```json
+{
+  "schema": "family-budget.receipt.v1",
+  "family_id": "uuid",
+  "transaction_id": "uuid",
+  "occurred_at": "2026-05-28T20:15:38Z",
+  "payee": "HEB",
+  "currency": "MXN",
+  "total_cents": -72040,
+  "iva_cents": 9683,
+  "items": [
+    {
+      "name": "Leche Alpura 1L",
+      "normalized_name": "leche alpura",
+      "qty": 2,
+      "unit_price_cents": 3200,
+      "total_cents": 6400,
+      "category": "Groceries",
+      "brand": "Alpura"
+    }
+  ],
+  "location_hint": null
+}
+```
+
+`location_hint` reserved for a follow-up release (could be filled by geocoding the merchant address line if the vision model returns it). Always `null` in v1 of the webhook schema.
+
+Success: any 2xx response within 10 s. Anything else → retry per backoff schedule.
+
+## 8. Vision prompt change
+
+Replace the current `RECEIPT_PROMPT` with one that requests the new fields. JSON contract:
+
+```json
+{
+  "date": "YYYY-MM-DD | null",
+  "total_amount": <int cents, negative>,
+  "iva_cents": <int cents, positive | null>,
+  "payee_name": "string | null",
+  "card_last4": "4-digit string | null",
+  "currency": "ISO-4217 | null",
+  "items": [
+    {
+      "name": "string",
+      "qty": <number | null>,
+      "unit_price_cents": <int positive | null>,
+      "total_cents": <int positive>,
+      "brand": "string | null",
+      "raw_text": "string"
+    }
+  ],
+  "confidence": <0.0–1.0>
+}
+```
+
+Rules added to the prompt:
+- Look for the card line: `**1234`, `XXXX1234`, `terminada en 1234`, `Card: ...1234`. Extract last 4 digits as `card_last4`.
+- Look for tax line: `IVA`, `Tax`, `Impuesto`. Extract as `iva_cents` (positive integer cents).
+- For each item: extract qty when explicit (`2 x` or `2 PZA`), brand when present, and the original line as `raw_text`.
+
+## 9. New / changed services
+
+- `app/services/budget/receipt_scanner_service.py` — extend `scan_receipt` to parse the new fields; extend `scan_and_create_transaction` with the 7 stages.
+- `app/services/budget/account_matching_service.py` (new) — `match_account(family_id, card_last4, receipt_currency, fallback_user_id)`.
+- `app/services/budget/duplicate_guard_service.py` (new) — `check_duplicate(family_id, payee_id, amount_cents)`.
+- `app/services/budget/transaction_item_service.py` (new) — CRUD + `get_trend(normalized_name, window_days)`. Normalization helper lives here.
+- `app/services/fx_service.py` (new) — `get_rate(from_ccy, to_ccy, on_date)` via `exchangerate.host` + Redis cache, key `fx:{from}:{to}:{date}`, 24h TTL (historical rates don't change).
+- `app/services/budget/a2a_webhook_service.py` (new) — `enqueue(family_id, transaction_id, payload)`, `dispatch_once(delivery_id)`, `sweep_retries()`. HMAC signing inline.
+- `app/services/budget/categorization_rule_service.py` — extend `suggest_category` to accept an `item_name` arg, then iterate per item in the new scanner flow.
+
+`receipt_draft_service.py` unchanged.
+
+## 10. Premium gating
+
+`receipt_scan` is already metered (existing). No change to the count semantics — one scan = one metered unit, regardless of how many items. Additional new feature flags:
+
+- `a2a_webhook` (boolean) — Plus + Pro only. Free tier sees the settings page disabled with an upsell.
+- `item_trends` (boolean) — Plus + Pro. Free tier sees items in the confirm card without trend badges.
+- `fx_cross_charge` (boolean) — Pro only. When disabled and the matched/fallback account's currency differs from the receipt's currency, the scan routes to the HITL drafts queue with reason `currency_mismatch` rather than picking an arbitrary account. Pro users get the auto-conversion path described in §3 stage (4).
+- `iva_breakout` — included for everyone (no gating; it's just a number we already extracted).
+- `duplicate_guard` — included for everyone.
+
+## 11. Error handling
+
+| failure | behavior |
+|---|---|
+| Vision returns no `card_last4` | account = last-used. `account_match.strategy = "last_used"`. Confirm card shows amber dot. |
+| `card_last4` matches >1 account | narrow by currency. If still >1, fallback to last-used. |
+| FX fetch fails | store transaction in receipt currency, `fx_rate = null`, response includes `warnings: ["fx_unavailable"]`. UI shows soft toast. |
+| Webhook delivery fails | row stays `pending` → retried by sweep. Never blocks scan response. |
+| Webhook URL invalid on save | `PUT /a2a-webhook` returns 422. |
+| Duplicate false positive | `force=true` resolves. UI offers `Save anyway`. |
+| IVA not extractable | leave `iva_cents = null`. No guess. UI omits the pill. |
+| Vision JSON malformed | as today — `ValidationError("Could not parse receipt data from image")`. |
+| Low confidence (< 0.3 or no total) | as today — `BudgetReceiptDraft` HITL queue, none of the 7 stages run. |
+| Item count > 200 | reject with `ValidationError` (defensive cap; real receipts top out around 80). |
+| LiteLLM proxy rejects (budget exceeded) | as today — `ValidationError`. |
+
+## 12. Testing
+
+Target ~25 new tests in `tests/test_receipt_scanner_v2.py`. Backend:
+
+1. `card_last4` exact match picks the account
+2. `card_last4` ambiguous → currency tiebreaker picks correct account
+3. `card_last4` ambiguous → still >1 after tiebreak → last-used fallback
+4. No `card_last4` → last-used fallback
+5. Caller-supplied `account_id` overrides everything
+6. Duplicate guard fires on same-payee same-amount within 60 s
+7. Duplicate guard does NOT fire across families (tenant isolation)
+8. Duplicate guard does NOT fire when amount differs by >1%
+9. `force=true` bypasses duplicate guard and commits
+10. Items persisted with correct `normalized_name`
+11. Normalization strips accents and unit suffixes
+12. Trend endpoint computes `pct_change` over 90-day window
+13. Trend endpoint returns null when `sample_size < 3`
+14. FX cross-charge stores `fx_rate`, `original_amount_cents`, `original_currency`
+15. FX failure → graceful skip, no fx_rate, warning emitted
+16. IVA extracted and stored
+17. Webhook fires on commit when enabled (mock httpx; assert payload + signature)
+18. Webhook does NOT fire when disabled
+19. Webhook does NOT fire when family has no row
+20. Webhook retry sweep picks up `pending` deliveries past `next_retry_at`
+21. Webhook signature is HMAC-SHA256 of body with family secret
+22. Tenant isolation: family A's `GET /items` cannot return family B's items
+23. Low-confidence still routes to drafts queue (regression)
+24. Shopping auto-check still runs (regression)
+25. `card_last4` migration backfills `**9222`, `***313`, `terminada en 1234` correctly
+
+Frontend (Playwright, in `e2e-tests/`):
+
+26. One-tap happy path: snap → confirm card → save → land on transactions list with new row
+27. Duplicate modal flow: re-snap same receipt within 60 s → modal → `Save anyway` → second transaction created
+28. FX display: scan USD receipt against MXN account → confirm card shows both totals
+29. IVA pill renders when present, hidden when absent
+30. Trend badges render when sample_size >= 3, hidden otherwise
+
+## 13. Open questions
+
+None. All previously open questions decided during brainstorm.
+
+## 14. Out of scope / follow-ups
+
+- Live camera coaching ("hold steady, move closer") — deferred.
+- Batch upload (drop 10 receipts at once) — deferred.
+- Multi-page PDF receipts — still first-page-only.
+- Voice memo overlay — deferred.
+- Merchant logo lookup pipeline — confirm card uses initials avatar in v2; logo integration is a polish follow-up.
+- Inline edit of items post-scan — re-scan flow only in v2.
+- Location geocoding into `location_hint` — webhook field is reserved (always null in v1).
+- i18n cleanup of W1–W6 inline ternaries — tracked in `project_i18n_debt.md`, separate effort.
+
+## 15. Rollout
+
+Single Alembic migration `wave4_scanner_v2`. No data flag. The new fields are all nullable, so existing transactions continue to work. The `card_last4` backfill on accounts runs in the migration body.
+
+Order of work, suggested:
+1. Migration + models + schemas.
+2. `FXService`, `transaction_item_service`, `account_matching_service`, `duplicate_guard_service` — pure services, easy to test in isolation.
+3. Extend scanner service to call them; wire new vision prompt.
+4. Extend `scan-receipt` endpoint; add `409 dup_warning` path.
+5. New endpoints (items, trends, webhook config, internal retry).
+6. Webhook dispatch + retry scheduler.
+7. Premium gating updates.
+8. Frontend: confirm card redesign first (biggest visible delta), then items list page, then webhook settings page.
+9. Playwright tests.
+10. Deploy via `./scripts/deploy-gcp.sh`.
+
+Estimated size: ~12 PRs if split, or one large branch if bundled.

--- a/e2e-tests/helpers/auth.js
+++ b/e2e-tests/helpers/auth.js
@@ -1,0 +1,22 @@
+const BASE_URL = process.env.BASE_URL || 'http://localhost:3003';
+const DEMO_USER = {
+  email: process.env.E2E_EMAIL || 'e2e-fresh@example.com',
+  password: process.env.E2E_PASSWORD || 'fresh1234',
+};
+
+/**
+ * Login as parent using demo credentials.
+ * @param {import('@playwright/test').Page} page
+ */
+async function loginAsParent(page) {
+  await page.goto(`${BASE_URL}/login`);
+  await page.waitForLoadState('networkidle');
+  await page.fill('input[name="email"]', DEMO_USER.email);
+  await page.fill('input[name="password"]', DEMO_USER.password);
+  await page.click('button[type="submit"]');
+  await page.waitForURL('**/dashboard', { timeout: 10000 });
+}
+
+module.exports = {
+  loginAsParent,
+};

--- a/e2e-tests/scanner-v2.spec.js
+++ b/e2e-tests/scanner-v2.spec.js
@@ -1,0 +1,29 @@
+const { test, expect } = require('@playwright/test');
+const { loginAsParent } = require('./helpers/auth');
+
+test.describe('Scanner v2', () => {
+  test('one-tap snap → confirm card', async ({ page }) => {
+    await loginAsParent(page);
+    await page.goto('/budget/scan-receipt');
+    await expect(page.locator('text=Snap receipt')).toBeVisible();
+    // The native camera input cannot be driven; assert UI scaffolding.
+    await expect(page.locator('#confirm-card.hidden')).toHaveCount(1);
+  });
+
+  test('duplicate modal flow', async ({ page }) => {
+    // requires a backend stub or pre-seeded recent tx; left as a fixture spec
+    test.skip(true, 'needs backend stub for dup-flow; covered by API test 26');
+  });
+
+  test('FX display when accounts differ', async ({ page }) => {
+    test.skip(true, 'needs backend stub; covered by API test 14');
+  });
+
+  test('IVA pill renders when present', async ({ page }) => {
+    test.skip(true, 'needs backend stub; covered by API test 16');
+  });
+
+  test('trend badges only when sample_size >= 3', async ({ page }) => {
+    test.skip(true, 'needs seeded item history');
+  });
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,7 +14,68 @@
         "tailwindcss": "^4.2.0"
       },
       "devDependencies": {
-        "@types/node": "^25.3.0"
+        "@astrojs/check": "^0.9.9",
+        "@types/node": "^25.3.0",
+        "typescript": "^5.9.3"
+      }
+    },
+    "node_modules/@astrojs/check": {
+      "version": "0.9.9",
+      "resolved": "https://registry.npmjs.org/@astrojs/check/-/check-0.9.9.tgz",
+      "integrity": "sha512-A5UW8uIuErLWEoRQvzgXpO1gTjUFtK8r7nU2Z7GewAMxUb7bPvpk11qaKKgxqXlHJWlAvaaxy+Xg28A6bmQ1Tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/language-server": "^2.16.7",
+        "chokidar": "^4.0.3",
+        "kleur": "^4.1.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "astro-check": "bin/astro-check.js"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0 || ^6.0.0"
+      }
+    },
+    "node_modules/@astrojs/check/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@astrojs/check/node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@astrojs/check/node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@astrojs/compiler": {
@@ -28,6 +89,48 @@
       "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.7.5.tgz",
       "integrity": "sha512-vreGnYSSKhAjFJCWAwe/CNhONvoc5lokxtRoZims+0wa3KbHBdPHSSthJsKxPd8d/aic6lWKpRTYGY/hsgK6EA==",
       "license": "MIT"
+    },
+    "node_modules/@astrojs/language-server": {
+      "version": "2.16.10",
+      "resolved": "https://registry.npmjs.org/@astrojs/language-server/-/language-server-2.16.10.tgz",
+      "integrity": "sha512-87VQ/5GSdHlRnUA+hGuerYyIGAj+9RbZmATyuKLEUePinUXhQ5YkRnRrHhOD9sSi5JOErLjrLkHnfZFEvGrV8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/compiler": "^2.13.1",
+        "@astrojs/yaml2ts": "^0.2.4",
+        "@jridgewell/sourcemap-codec": "^1.5.5",
+        "@volar/kit": "~2.4.28",
+        "@volar/language-core": "~2.4.28",
+        "@volar/language-server": "~2.4.28",
+        "@volar/language-service": "~2.4.28",
+        "muggle-string": "^0.4.1",
+        "tinyglobby": "^0.2.16",
+        "volar-service-css": "0.0.70",
+        "volar-service-emmet": "0.0.70",
+        "volar-service-html": "0.0.70",
+        "volar-service-prettier": "0.0.70",
+        "volar-service-typescript": "0.0.70",
+        "volar-service-typescript-twoslash-queries": "0.0.70",
+        "volar-service-yaml": "0.0.70",
+        "vscode-html-languageservice": "^5.6.2",
+        "vscode-uri": "^3.1.0"
+      },
+      "bin": {
+        "astro-ls": "bin/nodeServer.js"
+      },
+      "peerDependencies": {
+        "prettier": "^3.0.0",
+        "prettier-plugin-astro": ">=0.11.0"
+      },
+      "peerDependenciesMeta": {
+        "prettier": {
+          "optional": true
+        },
+        "prettier-plugin-astro": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@astrojs/markdown-remark": {
       "version": "6.3.10",
@@ -102,6 +205,16 @@
         "node": "18.20.8 || ^20.3.0 || >=22.0.0"
       }
     },
+    "node_modules/@astrojs/yaml2ts": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@astrojs/yaml2ts/-/yaml2ts-0.2.4.tgz",
+      "integrity": "sha512-8oddpOae35pJsXPQXhTkM0ypfKPskVsh2bCxRtbf7e+/Epw2nReakFYpLKjZMEr75CsoF203PMnCocpfz0s69A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.8.3"
+      }
+    },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
@@ -159,6 +272,68 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@emmetio/abbreviation": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-2.3.3.tgz",
+      "integrity": "sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emmetio/scanner": "^1.0.4"
+      }
+    },
+    "node_modules/@emmetio/css-abbreviation": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@emmetio/css-abbreviation/-/css-abbreviation-2.1.8.tgz",
+      "integrity": "sha512-s9yjhJ6saOO/uk1V74eifykk2CBYi01STTK3WlXWGOepyKa23ymJ053+DNQjpFcy1ingpaO7AxCcwLvHFY9tuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emmetio/scanner": "^1.0.4"
+      }
+    },
+    "node_modules/@emmetio/css-parser": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@emmetio/css-parser/-/css-parser-0.4.1.tgz",
+      "integrity": "sha512-2bC6m0MV/voF4CTZiAbG5MWKbq5EBmDPKu9Sb7s7nVcEzNQlrZP6mFFFlIaISM8X6514H9shWMme1fCm8cWAfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emmetio/stream-reader": "^2.2.0",
+        "@emmetio/stream-reader-utils": "^0.1.0"
+      }
+    },
+    "node_modules/@emmetio/html-matcher": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/html-matcher/-/html-matcher-1.3.0.tgz",
+      "integrity": "sha512-NTbsvppE5eVyBMuyGfVu2CRrLvo7J4YHb6t9sBFLyY03WYhXET37qA4zOYUjBWFCRHO7pS1B9khERtY0f5JXPQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@emmetio/scanner": "^1.0.0"
+      }
+    },
+    "node_modules/@emmetio/scanner": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@emmetio/scanner/-/scanner-1.0.4.tgz",
+      "integrity": "sha512-IqRuJtQff7YHHBk4G8YZ45uB9BaAGcwQeVzgj/zj8/UdOhtQpEIupUhSk8dys6spFIWVZVeK20CzGEnqR5SbqA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@emmetio/stream-reader": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/stream-reader/-/stream-reader-2.2.0.tgz",
+      "integrity": "sha512-fXVXEyFA5Yv3M3n8sUGT7+fvecGrZP4k6FnWWMSZVQf69kAq0LLpaBQLGcPR30m3zMmKYhECP4k/ZkzvhEW5kw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@emmetio/stream-reader-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/stream-reader-utils/-/stream-reader-utils-0.1.0.tgz",
+      "integrity": "sha512-ZsZ2I9Vzso3Ho/pjZFsmmZ++FWeEd/txqybHTm4OgaZzdS8V9V/YYWQwg5TC38Z7uLWUV1vavpLLbjJtKubR1A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.8.1",
@@ -1850,6 +2025,104 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
     },
+    "node_modules/@volar/kit": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/kit/-/kit-2.4.28.tgz",
+      "integrity": "sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-service": "2.4.28",
+        "@volar/typescript": "2.4.28",
+        "typesafe-path": "^0.2.2",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      }
+    },
+    "node_modules/@volar/language-core": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
+      "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/source-map": "2.4.28"
+      }
+    },
+    "node_modules/@volar/language-server": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-server/-/language-server-2.4.28.tgz",
+      "integrity": "sha512-NqcLnE5gERKuS4PUFwlhMxf6vqYo7hXtbMFbViXcbVkbZ905AIVWhnSo0ZNBC2V127H1/2zP7RvVOVnyITFfBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "@volar/language-service": "2.4.28",
+        "@volar/typescript": "2.4.28",
+        "path-browserify": "^1.0.1",
+        "request-light": "^0.7.0",
+        "vscode-languageserver": "^9.0.1",
+        "vscode-languageserver-protocol": "^3.17.5",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@volar/language-service": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-service/-/language-service-2.4.28.tgz",
+      "integrity": "sha512-Rh/wYCZJrI5vCwMk9xyw/Z+MsWxlJY1rmMZPsxUoJKfzIRjS/NF1NmnuEcrMbEVGja00aVpCsInJfixQTMdvLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "vscode-languageserver-protocol": "^3.17.5",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@volar/source-map": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
+      "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@volar/typescript": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
+      "integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "path-browserify": "^1.0.1",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@vscode/emmet-helper": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@vscode/emmet-helper/-/emmet-helper-2.11.0.tgz",
+      "integrity": "sha512-QLxjQR3imPZPQltfbWRnHU6JecWTF1QSWhx3GAKQpslx7y3Dp6sIIXhKjiUJ/BR9FX8PVthjr9PD6pNwOJfAzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emmet": "^2.4.3",
+        "jsonc-parser": "^2.3.0",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-languageserver-types": "^3.15.1",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@vscode/l10n": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.18.tgz",
+      "integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1860,6 +2133,38 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-align": {
@@ -2231,6 +2536,100 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -2239,6 +2638,26 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
@@ -2576,6 +2995,23 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
+    "node_modules/emmet": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/emmet/-/emmet-2.4.11.tgz",
+      "integrity": "sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "./packages/scanner",
+        "./packages/abbreviation",
+        "./packages/css-abbreviation",
+        "./"
+      ],
+      "dependencies": {
+        "@emmetio/abbreviation": "^2.3.3",
+        "@emmetio/css-abbreviation": "^2.1.8"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
@@ -2663,6 +3099,16 @@
         "@esbuild/win32-x64": "0.27.3"
       }
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -2710,6 +3156,30 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -2779,6 +3249,16 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-east-asian-width": {
@@ -3155,6 +3635,20 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsonc-parser": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.3.1.tgz",
+      "integrity": "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/kleur": {
       "version": "3.0.3",
@@ -4297,6 +4791,13 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/muggle-string": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
+      "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -4495,6 +4996,13 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/piccolore": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
@@ -4508,9 +5016,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -4545,6 +5053,22 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prismjs": {
@@ -4771,6 +5295,33 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/request-light": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.7.0.tgz",
+      "integrity": "sha512-lMbBMrDoxgsyO+yB3sDcrDuX85yYt7sS8BfQd11jtbW/z5ZWgLZRcEGLsLoYw7I0WSUGQBs8CC8ScIxkTX1+6Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/retext": {
@@ -5150,13 +5701,13 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -5233,18 +5784,34 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/typesafe-path": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/typesafe-path/-/typesafe-path-0.2.2.tgz",
+      "integrity": "sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-auto-import-cache": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/typescript-auto-import-cache/-/typescript-auto-import-cache-0.3.6.tgz",
+      "integrity": "sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.8"
       }
     },
     "node_modules/ufo": {
@@ -6113,6 +6680,261 @@
         }
       }
     },
+    "node_modules/volar-service-css": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-css/-/volar-service-css-0.0.70.tgz",
+      "integrity": "sha512-K1qyOvBpE3rzdAv3e4/6Rv5yizrYPy5R/ne3IWCAzLBuMO4qBMV3kSqWzj6KUVe6S0AnN6wxF7cRkiaKfYMYJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-css-languageservice": "^6.3.0",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-emmet": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-emmet/-/volar-service-emmet-0.0.70.tgz",
+      "integrity": "sha512-xi5bC4m/VyE3zy/n2CXspKeDZs3qA41tHLTw275/7dNWM/RqE2z3BnDICQybHIVp/6G1iOQj5c1qXMgQC08TNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emmetio/css-parser": "^0.4.1",
+        "@emmetio/html-matcher": "^1.3.0",
+        "@vscode/emmet-helper": "^2.9.3",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-html": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-html/-/volar-service-html-0.0.70.tgz",
+      "integrity": "sha512-eR6vCgMdmYAo4n+gcT7DSyBQbwB8S3HZZvSagTf0sxNaD4WppMCFfpqWnkrlGStPKMZvMiejRRVmqsX9dYcTvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-html-languageservice": "^5.3.0",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-prettier": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-prettier/-/volar-service-prettier-0.0.70.tgz",
+      "integrity": "sha512-Z6BCFSpGVCd8BPAsZ785Kce1BGlWd5ODqmqZGVuB14MJvrR4+CYz6cDy4F+igmE1gMifqfvMhdgT8Aud4M5ngg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0",
+        "prettier": "^2.2 || ^3.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        },
+        "prettier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-typescript": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-typescript/-/volar-service-typescript-0.0.70.tgz",
+      "integrity": "sha512-l46Bx4cokkUedTd74ojO5H/zqHZJ8SUuyZ0IB8JN4jfRqUM3bQFBHoOwlZCyZmOeO0A3RQNkMnFclxO4c++gsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-browserify": "^1.0.1",
+        "semver": "^7.6.2",
+        "typescript-auto-import-cache": "^0.3.5",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-nls": "^5.2.0",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-typescript-twoslash-queries": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-typescript-twoslash-queries/-/volar-service-typescript-twoslash-queries-0.0.70.tgz",
+      "integrity": "sha512-IdD13Z9N2Bu8EM6CM0fDV1E69olEYGHDU25X51YXmq8Y0CmJ2LNj6gOiBJgpS5JGUqFzECVhMNBW7R0sPdRTMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-yaml": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-yaml/-/volar-service-yaml-0.0.70.tgz",
+      "integrity": "sha512-0c8bXDBeoATF9F6iPIlOuYTuZAC4c+yi0siQo920u7eiBJk8oQmUmg9cDUbR4+Gl++bvGP4plj3fErbJuPqdcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-uri": "^3.0.8",
+        "yaml-language-server": "~1.20.0"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vscode-css-languageservice": {
+      "version": "6.3.10",
+      "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.3.10.tgz",
+      "integrity": "sha512-eq5N9Er3fC4vA9zd9EFhyBG90wtCCuXgRSpAndaOgXMh1Wgep5lBgRIeDgjZBW9pa+332yC9+49cZMW8jcL3MA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vscode/l10n": "^0.0.18",
+        "vscode-languageserver-textdocument": "^1.0.12",
+        "vscode-languageserver-types": "3.17.5",
+        "vscode-uri": "^3.1.0"
+      }
+    },
+    "node_modules/vscode-html-languageservice": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.6.2.tgz",
+      "integrity": "sha512-ulCrSnFnfQ16YzvwnYUgEbUEl/ZG7u2eV27YhvLObSHKkb8fw1Z9cgsnUwjTEeDIdJDoTDTDpxuhQwoenoLNMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vscode/l10n": "^0.0.18",
+        "vscode-languageserver-textdocument": "^1.0.12",
+        "vscode-languageserver-types": "^3.17.5",
+        "vscode-uri": "^3.1.0"
+      }
+    },
+    "node_modules/vscode-json-languageservice": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-4.1.8.tgz",
+      "integrity": "sha512-0vSpg6Xd9hfV+eZAaYN63xVVMOTmJ4GgHxXnkLCh+9RsQBkWKIghzLhW2B9ebfG+LQQg8uLtsQ2aUKjTgE+QOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-languageserver-types": "^3.16.0",
+        "vscode-nls": "^5.0.0",
+        "vscode-uri": "^3.0.2"
+      },
+      "engines": {
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/vscode-json-languageservice/node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-nls": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.2.0.tgz",
+      "integrity": "sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -6170,6 +6992,94 @@
       "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
       "license": "MIT"
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "devOptional": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yaml-language-server": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-1.20.0.tgz",
+      "integrity": "sha512-qhjK/bzSRZ6HtTvgeFvjNPJGWdZ0+x5NREV/9XZWFjIGezew2b4r5JPy66IfOhd5OA7KeFwk1JfmEbnTvev0cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vscode/l10n": "^0.0.18",
+        "ajv": "^8.17.1",
+        "ajv-draft-04": "^1.0.0",
+        "prettier": "^3.5.0",
+        "request-light": "^0.5.7",
+        "vscode-json-languageservice": "4.1.8",
+        "vscode-languageserver": "^9.0.0",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-languageserver-types": "^3.16.0",
+        "vscode-uri": "^3.0.2",
+        "yaml": "2.7.1"
+      },
+      "bin": {
+        "yaml-language-server": "bin/yaml-language-server"
+      }
+    },
+    "node_modules/yaml-language-server/node_modules/request-light": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.5.8.tgz",
+      "integrity": "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yaml-language-server/node_modules/yaml": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
+      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/yargs-parser": {
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
@@ -6177,6 +7087,51 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yocto-queue": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,8 @@
     "tailwindcss": "^4.2.0"
   },
   "devDependencies": {
-    "@types/node": "^25.3.0"
+    "@astrojs/check": "^0.9.9",
+    "@types/node": "^25.3.0",
+    "typescript": "^5.9.3"
   }
 }

--- a/frontend/src/components/BottomNav.astro
+++ b/frontend/src/components/BottomNav.astro
@@ -1,6 +1,7 @@
 ---
 import { t } from "../lib/i18n";
 import { apiFetch } from "../lib/api";
+import { NAV_VERSION } from "../lib/nav-version";
 
 interface Props {
     active?: "tasks" | "rewards" | "profile" | "parent" | "budget" | "notifications" | "pet" | "chat";
@@ -33,6 +34,7 @@ const itemActive = "bg-brand-coral text-brand-ink border-2 border-brand-ink shad
 <div class="bottom-nav-spacer" aria-hidden="true" transition:persist="bottom-nav-spacer"></div>
 
 <nav
+    data-nav-ver={NAV_VERSION}
     class="fixed bottom-0 left-0 right-0 bg-brand-cream border-t-2 border-brand-ink safe-area-bottom z-50"
     transition:persist="bottom-nav"
 >
@@ -170,7 +172,17 @@ const itemActive = "bg-brand-coral text-brand-ink border-2 border-brand-ink shad
         });
     }
 
-    document.addEventListener("astro:page-load", syncNav);
+    document.addEventListener("astro:page-load", () => {
+        // Stale-nav guard: persisted nav predates a server restart/deploy.
+        // Versions differ → force a hard reload so the fresh nav is rendered.
+        const navVer = document.querySelector<HTMLElement>("[data-nav-ver]")?.dataset?.navVer;
+        const pageVer = document.querySelector<HTMLMetaElement>('meta[name="nav-ver"]')?.content;
+        if (navVer && pageVer && navVer !== pageVer) {
+            window.location.reload();
+            return;
+        }
+        syncNav();
+    });
 </script>
 
 <style>

--- a/frontend/src/components/BottomNav.astro
+++ b/frontend/src/components/BottomNav.astro
@@ -1,8 +1,6 @@
 ---
 import { t } from "../lib/i18n";
 import { apiFetch } from "../lib/api";
-import { NAV_VERSION } from "../lib/nav-version";
-
 interface Props {
     active?: "tasks" | "rewards" | "profile" | "parent" | "budget" | "notifications" | "pet" | "chat";
     role?: string;
@@ -31,12 +29,10 @@ const itemIdle = "text-brand-ink-soft hover:text-brand-ink";
 const itemActive = "bg-brand-coral text-brand-ink border-2 border-brand-ink shadow-[2px_2px_0_var(--color-brand-ink)]";
 ---
 
-<div class="bottom-nav-spacer" aria-hidden="true" transition:persist="bottom-nav-spacer"></div>
+<div class="bottom-nav-spacer" aria-hidden="true"></div>
 
 <nav
-    data-nav-ver={NAV_VERSION}
     class="fixed bottom-0 left-0 right-0 bg-brand-cream border-t-2 border-brand-ink safe-area-bottom z-50"
-    transition:persist="bottom-nav"
 >
     <div class="max-w-md mx-auto flex justify-around items-center px-1 py-2">
         <a href="/dashboard" data-nav-key="tasks" class={`${itemBase} ${active === "tasks" ? itemActive : itemIdle}`}>
@@ -152,15 +148,15 @@ const itemActive = "bg-brand-coral text-brand-ink border-2 border-brand-ink shad
     const IDLE   = "text-brand-ink-soft hover:text-brand-ink";
 
     function urlToKey(path: string): string {
-        if (path.startsWith("/budget"))       return "budget";
-        if (path.startsWith("/parent/frankie")) return "parent"; // Jarvis lives under parent nav
-        if (path.startsWith("/parent"))       return "parent";
-        if (path.startsWith("/rewards"))      return "rewards";
+        if (path.startsWith("/budget"))        return "budget";
+        if (path.startsWith("/parent/frankie")) return "parent";
+        if (path.startsWith("/parent"))        return "parent";
+        if (path.startsWith("/rewards"))       return "rewards";
         if (path.startsWith("/notifications")) return "notifications";
-        if (path.startsWith("/chat"))         return "chat";
-        if (path.startsWith("/pet"))          return "pet";
-        if (path.startsWith("/profile"))      return "profile";
-        return "tasks"; // /dashboard and everything else
+        if (path.startsWith("/chat"))          return "chat";
+        if (path.startsWith("/pet"))           return "pet";
+        if (path.startsWith("/profile"))       return "profile";
+        return "tasks";
     }
 
     function syncNav() {
@@ -172,17 +168,8 @@ const itemActive = "bg-brand-coral text-brand-ink border-2 border-brand-ink shad
         });
     }
 
-    document.addEventListener("astro:page-load", () => {
-        // Stale-nav guard: persisted nav predates a server restart/deploy.
-        // Versions differ → force a hard reload so the fresh nav is rendered.
-        const navVer = document.querySelector<HTMLElement>("[data-nav-ver]")?.dataset?.navVer;
-        const pageVer = document.querySelector<HTMLMetaElement>('meta[name="nav-ver"]')?.content;
-        if (navVer && pageVer && navVer !== pageVer) {
-            window.location.reload();
-            return;
-        }
-        syncNav();
-    });
+    // Sync active item after every navigation (full load or view transition).
+    document.addEventListener("astro:page-load", syncNav);
 </script>
 
 <style>

--- a/frontend/src/components/FABButton.astro
+++ b/frontend/src/components/FABButton.astro
@@ -8,7 +8,7 @@
     id="fab-button"
     aria-label="Register expense"
     style="bottom: calc(88px + env(safe-area-inset-bottom, 0px) + 16px);"
-    class="press fixed right-4 md:!bottom-10 md:right-8 z-20 w-16 h-16 bg-brand-coral text-brand-ink rounded-full border-2 border-brand-ink shadow-[var(--shadow-pop)] flex items-center justify-center"
+    class="press fixed right-4 md:right-8 z-20 w-16 h-16 bg-brand-coral text-brand-ink rounded-full border-2 border-brand-ink shadow-[var(--shadow-pop)] flex items-center justify-center"
 >
     <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3">
         <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />

--- a/frontend/src/components/FABButton.astro
+++ b/frontend/src/components/FABButton.astro
@@ -7,7 +7,7 @@
 <button
     id="fab-button"
     aria-label="Register expense"
-    class="press fixed bottom-24 right-4 md:bottom-10 md:right-8 z-20 w-16 h-16 bg-brand-coral text-brand-ink rounded-full border-2 border-brand-ink shadow-[var(--shadow-pop)] flex items-center justify-center"
+    class="press fixed bottom-28 right-4 md:bottom-10 md:right-8 z-20 w-16 h-16 bg-brand-coral text-brand-ink rounded-full border-2 border-brand-ink shadow-[var(--shadow-pop)] flex items-center justify-center"
 >
     <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3">
         <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />

--- a/frontend/src/components/FABButton.astro
+++ b/frontend/src/components/FABButton.astro
@@ -7,7 +7,8 @@
 <button
     id="fab-button"
     aria-label="Register expense"
-    class="press fixed bottom-28 right-4 md:bottom-10 md:right-8 z-20 w-16 h-16 bg-brand-coral text-brand-ink rounded-full border-2 border-brand-ink shadow-[var(--shadow-pop)] flex items-center justify-center"
+    style="bottom: calc(88px + env(safe-area-inset-bottom, 0px) + 16px);"
+    class="press fixed right-4 md:!bottom-10 md:right-8 z-20 w-16 h-16 bg-brand-coral text-brand-ink rounded-full border-2 border-brand-ink shadow-[var(--shadow-pop)] flex items-center justify-center"
 >
     <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3">
         <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -80,6 +80,12 @@ const bannerCopy = {
     <slot name="overlays" />
 
     <script define:vars={{ sentLabel: bannerCopy.sent, resendLabel: bannerCopy.resend }}>
+        // ClientRouter removed — dispatch astro:page-load once on initial load.
+        // rAF ensures all module scripts have registered their listeners first.
+        requestAnimationFrame(() => {
+            document.dispatchEvent(new Event('astro:page-load'));
+        });
+
         document.addEventListener('astro:page-load', () => {
             (async () => {
                 try {

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -1,6 +1,5 @@
 ---
 import "../styles/global.css";
-import { ClientRouter } from "astro:transitions";
 import { t } from "../lib/i18n";
 import ToastContainer from "../components/ToastContainer.astro";
 import Head from "../components/meta/Head.astro";
@@ -42,7 +41,6 @@ const bannerCopy = {
 <html lang={lang} data-theme={theme === "dark" ? "dark" : undefined}>
 	<head>
 		<Head title={title} description={description} lang={lang} />
-		<ClientRouter />
 		{theme === "system" && (
 			<script is:inline>
 				try {

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -4,8 +4,6 @@ import { ClientRouter } from "astro:transitions";
 import { t } from "../lib/i18n";
 import ToastContainer from "../components/ToastContainer.astro";
 import Head from "../components/meta/Head.astro";
-import { NAV_VERSION } from "../lib/nav-version";
-
 interface Props {
 	title?: string;
 	description?: string;
@@ -44,7 +42,6 @@ const bannerCopy = {
 <html lang={lang} data-theme={theme === "dark" ? "dark" : undefined}>
 	<head>
 		<Head title={title} description={description} lang={lang} />
-		<meta name="nav-ver" content={NAV_VERSION} />
 		<ClientRouter />
 		{theme === "system" && (
 			<script is:inline>

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -4,6 +4,7 @@ import { ClientRouter } from "astro:transitions";
 import { t } from "../lib/i18n";
 import ToastContainer from "../components/ToastContainer.astro";
 import Head from "../components/meta/Head.astro";
+import { NAV_VERSION } from "../lib/nav-version";
 
 interface Props {
 	title?: string;
@@ -43,6 +44,7 @@ const bannerCopy = {
 <html lang={lang} data-theme={theme === "dark" ? "dark" : undefined}>
 	<head>
 		<Head title={title} description={description} lang={lang} />
+		<meta name="nav-ver" content={NAV_VERSION} />
 		<ClientRouter />
 		{theme === "system" && (
 			<script is:inline>

--- a/frontend/src/lib/api/budget.ts
+++ b/frontend/src/lib/api/budget.ts
@@ -941,11 +941,14 @@ export async function scanReceipt(
     file: File,
     opts: { force?: boolean; account_id?: string } = {},
 ): Promise<{ status: number; body: ScanReceiptResponse }> {
+    // account_id is declared on the backend as a Form field (it lives in
+    // the multipart body alongside the file). force stays in the query
+    // string because the route declares it as Query(...).
     const form = new FormData();
     form.append("file", file);
+    if (opts.account_id) form.append("account_id", opts.account_id);
     const q = new URLSearchParams();
     if (opts.force) q.set("force", "true");
-    if (opts.account_id) q.set("account_id", opts.account_id);
     const url = `/api/budget/transactions/scan-receipt${q.toString() ? "?" + q : ""}`;
     const resp = await fetch(url, {
         method: "POST",

--- a/frontend/src/lib/api/budget.ts
+++ b/frontend/src/lib/api/budget.ts
@@ -892,3 +892,66 @@ export async function transferBetweenAccounts(
         body: JSON.stringify(data),
     });
 }
+
+// ─── Receipt Scanner v2 ───────────────────────────────────────────────────────
+
+export interface ScanReceiptResponse {
+    success: boolean;
+    transaction_id: string | null;
+    transaction?: any;
+    items: Array<{
+        id: string;
+        name: string;
+        normalized_name: string;
+        qty: number | null;
+        unit_price_cents: number | null;
+        total_cents: number;
+        brand: string | null;
+        category_id: string | null;
+    }>;
+    account_match?: { strategy: string; matched_card_last4: string | null };
+    fx?: { rate: string; original_amount_cents: number; original_currency: string } | null;
+    trends: Array<{
+        normalized_name: string;
+        avg_unit_cents: number;
+        last_unit_cents: number;
+        pct_change: number;
+        sample_size: number;
+    }>;
+    confidence: number;
+    shopping_auto_checked: string[];
+    warnings: string[];
+    dup_warning: {
+        existing_transaction_id: string;
+        scanned_at: string;
+        amount_cents: number;
+        payee: string | null;
+    } | null;
+    scanned_preview?: Record<string, unknown> | null;
+    draft_id?: string | null;
+    message?: string | null;
+}
+
+/**
+ * Scan a receipt image/PDF via the v2 endpoint. Returns the parsed body together
+ * with the HTTP status so callers can branch on 409 (duplicate) versus 200/201.
+ */
+export async function scanReceipt(
+    token: string,
+    file: File,
+    opts: { force?: boolean; account_id?: string } = {},
+): Promise<{ status: number; body: ScanReceiptResponse }> {
+    const form = new FormData();
+    form.append("file", file);
+    const q = new URLSearchParams();
+    if (opts.force) q.set("force", "true");
+    if (opts.account_id) q.set("account_id", opts.account_id);
+    const url = `/api/budget/transactions/scan-receipt${q.toString() ? "?" + q : ""}`;
+    const resp = await fetch(url, {
+        method: "POST",
+        body: form,
+        headers: { "Authorization": `Bearer ${token}` },
+    });
+    const body = await resp.json();
+    return { status: resp.status, body };
+}

--- a/frontend/src/lib/nav-version.ts
+++ b/frontend/src/lib/nav-version.ts
@@ -1,0 +1,4 @@
+// Evaluated once at Node.js module load (server startup).
+// Changes on every deploy/restart. ES module cache guarantees
+// BottomNav and Layout receive the same value within a process.
+export const NAV_VERSION = Date.now().toString(36);

--- a/frontend/src/lib/nav-version.ts
+++ b/frontend/src/lib/nav-version.ts
@@ -1,4 +1,0 @@
-// Evaluated once at Node.js module load (server startup).
-// Changes on every deploy/restart. ES module cache guarantees
-// BottomNav and Layout receive the same value within a process.
-export const NAV_VERSION = Date.now().toString(36);

--- a/frontend/src/pages/budget/items/[normalized_name].astro
+++ b/frontend/src/pages/budget/items/[normalized_name].astro
@@ -1,0 +1,50 @@
+---
+import Layout from "@layouts/Layout.astro";
+import BudgetNavNew from "@components/BudgetNavNew.astro";
+import BottomNav from "@components/BottomNav.astro";
+import DrawerMenu from "@components/DrawerMenu.astro";
+import { apiFetch } from "@lib/api";
+
+const token = Astro.cookies.get("access_token")?.value;
+if (!token) return Astro.redirect("/login");
+const lang = (Astro.cookies.get("lang")?.value ?? "en") as "en" | "es";
+const { normalized_name } = Astro.params;
+
+const { data: items } = await apiFetch<any[]>(
+  `/api/budget/items?normalized_name=${encodeURIComponent(normalized_name || "")}&limit=100`,
+  { token },
+);
+const { data: trend } = await apiFetch<any>(
+  `/api/budget/items/trend?normalized_name=${encodeURIComponent(normalized_name || "")}`,
+  { token },
+);
+---
+
+<Layout title={normalized_name} lang={lang}>
+  <DrawerMenu lang={lang} />
+  <BudgetNavNew lang={lang} active="transactions" pendingDrafts={0} />
+  <main class="px-4 pb-32 pt-6 max-w-md mx-auto">
+    <h1 class="text-2xl font-display capitalize">{normalized_name}</h1>
+    {trend && (
+      <div class="card p-3 my-3 text-sm">
+        <div>{lang === "es" ? "Promedio 90 días" : "90-day average"}:
+          ${(trend.avg_unit_cents / 100).toFixed(2)}</div>
+        <div>{lang === "es" ? "Último" : "Last"}:
+          ${(trend.last_unit_cents / 100).toFixed(2)}
+          ({(trend.pct_change * 100).toFixed(1)}%)</div>
+      </div>
+    )}
+    <ul class="divide-y divide-fg/10">
+      {(items || []).map(it => (
+        <li class="py-2 flex justify-between">
+          <a href={`/budget/transactions/${it.transaction_id}`} class="flex-1">
+            <div class="text-sm">{it.name}</div>
+            <div class="text-xs text-fg/60">{it.qty ?? 1} × ${(it.unit_price_cents ?? it.total_cents) / 100}</div>
+          </a>
+          <span class="text-sm">${(it.total_cents / 100).toFixed(2)}</span>
+        </li>
+      ))}
+    </ul>
+  </main>
+  <BottomNav lang={lang} active="budget" />
+</Layout>

--- a/frontend/src/pages/budget/receipt-drafts.astro
+++ b/frontend/src/pages/budget/receipt-drafts.astro
@@ -268,7 +268,7 @@ const l = {
             </div>
         </main>
 
-        <BottomNav activePage="budget" />
+        <BottomNav active="budget" role={user.role} lang={lang} />
     </div>
 </Layout>
 

--- a/frontend/src/pages/budget/scan-receipt.astro
+++ b/frontend/src/pages/budget/scan-receipt.astro
@@ -285,7 +285,7 @@ const title = lang === "es" ? "Escanear ticket" : "Scan receipt";
                     ? `<span class="text-xs text-brand-ink-soft mr-1">${esc(it.qty)}×</span>`
                     : "";
                 return `<li class="flex justify-between items-center py-1.5 text-sm">
-                    <span class="text-brand-ink">${qtyLabel}${esc(it.name)}${badge}</span>
+                    <span class="text-brand-ink">${qtyLabel}<a href="/budget/items/${encodeURIComponent(it.normalized_name)}" class="underline-offset-4 hover:underline">${esc(it.name)}</a>${badge}</span>
                     <span class="text-brand-ink font-medium num">${money(it.total_cents, currency)}</span>
                 </li>`;
             }).join("");

--- a/frontend/src/pages/budget/scan-receipt.astro
+++ b/frontend/src/pages/budget/scan-receipt.astro
@@ -182,11 +182,13 @@ const title = lang === "es" ? "Escanear ticket" : "Scan receipt";
 
         // ── Scan helpers (inline fetch — keeps script self-contained) ─────────
         async function scanReceipt(file, opts) {
+            // account_id rides the multipart form body (Form(...) on the
+            // route); force stays as a Query parameter.
             const form = new FormData();
             form.append("file", file);
+            if (opts && opts.account_id) form.append("account_id", opts.account_id);
             const q = new URLSearchParams();
             if (opts && opts.force) q.set("force", "true");
-            if (opts && opts.account_id) q.set("account_id", opts.account_id);
             const url = `/api/budget/transactions/scan-receipt${q.toString() ? "?" + q : ""}`;
             const resp = await fetch(url, {
                 method: "POST",

--- a/frontend/src/pages/budget/scan-receipt.astro
+++ b/frontend/src/pages/budget/scan-receipt.astro
@@ -1,8 +1,19 @@
 ---
 /**
- * Receipt Scanner Page
- * Allows scanning receipts with camera or file upload to create transactions automatically
- * Premium feature (Plus/Pro plans)
+ * Receipt Scanner Page (v2 — one-tap snap UX)
+ *
+ * The user picks a photo or file. The page kicks off the v2 scan-receipt
+ * endpoint, shows an animated overlay through the 4 server-side stages, then
+ * renders a confirm card with auto-detected account, total, optional FX line,
+ * optional IVA pill, itemized list with inline price-trend badges, and a
+ * primary "Looks good — save" plus "Delete & re-scan" actions.
+ *
+ * Branching:
+ *   - 409 Conflict + dup_warning → modal with "Open original" / "Save anyway"
+ *   - body.draft_id            → redirect to /budget/receipt-drafts (low confidence)
+ *   - otherwise                → confirm card
+ *
+ * Premium feature (Plus/Pro plans), parent-only.
  */
 
 import Layout from "@layouts/Layout.astro";
@@ -10,13 +21,11 @@ import BottomNav from "@components/BottomNav.astro";
 import BudgetNavNew from "@components/BudgetNavNew.astro";
 import DrawerMenu from "@components/DrawerMenu.astro";
 import { apiFetch } from "@lib/api";
-import { getAccounts } from "@lib/api/budget";
-import type { BudgetAccount } from "@lib/api/budget";
 
 const token = Astro.cookies.get("access_token")?.value;
 if (!token) return Astro.redirect("/login");
 
-const lang = Astro.cookies.get("lang")?.value ?? "en";
+const lang = (Astro.cookies.get("lang")?.value ?? "en") as "en" | "es";
 
 const { data: user, ok: userOk } = await apiFetch<any>("/api/auth/me", { token });
 if (!userOk) {
@@ -28,440 +37,416 @@ if (user.role !== "parent") {
     return Astro.redirect("/dashboard");
 }
 
-const { data: accounts, ok: accountsOk } = await getAccounts(token);
-const { data: draftsCount } = await apiFetch<{count: number}>("/api/budget/receipt-drafts/count", { token });
+const { data: draftsCount } = await apiFetch<{ count: number }>(
+    "/api/budget/receipt-drafts/count",
+    { token },
+);
 const pendingDraftsCount = draftsCount?.count ?? 0;
 
-const l = {
-    en: {
-        title: "Scan Receipt",
-        subtitle: "Take a photo or upload a receipt to create a transaction automatically",
-        account: "Target Account",
-        accountPlaceholder: "Select account...",
-        accountHelp: "Transaction will be added to this account",
-        takePhoto: "Take Photo",
-        uploadFile: "Upload Image",
-        or: "or",
-        scanning: "Analyzing receipt...",
-        scanBtn: "Scan Receipt",
-        success: "Transaction Created!",
-        lowConfidence: "Low confidence - please review",
-        date: "Date",
-        amount: "Amount",
-        payee: "Payee",
-        items: "Items",
-        confidence: "Confidence",
-        viewTransaction: "View Transactions",
-        tryAgain: "Scan Another",
-        premiumRequired: "Receipt scanning requires a Plus or Pro plan",
-        upgrade: "Upgrade Plan",
-        noImage: "Please select or capture a receipt image",
-        noAccount: "Please select a target account",
-        error: "Error scanning receipt",
-        dragDrop: "Drag & drop receipt here",
-        maxSize: "Max 10MB - JPEG, PNG, or WebP",
-    },
-    es: {
-        title: "Escanear Recibo",
-        subtitle: "Toma una foto o sube un recibo para crear una transaccion automaticamente",
-        account: "Cuenta Destino",
-        accountPlaceholder: "Seleccionar cuenta...",
-        accountHelp: "La transaccion se agregara a esta cuenta",
-        takePhoto: "Tomar Foto",
-        uploadFile: "Subir Imagen",
-        or: "o",
-        scanning: "Analizando recibo...",
-        scanBtn: "Escanear Recibo",
-        success: "Transaccion Creada!",
-        lowConfidence: "Baja confianza - por favor revisa",
-        date: "Fecha",
-        amount: "Monto",
-        payee: "Beneficiario",
-        items: "Articulos",
-        confidence: "Confianza",
-        viewTransaction: "Ver Transacciones",
-        tryAgain: "Escanear Otro",
-        premiumRequired: "El escaneo de recibos requiere un plan Plus o Pro",
-        upgrade: "Mejorar Plan",
-        noImage: "Por favor selecciona o captura una imagen del recibo",
-        noAccount: "Por favor selecciona una cuenta destino",
-        error: "Error al escanear recibo",
-        dragDrop: "Arrastra y suelta el recibo aqui",
-        maxSize: "Max 10MB - JPEG, PNG o WebP",
-    },
-};
-const t = l[lang as keyof typeof l] || l.en;
+const title = lang === "es" ? "Escanear ticket" : "Scan receipt";
 ---
 
-<Layout title={`${t.title} - Budget`}>
+<Layout title={`${title} - Budget`}>
     <div class="w-full max-w-md md:max-w-4xl lg:max-w-6xl mx-auto bg-brand-cream-deep flex flex-col min-h-screen">
         <!-- Header -->
         <header class="bg-gradient-to-br from-brand-coral to-brand-sky-deep text-white pt-12 pb-6 px-6 rounded-b-[var(--radius-tile)] shadow-[var(--shadow-card)]">
-            <div class="flex items-center justify-between mb-6">
+            <div class="flex items-center justify-between mb-2">
                 <a href="/budget/transactions" class="text-white hover:text-brand-cream transition">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
                     </svg>
                 </a>
-                <h1 class="text-2xl font-bold">{t.title}</h1>
+                <h1 class="text-2xl font-display font-extrabold">{title}</h1>
                 <div class="w-6"></div>
             </div>
-
-            <div class="bg-brand-cream/20 backdrop-blur-md rounded-2xl p-4 border border-white/30">
-                <div class="flex items-center gap-3">
-                    <div class="bg-brand-cream/30 rounded-full p-2">
-                        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z" />
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 13a3 3 0 11-6 0 3 3 0 016 0z" />
-                        </svg>
-                    </div>
-                    <p class="text-white/90 text-sm">{t.subtitle}</p>
-                </div>
-            </div>
+            <p class="text-white/80 text-sm text-center">
+                {lang === "es"
+                    ? "Toma una foto y deja que la IA llene todo."
+                    : "Snap a photo and let AI fill in the rest."}
+            </p>
         </header>
 
         <BudgetNavNew active="none" lang={lang} pendingDrafts={pendingDraftsCount} />
         <DrawerMenu lang={lang} />
 
         <!-- Main Content -->
-        <main class="px-6 py-6 flex-grow max-w-lg mx-auto w-full">
-            <!-- Scan Form -->
-            <div id="scan-form" class="space-y-5">
-                <!-- Account Selection -->
-                <div class="bg-brand-cream rounded-2xl shadow-[var(--shadow-card)] border border-brand-ink/10 p-5">
-                    <label for="account-id" class="block text-sm font-semibold text-brand-ink mb-2">
-                        {t.account}
-                    </label>
-                    <select
-                        id="account-id"
-                        required
-                        class="w-full px-4 py-3 border-2 border-brand-ink/10 rounded-xl focus:ring-2 focus:ring-brand-coral focus:border-brand-coral bg-brand-cream-deep"
-                    >
-                        <option value="">{t.accountPlaceholder}</option>
-                        {accountsOk && accounts && accounts.map((account: BudgetAccount) => (
-                            <option value={account.id}>{account.name} ({account.type})</option>
-                        ))}
-                    </select>
-                    <p class="text-xs text-brand-ink-soft mt-1.5">{t.accountHelp}</p>
-                </div>
-
-                <!-- Image Capture/Upload -->
-                <div class="bg-brand-cream rounded-2xl shadow-[var(--shadow-card)] border border-brand-ink/10 p-5">
-                    <!-- Preview Area -->
-                    <div
-                        id="drop-zone"
-                        class="relative border-2 border-dashed border-brand-ink/20 rounded-xl p-8 text-center hover:border-brand-coral transition cursor-pointer"
-                    >
-                        <div id="placeholder-content">
-                            <svg xmlns="http://www.w3.org/2000/svg" class="h-12 w-12 text-brand-ink-soft mx-auto mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-                            </svg>
-                            <p class="text-sm font-medium text-brand-ink-soft">{t.dragDrop}</p>
-                            <p class="text-xs text-brand-ink-soft mt-1">{t.maxSize}</p>
-                        </div>
-                        <img id="preview-image" class="hidden max-h-64 mx-auto rounded-lg" alt="Receipt preview" />
-                        <input type="file" id="file-input" accept="image/jpeg,image/png,image/webp" class="hidden" />
-                    </div>
-
-                    <!-- Action Buttons -->
-                    <div class="flex gap-3 mt-4">
-                        <button
-                            id="camera-btn"
-                            type="button"
-                            class="flex-1 flex items-center justify-center gap-2 bg-brand-coral-deep text-white px-4 py-3 rounded-xl font-semibold hover:bg-brand-coral-deep transition"
-                        >
-                            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z" />
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 13a3 3 0 11-6 0 3 3 0 016 0z" />
-                            </svg>
-                            <span class="text-sm">{t.takePhoto}</span>
-                        </button>
-                        <button
-                            id="upload-btn"
-                            type="button"
-                            class="flex-1 flex items-center justify-center gap-2 bg-brand-cream-deep text-brand-ink px-4 py-3 rounded-xl font-semibold hover:bg-brand-cream-deep transition border border-brand-ink/10"
-                        >
-                            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                            </svg>
-                            <span class="text-sm">{t.uploadFile}</span>
-                        </button>
-                    </div>
-                    <!-- Camera capture input (hidden, for mobile) -->
-                    <input type="file" id="camera-input" accept="image/*" capture="environment" class="hidden" />
-                </div>
-
-                <!-- Scan Button -->
-                <button
-                    id="scan-btn"
-                    type="button"
-                    disabled
-                    class="w-full bg-gradient-to-r from-brand-coral to-brand-sky-deep text-white px-6 py-4 rounded-xl font-bold text-lg transition disabled:opacity-50 disabled:cursor-not-allowed shadow-[var(--shadow-pop)]"
-                >
-                    {t.scanBtn}
-                </button>
+        <main class="px-6 py-8 flex-grow max-w-lg mx-auto w-full">
+            <div id="scan-actions" class="flex flex-col gap-3">
+                <label class="cursor-pointer block w-full text-center bg-brand-coral-deep text-white px-6 py-4 rounded-2xl font-bold text-lg shadow-[var(--shadow-card)] press">
+                    {lang === "es" ? "📷 Tomar foto" : "📷 Snap receipt"}
+                    <input
+                        id="cam-input"
+                        type="file"
+                        accept="image/*,application/pdf"
+                        capture="environment"
+                        class="hidden"
+                    />
+                </label>
+                <label class="cursor-pointer block w-full text-center bg-brand-cream text-brand-ink px-6 py-4 rounded-2xl font-bold text-lg border-2 border-brand-ink/10 press">
+                    {lang === "es" ? "⬆ Subir imagen" : "⬆ Upload image"}
+                    <input
+                        id="up-input"
+                        type="file"
+                        accept="image/jpeg,image/png,image/webp,image/gif,application/pdf"
+                        class="hidden"
+                    />
+                </label>
             </div>
 
-            <!-- Loading State -->
-            <div id="loading-state" class="hidden">
-                <div class="bg-brand-cream rounded-2xl shadow-[var(--shadow-card)] border border-brand-ink/10 p-8 text-center">
-                    <div class="animate-pulse">
-                        <div class="bg-brand-coral/15 rounded-full w-20 h-20 flex items-center justify-center mx-auto mb-4">
-                            <svg xmlns="http://www.w3.org/2000/svg" class="h-10 w-10 text-brand-coral-deep animate-spin" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-                            </svg>
-                        </div>
-                        <p class="text-lg font-semibold text-brand-ink">{t.scanning}</p>
-                        <p class="text-sm text-brand-ink-soft mt-2">AI is reading your receipt...</p>
-                    </div>
-                </div>
-            </div>
+            <!-- Confirm card target -->
+            <section id="confirm-card" class="hidden mt-8"></section>
 
-            <!-- Results -->
-            <div id="results-state" class="hidden space-y-4">
-                <div id="result-card" class="bg-brand-cream rounded-2xl shadow-[var(--shadow-card)] border border-brand-ink/10 p-5">
-                    <!-- Filled by JS -->
-                </div>
-
-                <div class="flex gap-3">
-                    <a
-                        href="/budget/transactions"
-                        class="flex-1 text-center bg-brand-coral-deep text-white px-4 py-3 rounded-xl font-semibold hover:bg-brand-coral-deep transition"
-                    >
-                        {t.viewTransaction}
-                    </a>
-                    <button
-                        id="try-again-btn"
-                        type="button"
-                        class="flex-1 bg-brand-cream-deep text-brand-ink px-4 py-3 rounded-xl font-semibold hover:bg-brand-cream-deep transition border border-brand-ink/10"
-                    >
-                        {t.tryAgain}
-                    </button>
-                </div>
-            </div>
+            <!-- Duplicate modal -->
+            <dialog
+                id="dup-modal"
+                class="rounded-2xl p-0 bg-transparent backdrop:bg-brand-ink/40"
+            ></dialog>
         </main>
+
+        <!-- Full-screen overlay (covers the page during scan) -->
+        <div
+            id="scan-overlay"
+            class="hidden fixed inset-0 z-50 bg-brand-cream/95 flex flex-col items-center justify-center p-6"
+        >
+            <div class="size-32 rounded-2xl bg-brand-coral/15 mb-6 animate-pulse flex items-center justify-center">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-12 w-12 text-brand-coral-deep animate-spin" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                </svg>
+            </div>
+            <ul id="scan-stages" class="text-brand-ink text-sm space-y-1 text-center font-medium">
+                <li data-stage="0">{lang === "es" ? "Leyendo…" : "Reading…"}</li>
+                <li data-stage="1" class="opacity-30">{lang === "es" ? "Detectando cuenta…" : "Matching account…"}</li>
+                <li data-stage="2" class="opacity-30">{lang === "es" ? "Categorizando…" : "Categorizing…"}</li>
+                <li data-stage="3" class="opacity-30">{lang === "es" ? "Buscando duplicados…" : "Checking duplicates…"}</li>
+            </ul>
+        </div>
 
         <BottomNav active="budget" role={user.role} lang={lang} />
     </div>
 </Layout>
 
-<script define:vars={{ t }}>
-    document.addEventListener('astro:page-load', () => {
-        const fileInput = document.getElementById('file-input');
-        const cameraInput = document.getElementById('camera-input');
-        const cameraBtn = document.getElementById('camera-btn');
-        const uploadBtn = document.getElementById('upload-btn');
-        const scanBtn = document.getElementById('scan-btn');
-        const dropZone = document.getElementById('drop-zone');
-        const previewImage = document.getElementById('preview-image');
-        const placeholderContent = document.getElementById('placeholder-content');
-        const scanForm = document.getElementById('scan-form');
-        const loadingState = document.getElementById('loading-state');
-        const resultsState = document.getElementById('results-state');
-        const resultCard = document.getElementById('result-card');
-        const tryAgainBtn = document.getElementById('try-again-btn');
+<script define:vars={{ lang, token }}>
+    document.addEventListener("astro:page-load", () => {
+        const camInput = document.getElementById("cam-input");
+        const upInput = document.getElementById("up-input");
+        const overlay = document.getElementById("scan-overlay");
+        const confirmCard = document.getElementById("confirm-card");
+        const dupModal = document.getElementById("dup-modal");
 
-        if (!fileInput || !scanBtn) return;
+        if (!camInput || !upInput || !overlay || !confirmCard || !dupModal) return;
 
-        let selectedFile = null;
-
-        // Camera button
-        cameraBtn?.addEventListener('click', () => {
-            cameraInput?.click();
-        });
-
-        // Upload button
-        uploadBtn?.addEventListener('click', () => {
-            fileInput?.click();
-        });
-
-        // Drop zone click
-        dropZone?.addEventListener('click', () => {
-            fileInput?.click();
-        });
-
-        // Drag and drop
-        dropZone?.addEventListener('dragover', (e) => {
-            e.preventDefault();
-            dropZone.classList.add('border-brand-coral', 'bg-brand-coral/15');
-        });
-
-        dropZone?.addEventListener('dragleave', () => {
-            dropZone.classList.remove('border-brand-coral', 'bg-brand-coral/15');
-        });
-
-        dropZone?.addEventListener('drop', (e) => {
-            e.preventDefault();
-            dropZone.classList.remove('border-brand-coral', 'bg-brand-coral/15');
-            const files = e.dataTransfer?.files;
-            if (files?.[0]) handleFileSelect(files[0]);
-        });
-
-        // File selection handlers
-        fileInput?.addEventListener('change', (e) => {
-            const file = e.target?.files?.[0];
-            if (file) handleFileSelect(file);
-        });
-
-        cameraInput?.addEventListener('change', (e) => {
-            const file = e.target?.files?.[0];
-            if (file) handleFileSelect(file);
-        });
-
-        function handleFileSelect(file) {
-            selectedFile = file;
-
-            // Show preview
-            const reader = new FileReader();
-            reader.onload = (e) => {
-                previewImage.src = e.target.result;
-                previewImage.classList.remove('hidden');
-                placeholderContent.classList.add('hidden');
-            };
-            reader.readAsDataURL(file);
-
-            // Enable scan button
-            scanBtn.disabled = false;
+        // ── Helpers ───────────────────────────────────────────────────────────
+        function money(cents, ccy) {
+            const c = Number(cents || 0);
+            const sign = c < 0 ? "-" : "";
+            const abs = Math.abs(c) / 100;
+            return `${sign}$${abs.toFixed(2)} ${ccy || ""}`.trim();
         }
 
-        // Scan button
-        scanBtn?.addEventListener('click', async () => {
-            const accountId = document.getElementById('account-id')?.value;
+        function esc(s) {
+            return String(s || "").replace(/[<>&"']/g, (c) => ({
+                "<": "&lt;",
+                ">": "&gt;",
+                "&": "&amp;",
+                "\"": "&quot;",
+                "'": "&#39;",
+            }[c]));
+        }
 
-            if (!accountId) {
-                alert(t.noAccount);
-                return;
-            }
+        function timeAgo(iso, l) {
+            const sec = Math.round((Date.now() - new Date(iso).getTime()) / 1000);
+            if (sec < 60) return l === "es" ? `hace ${sec}s` : `${sec}s ago`;
+            return l === "es"
+                ? `hace ${Math.round(sec / 60)}m`
+                : `${Math.round(sec / 60)}m ago`;
+        }
 
-            if (!selectedFile) {
-                alert(t.noImage);
-                return;
-            }
+        // ── Overlay tick animation (advances stage labels every 700ms) ───────
+        function tickStages() {
+            const stages = overlay.querySelectorAll("#scan-stages li");
+            let i = 0;
+            return setInterval(() => {
+                if (i > 0 && stages[i - 1]) stages[i - 1].classList.remove("opacity-30");
+                if (i < stages.length && stages[i]) stages[i].classList.remove("opacity-30");
+                i = Math.min(stages.length, i + 1);
+            }, 700);
+        }
 
-            // Show loading
-            scanForm.classList.add('hidden');
-            loadingState.classList.remove('hidden');
+        function resetStages() {
+            const stages = overlay.querySelectorAll("#scan-stages li");
+            stages.forEach((el, idx) => {
+                if (idx === 0) el.classList.remove("opacity-30");
+                else el.classList.add("opacity-30");
+            });
+        }
 
+        // ── Scan helpers (inline fetch — keeps script self-contained) ─────────
+        async function scanReceipt(file, opts) {
+            const form = new FormData();
+            form.append("file", file);
+            const q = new URLSearchParams();
+            if (opts && opts.force) q.set("force", "true");
+            if (opts && opts.account_id) q.set("account_id", opts.account_id);
+            const url = `/api/budget/transactions/scan-receipt${q.toString() ? "?" + q : ""}`;
+            const resp = await fetch(url, {
+                method: "POST",
+                body: form,
+                headers: { "Authorization": `Bearer ${token}` },
+            });
+            const body = await resp.json().catch(() => ({}));
+            return { status: resp.status, body };
+        }
+
+        // ── Top-level: run a scan ─────────────────────────────────────────────
+        async function runScan(file) {
+            resetStages();
+            overlay.classList.remove("hidden");
+            const ticker = tickStages();
             try {
-                const formData = new FormData();
-                formData.append('file', selectedFile);
-                formData.append('account_id', accountId);
+                const { status, body } = await scanReceipt(file);
+                clearInterval(ticker);
+                overlay.classList.add("hidden");
 
-                const response = await fetch('/api/budget/transactions/scan-receipt', {
-                    method: 'POST',
-                    body: formData,
-                });
-
-                const data = await response.json();
-
-                if (response.status === 403) {
-                    // Premium required
-                    loadingState.classList.add('hidden');
-                    scanForm.classList.remove('hidden');
-                    alert(t.premiumRequired);
+                if (status === 403) {
+                    alert(lang === "es"
+                        ? "El escaneo de recibos requiere un plan Plus o Pro."
+                        : "Receipt scanning requires a Plus or Pro plan.");
                     return;
                 }
-
-                // Show results
-                loadingState.classList.add('hidden');
-                resultsState.classList.remove('hidden');
-                displayResults(data);
-
-            } catch (error) {
-                loadingState.classList.add('hidden');
-                scanForm.classList.remove('hidden');
-                alert(t.error + ': ' + error.message);
+                if (status === 409 && body && body.dup_warning) {
+                    showDupModal(file, body);
+                    return;
+                }
+                if (body && body.draft_id) {
+                    window.location.href = "/budget/receipt-drafts";
+                    return;
+                }
+                if (status >= 400 || !body || !body.success) {
+                    alert(lang === "es"
+                        ? "Error escaneando."
+                        : "Scan failed.");
+                    return;
+                }
+                showConfirmCard(body);
+            } catch (e) {
+                clearInterval(ticker);
+                overlay.classList.add("hidden");
+                alert(lang === "es" ? "Error escaneando." : "Scan failed.");
             }
-        });
+        }
 
-        // Try again
-        tryAgainBtn?.addEventListener('click', () => {
-            resultsState.classList.add('hidden');
-            scanForm.classList.remove('hidden');
-            selectedFile = null;
-            previewImage.classList.add('hidden');
-            previewImage.src = '';
-            placeholderContent.classList.remove('hidden');
-            scanBtn.disabled = true;
-            fileInput.value = '';
-            cameraInput.value = '';
-        });
+        // ── Render the confirm card from a successful response ────────────────
+        function showConfirmCard(body) {
+            const tx = body.transaction || {};
+            const currency = tx.currency || "MXN";
 
-        function displayResults(data) {
-            const scanned = data.scanned_data || {};
-            const isSuccess = data.success;
-            const confidence = Math.round((data.confidence || 0) * 100);
+            // FX line — only when present
+            const fxLine = body.fx
+                ? `<div class="text-sm text-brand-ink-soft mt-1">≈ ${money(
+                    body.fx.original_amount_cents,
+                    body.fx.original_currency,
+                )} @ ${esc(body.fx.rate)}</div>`
+                : "";
 
-            const confidenceColor = confidence >= 80 ? 'text-brand-mint-deep bg-brand-mint/20' :
-                                   confidence >= 50 ? 'text-yellow-600 bg-brand-sun/20' :
-                                   'text-red-600 bg-red-100';
+            // IVA pill — only when transaction has iva_cents
+            const ivaPill = tx.iva_cents
+                ? `<div class="inline-block px-3 py-1 rounded-full bg-brand-cream-deep text-xs font-semibold text-brand-ink">
+                       IVA ${money(tx.iva_cents, currency)}
+                   </div>`
+                : "";
 
-            const amount = scanned.total_amount != null
-                ? (scanned.total_amount / 100).toFixed(2)
-                : '—';
+            // Match strategy → indicator
+            const strategy = body.account_match && body.account_match.strategy;
+            const matchBadge = strategy === "card_last4"
+                ? `<span class="inline-block text-brand-mint-deep font-bold">✓</span>`
+                : strategy === "override"
+                    ? `<span class="inline-block text-brand-ink font-bold">●</span>`
+                    : `<span class="inline-block text-yellow-600 font-bold" title="${
+                        lang === "es" ? "Mejor estimación" : "Best guess"
+                    }">●</span>`;
 
-            let itemsHtml = '';
-            if (scanned.items?.length > 0) {
-                itemsHtml = `
-                    <div class="mt-3 pt-3 border-t border-brand-ink/10">
-                        <p class="text-xs font-semibold text-brand-ink-soft uppercase tracking-wider mb-2">${t.items}</p>
-                        <div class="space-y-1">
-                            ${scanned.items.map(item => `
-                                <div class="flex justify-between text-sm">
-                                    <span class="text-brand-ink-soft">${item.name}</span>
-                                    <span class="text-brand-ink font-medium">$${(item.amount_cents / 100).toFixed(2)}</span>
-                                </div>
-                            `).join('')}
+            // Trend badges (only when sample_size >= 3 AND |pct_change| >= 0.05)
+            const trendsMap = new Map(
+                (body.trends || []).map((t) => [t.normalized_name, t]),
+            );
+
+            const items = body.items || [];
+            const itemsHtml = items.map((it) => {
+                const t = trendsMap.get(it.normalized_name);
+                let badge = "";
+                if (t && t.sample_size >= 3 && Math.abs(t.pct_change) >= 0.05) {
+                    const up = t.pct_change > 0;
+                    const color = up ? "text-red-600" : "text-brand-mint-deep";
+                    const arrow = up ? "📈" : "📉";
+                    const pct = (t.pct_change * 100).toFixed(0);
+                    badge = `<span class="ml-2 text-xs font-semibold ${color}">${arrow} ${pct}%</span>`;
+                }
+                const qtyLabel = it.qty && Number(it.qty) > 1
+                    ? `<span class="text-xs text-brand-ink-soft mr-1">${esc(it.qty)}×</span>`
+                    : "";
+                return `<li class="flex justify-between items-center py-1.5 text-sm">
+                    <span class="text-brand-ink">${qtyLabel}${esc(it.name)}${badge}</span>
+                    <span class="text-brand-ink font-medium num">${money(it.total_cents, currency)}</span>
+                </li>`;
+            }).join("");
+
+            const itemsBlock = items.length
+                ? `<ul class="border-t border-brand-ink/10 pt-3 divide-y divide-brand-ink/5">${itemsHtml}</ul>`
+                : "";
+
+            // Total — tx.amount is already cents (negative for expenses)
+            const totalDisplay = money(
+                typeof tx.amount === "number" ? Math.abs(tx.amount) : 0,
+                currency,
+            );
+
+            confirmCard.innerHTML = `
+                <div class="bg-brand-cream rounded-2xl shadow-[var(--shadow-card)] border border-brand-ink/10 p-5 space-y-4">
+                    <div>
+                        <h2 class="text-xl font-display font-extrabold text-brand-ink">
+                            ${esc(tx.payee_name || (lang === "es" ? "Ticket" : "Receipt"))}
+                        </h2>
+                        <div class="text-3xl font-display font-extrabold text-brand-coral-deep num mt-1">
+                            ${totalDisplay}
+                        </div>
+                        ${fxLine}
+                    </div>
+
+                    <div class="text-sm">
+                        <div class="text-brand-ink-soft text-xs uppercase tracking-wider font-semibold mb-1">
+                            ${lang === "es" ? "Cuenta" : "Account"}
+                        </div>
+                        <div class="flex items-center gap-2">
+                            ${matchBadge}
+                            <span class="text-brand-ink font-medium">${esc(tx.account_name || "—")}</span>
                         </div>
                     </div>
-                `;
+
+                    ${ivaPill}
+
+                    ${itemsBlock}
+
+                    <div class="flex flex-col gap-2 pt-3">
+                        <a
+                            href="/budget/transactions"
+                            class="block w-full text-center bg-brand-coral-deep text-white px-4 py-3 rounded-xl font-semibold press"
+                        >
+                            ${lang === "es" ? "✓ Listo, guardar" : "✓ Looks good — save"}
+                        </a>
+                        <div class="flex gap-2">
+                            <a
+                                href="/budget/transactions/${esc(body.transaction_id || "")}"
+                                class="flex-1 text-center bg-brand-cream-deep text-brand-ink px-4 py-3 rounded-xl font-semibold border border-brand-ink/10 press"
+                            >
+                                ${lang === "es" ? "Editar" : "Edit"}
+                            </a>
+                            <button
+                                id="del-tx"
+                                type="button"
+                                class="flex-1 text-center bg-brand-cream-deep text-brand-ink px-4 py-3 rounded-xl font-semibold border border-brand-ink/10 press"
+                            >
+                                ${lang === "es" ? "Borrar y re-escanear" : "Delete & re-scan"}
+                            </button>
+                        </div>
+                    </div>
+                </div>`;
+            confirmCard.classList.remove("hidden");
+
+            // Hide CTAs once the card is visible
+            const actions = document.getElementById("scan-actions");
+            if (actions) actions.classList.add("hidden");
+
+            const delBtn = document.getElementById("del-tx");
+            if (delBtn) {
+                delBtn.onclick = async () => {
+                    if (!body.transaction_id) {
+                        window.location.reload();
+                        return;
+                    }
+                    try {
+                        await fetch(`/api/budget/transactions/${body.transaction_id}`, {
+                            method: "DELETE",
+                            headers: { "Authorization": `Bearer ${token}` },
+                        });
+                    } catch (_) {
+                        // swallow — reload regardless so user can re-try
+                    }
+                    window.location.reload();
+                };
+            }
+        }
+
+        // ── Duplicate modal: open original or force-save through ──────────────
+        function showDupModal(file, body) {
+            const dup = body.dup_warning || {};
+            const ccy = (body.transaction && body.transaction.currency) || "MXN";
+            dupModal.innerHTML = `
+                <form method="dialog" class="bg-brand-cream rounded-2xl shadow-[var(--shadow-card)] border border-brand-ink/10 p-5 space-y-3 max-w-sm mx-auto">
+                    <h3 class="text-lg font-display font-extrabold text-brand-ink">
+                        ${lang === "es" ? "⚠ Ya escaneado" : "⚠ Already scanned"}
+                    </h3>
+                    <p class="text-sm text-brand-ink-soft">
+                        ${esc(dup.payee || (lang === "es" ? "Comercio" : "Merchant"))} ·
+                        ${money(dup.amount_cents, ccy)} ·
+                        ${esc(timeAgo(dup.scanned_at, lang))}
+                    </p>
+                    <div class="flex gap-2 justify-end pt-2">
+                        <a
+                            href="/budget/transactions/${esc(dup.existing_transaction_id || "")}"
+                            class="bg-brand-cream-deep text-brand-ink px-4 py-2 rounded-xl font-semibold border border-brand-ink/10 press"
+                        >
+                            ${lang === "es" ? "Ver original" : "Open original"}
+                        </a>
+                        <button
+                            id="force-save"
+                            type="button"
+                            class="bg-brand-coral-deep text-white px-4 py-2 rounded-xl font-semibold press"
+                        >
+                            ${lang === "es" ? "Guardar de todas formas" : "Save anyway"}
+                        </button>
+                    </div>
+                </form>`;
+            try {
+                dupModal.showModal();
+            } catch (_) {
+                // <dialog> not supported — fall back to inline render
+                dupModal.classList.remove("hidden");
             }
 
-            resultCard.innerHTML = `
-                <div class="flex items-center gap-3 mb-4">
-                    ${isSuccess
-                        ? `<div class="bg-brand-mint/20 rounded-full p-2">
-                               <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-brand-mint-deep" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
-                               </svg>
-                           </div>
-                           <div>
-                               <p class="font-bold text-brand-mint-deep">${t.success}</p>
-                               <p class="text-xs text-brand-ink-soft">${data.message || ''}</p>
-                           </div>`
-                        : `<div class="bg-brand-sun/20 rounded-full p-2">
-                               <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-yellow-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z" />
-                               </svg>
-                           </div>
-                           <div>
-                               <p class="font-bold text-brand-ink">${t.lowConfidence}</p>
-                               <p class="text-xs text-brand-ink-soft">${data.message || ''}</p>
-                           </div>`
+            const forceBtn = document.getElementById("force-save");
+            if (forceBtn) {
+                forceBtn.addEventListener("click", async (e) => {
+                    e.preventDefault();
+                    try { dupModal.close(); } catch (_) {}
+                    resetStages();
+                    overlay.classList.remove("hidden");
+                    const ticker = tickStages();
+                    try {
+                        const { body: r2 } = await scanReceipt(file, { force: true });
+                        clearInterval(ticker);
+                        overlay.classList.add("hidden");
+                        if (r2 && r2.success) {
+                            showConfirmCard(r2);
+                        } else {
+                            alert(lang === "es" ? "Error guardando." : "Save failed.");
+                        }
+                    } catch (_) {
+                        clearInterval(ticker);
+                        overlay.classList.add("hidden");
+                        alert(lang === "es" ? "Error guardando." : "Save failed.");
                     }
-                </div>
-
-                <div class="space-y-3">
-                    <div class="flex justify-between items-center">
-                        <span class="text-sm text-brand-ink-soft">${t.confidence}</span>
-                        <span class="text-sm font-bold px-2.5 py-0.5 rounded-full ${confidenceColor}">${confidence}%</span>
-                    </div>
-                    <div class="flex justify-between items-center">
-                        <span class="text-sm text-brand-ink-soft">${t.date}</span>
-                        <span class="text-sm font-medium text-brand-ink">${scanned.date || '—'}</span>
-                    </div>
-                    <div class="flex justify-between items-center">
-                        <span class="text-sm text-brand-ink-soft">${t.amount}</span>
-                        <span class="text-lg font-bold text-red-600">$${amount} ${scanned.currency || ''}</span>
-                    </div>
-                    <div class="flex justify-between items-center">
-                        <span class="text-sm text-brand-ink-soft">${t.payee}</span>
-                        <span class="text-sm font-medium text-brand-ink">${scanned.payee_name || '—'}</span>
-                    </div>
-                </div>
-
-                ${itemsHtml}
-            `;
+                });
+            }
         }
+
+        // ── Wire up the inputs ────────────────────────────────────────────────
+        camInput.addEventListener("change", (e) => {
+            const f = e.target && e.target.files && e.target.files[0];
+            if (f) runScan(f);
+        });
+        upInput.addEventListener("change", (e) => {
+            const f = e.target && e.target.files && e.target.files[0];
+            if (f) runScan(f);
+        });
     });
 </script>

--- a/frontend/src/pages/notifications.astro
+++ b/frontend/src/pages/notifications.astro
@@ -143,6 +143,6 @@ const iconFor = (type: string): string => {
             )}
         </main>
 
-        <BottomNav active="tasks" role={user.role} lang={lang} />
+        <BottomNav active="notifications" role={user.role} lang={lang} />
     </div>
 </Layout>

--- a/frontend/src/pages/parent/frankie.astro
+++ b/frontend/src/pages/parent/frankie.astro
@@ -80,7 +80,7 @@ const labels = {
                     <option value="claude-sonnet">🧠 Claude Sonnet — smarter, slower</option>
                     <option value="gpt-4o">🟢 GPT-4o</option>
                     <option value="gemini-2.5-flash">💎 Gemini 2.5 Flash</option>
-                    <option value="gemma3">🖥️ Gemma 3 4B — local GPU, free</option>
+                    <option value="qwen3">🖥️ Qwen 2.5 3B — local GPU, free</option>
                 </select>
             </div>
         </header>
@@ -143,8 +143,8 @@ const labels = {
 
         // Restore persisted model choice (migrate deprecated qwen-coder → mistral-nemo)
         let savedModel = localStorage.getItem("jarvis-model") || "claude-haiku";
-        if (savedModel === "qwen-coder" || savedModel === "mistral-nemo") {
-            savedModel = "gemma3";
+        if (["qwen-coder", "mistral-nemo", "gemma3"].includes(savedModel)) {
+            savedModel = "qwen3";
             localStorage.setItem("jarvis-model", savedModel);
         }
         if (modelSelect) {

--- a/frontend/src/pages/parent/frankie.astro
+++ b/frontend/src/pages/parent/frankie.astro
@@ -223,13 +223,23 @@ const labels = {
                         } else if (event === "reply") {
                             pending?.classList.add("hidden");
                             if (scroll) {
+                                const MODEL_META: Record<string, {label: string; icon: string; color: string}> = {
+                                    "claude-haiku":     { label: "Claude Haiku",       icon: "⚡", color: "bg-orange-100 text-orange-700" },
+                                    "claude-sonnet":    { label: "Claude Sonnet",      icon: "🧠", color: "bg-violet-100 text-violet-700" },
+                                    "gpt-4o":           { label: "GPT-4o",             icon: "🟢", color: "bg-green-100 text-green-700" },
+                                    "gemini-2.5-flash": { label: "Gemini 2.5 Flash",   icon: "💎", color: "bg-sky-100 text-sky-700" },
+                                    "qwen3":            { label: "Qwen 2.5 3B · GPU",  icon: "🖥️", color: "bg-gray-100 text-gray-600" },
+                                };
                                 const bot = document.createElement("div");
-                                bot.className = "flex justify-start";
+                                bot.className = "flex justify-start flex-col gap-1";
                                 const actions: string[] = Array.isArray(payload.actions) ? payload.actions : liveActions;
                                 const actionBadges = actions.length
                                     ? `<div class="mt-2 flex flex-wrap gap-1">${actions.map(() => `<span class="text-[10px] font-bold px-2 py-0.5 rounded-full bg-violet-100 text-violet-700"></span>`).join("")}</div>`
                                     : "";
-                                bot.innerHTML = `<div class="max-w-[80%] rounded-2xl px-4 py-2.5 text-sm bg-brand-cream border border-brand-ink/10 text-brand-ink"><p class="whitespace-pre-wrap"></p>${actionBadges}</div>`;
+                                const modelKey = payload.model ?? selectedModel;
+                                const meta = MODEL_META[modelKey] ?? { label: modelKey, icon: "🤖", color: "bg-gray-100 text-gray-600" };
+                                const modelCard = `<div class="flex items-center gap-1 pl-1"><span class="text-[10px] font-semibold px-2 py-0.5 rounded-full ${meta.color}">${meta.icon} ${meta.label}</span></div>`;
+                                bot.innerHTML = `<div class="max-w-[80%] rounded-2xl px-4 py-2.5 text-sm bg-brand-cream border border-brand-ink/10 text-brand-ink"><p class="whitespace-pre-wrap"></p>${actionBadges}</div>${modelCard}`;
                                 (bot.querySelector("p") as HTMLElement).textContent = payload.reply ?? "";
                                 bot.querySelectorAll("span.bg-violet-100").forEach((el, i) => {
                                     (el as HTMLElement).textContent = "⚡ " + actions[i];

--- a/frontend/src/pages/parent/settings/a2a.astro
+++ b/frontend/src/pages/parent/settings/a2a.astro
@@ -1,0 +1,69 @@
+---
+import Layout from "@layouts/Layout.astro";
+import BottomNav from "@components/BottomNav.astro";
+import DrawerMenu from "@components/DrawerMenu.astro";
+import { apiFetch } from "@lib/api";
+
+const token = Astro.cookies.get("access_token")?.value;
+if (!token) return Astro.redirect("/login");
+const lang = (Astro.cookies.get("lang")?.value ?? "en") as "en" | "es";
+const { data: user } = await apiFetch<any>("/api/auth/me", { token });
+if (user?.role !== "parent") return Astro.redirect("/dashboard");
+const { data: cfg } = await apiFetch<any>("/api/budget/a2a-webhook", { token });
+---
+
+<Layout title={lang === "es" ? "Agente de precios" : "Price Agent"} lang={lang}>
+  <DrawerMenu lang={lang} />
+  <main class="px-4 pb-32 pt-6 max-w-md mx-auto">
+    <h1 class="text-2xl font-display mb-4">{lang === "es" ? "Agente de precios" : "Price Agent"}</h1>
+
+    <form id="form" class="card p-4 space-y-3">
+      <label class="block">
+        <span class="text-sm">URL</span>
+        <input id="url" type="url" required pattern="https://.*"
+               value={cfg?.url ?? ""} class="brand-input w-full" />
+      </label>
+      <label class="flex items-center gap-2">
+        <input id="enabled" type="checkbox" checked={cfg?.enabled} />
+        <span>{lang === "es" ? "Activo" : "Enabled"}</span>
+      </label>
+      <label class="flex items-center gap-2">
+        <input id="rotate" type="checkbox" />
+        <span>{lang === "es" ? "Rotar secreto" : "Rotate secret"}</span>
+      </label>
+      <div class="text-xs text-fg/60">
+        {lang === "es" ? "Último éxito" : "Last success"}: {cfg?.last_success_at ?? "—"}<br/>
+        {lang === "es" ? "Fallas" : "Failures"}: {cfg?.failure_count ?? 0}
+      </div>
+      <button class="brand-btn brand-btn-primary w-full">
+        {lang === "es" ? "Guardar" : "Save"}
+      </button>
+      <pre id="secret-out" class="hidden text-xs bg-fg/5 p-2 rounded"></pre>
+    </form>
+  </main>
+  <BottomNav lang={lang} active="parent" />
+</Layout>
+
+<script type="module" define:vars={{ token, lang }}>
+  document.getElementById("form").addEventListener("submit", async (e) => {
+    e.preventDefault();
+    const resp = await fetch("/api/budget/a2a-webhook", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json",
+                 "Authorization": `Bearer ${token}` },
+      body: JSON.stringify({
+        url: document.getElementById("url").value,
+        enabled: document.getElementById("enabled").checked,
+        rotate_secret: document.getElementById("rotate").checked,
+      }),
+    });
+    const body = await resp.json();
+    if (body.secret) {
+      const out = document.getElementById("secret-out");
+      out.classList.remove("hidden");
+      out.textContent = (lang === "es" ? "Secreto nuevo (cópialo): " : "New secret (copy now): ") + body.secret;
+    } else {
+      alert(lang === "es" ? "Guardado." : "Saved.");
+    }
+  });
+</script>

--- a/scripts/deploy-gcp.sh
+++ b/scripts/deploy-gcp.sh
@@ -328,6 +328,19 @@ verify() {
         fi
     done
 
+    info "Nav sanity check (Inbox + Chat links in SSR bundle)…"
+    NAV_BUNDLE=$(gssh "sudo docker exec gcp_family_frontend grep -rl 'href=\"/notifications\"' /app/dist/server/ 2>/dev/null | head -1")
+    if [[ -n "$NAV_BUNDLE" ]]; then
+        CHAT_OK=$(gssh "sudo docker exec gcp_family_frontend grep -c 'href=\"/chat\"' '$NAV_BUNDLE' 2>/dev/null || echo 0")
+        if [[ "$CHAT_OK" -gt 0 ]]; then
+            success "Nav SSR bundle has /notifications and /chat ✅"
+        else
+            warning "Nav sanity FAILED — /chat missing from $NAV_BUNDLE — stale Docker image, rebuild required"
+        fi
+    else
+        warning "Nav sanity FAILED — /notifications not found in /app/dist/server/ — stale Docker image, rebuild required"
+    fi
+
     info "Container status:"
     gssh "cd $REMOTE_PATH && sudo docker compose --env-file .env -f $COMPOSE_FILE ps"
 }


### PR DESCRIPTION
## Summary

Receipt Scanner v2 — rebuilds the receipt scanner from a "snap-then-fill-a-form" flow into a one-tap snap-and-confirm experience with full server-side automation.

- **One-tap UX**: snap → 7-stage server pipeline → confirm card with merchant, total, FX line, matched account, IVA pill, items + price-trend badges. No pre-pick account dropdown.
- **First-class items**: new `budget_transaction_items` table makes line items queryable for per-item categorization, price-trend lookup, and external feed to a price-comparison agent.
- **Account auto-detect**: receipts that print the card last-4 auto-match to the right account; falls back to last-used family transaction.
- **Duplicate guard**: same-payee same-amount within 60s returns 409 with a "save anyway" override (`?force=true`).
- **FX cross-charge** (Pro): USD receipt on MXN account stores fx_rate + original_amount + original_currency; non-Pro routes currency-mismatch scans to HITL.
- **IVA breakout**: tax line extracted and stored as `iva_cents` on the transaction.
- **A2A webhook** (Plus/Pro): per-family HMAC-signed POST of each scanned receipt to an external price agent, with 5x exponential-backoff retry log and `/api/internal/a2a/retry` sweep endpoint (cron-driven).
- **Item history**: `/budget/items/[normalized_name]` page shows every past occurrence + 90d trend.
- **Settings**: `/parent/settings/a2a` for the webhook config with rotate-once-reveal of the secret.

## Architecture

Single Alembic migration `wave4_scanner_v2` adds 3 tables (`budget_transaction_items`, `family_a2a_webhooks`, `a2a_webhook_deliveries`) + 6 columns (`card_last4`, `iva_cents`, `fx_rate`, `original_amount_cents`, `original_currency` on `budget_transactions`; `card_last4` on `budget_accounts` with backfill from existing account names like `**9222`, `terminada en 1234`, `XXXX1234`). 5 new services (`FXService`, `TransactionItemService`, `AccountMatchingService`, `DuplicateGuardService`, `A2AWebhookService`); existing scanner service rewritten with the 7 stages; existing `/scan-receipt` endpoint gains optional `account_id` + `force` params and returns 409 on duplicate detection.

Premium flags: `a2a_webhook` (Plus+), `item_trends` (Plus+), `fx_cross_charge` (Pro). Free users with currency-mismatched receipts are routed to the HITL drafts queue.

## Spec & plan

- Spec: `docs/superpowers/specs/2026-05-28-receipt-scanner-v2-design.md`
- Plan: `docs/superpowers/plans/2026-05-28-receipt-scanner-v2.md`

## Test plan

- [x] Backend `pytest tests/test_receipt_scanner_v2.py` — 8/8 pass (vision parsing + 4 pipeline integration + 3 endpoint)
- [x] Backend `pytest tests/test_a2a_webhook_service.py` — 12/12 (service + retry sweep + endpoint + token guard)
- [x] Backend `pytest tests/test_transaction_item_service.py` — 7/7 (normalize + bulk_create + trend + list endpoint)
- [x] Backend `pytest tests/test_account_matching_service.py` — 7/7 (card_last4 + currency tiebreaker + last-used + override + closed-account exclusion)
- [x] Backend `pytest tests/test_duplicate_guard_service.py` — 4/4 (60s window, 1% tolerance, tenant isolation)
- [x] Backend `pytest tests/test_fx_service.py` — 3/3 (same-currency, cache hit/miss, HTTP failure)
- [x] Backend `pytest tests/test_premium_v2.py` — 3/3 (free blocks a2a, pro allows fx, currency-mismatch routes free user to drafts)
- [x] Backend `pytest tests/test_wave4_scanner_v2_migration.py` — 3/3 (tables + cols + card_last4 backfill regex)
- [x] Backend `pytest tests/test_receipt_scanner.py` — 12/12 (v1 regression suite intact)
- [x] Backend `pytest tests/test_categorization_rule_service.py` — 47/47 (after extending `suggest_category` with `item_name`)
- [x] Wider sweep: 611 backend tests passing
- [x] Frontend `astro check` — zero new errors in scanner v2 files
- [x] Live deploy to `https://gcp-family.agent-ia.mx` — migration ran, all containers healthy, public endpoints 200, `/budget/scan-receipt` redirects unauthed users
- [x] `POST /api/internal/a2a/retry` verified live (returns `{"processed":0}` with valid token)
- [x] Cron `*/5 * * * *` installed on `family-app` VM (uses python urllib since backend image has no curl)
- [ ] End-to-end: scan a real Mexican supermarket receipt from a phone to verify camera capture + auto account-detect on prod (manual)

## Follow-ups (tracked, none blocking merge)

- `BudgetTransaction.created_by_id` missing — per-user last-used fallback degrades to family-wide. Add column in a future migration.
- Webhook payload `category` field carries `category_id` UUID; spec example shows category name. Decide once external agent contract is finalized.
- 4 Playwright tests scaffolded as `test.skip` pending mock-layer; backend API tests cover the logic.
- CLAUDE.md stale: claims project `agentia-prod-497016`/VM `agentia-family-hub`. Actual is `family-prod`/`family-app`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)