### PR TITLE
feat(budget): show price comparison panel on transaction detail

### DIFF
--- a/backend/app/api/routes/budget/__init__.py
+++ b/backend/app/api/routes/budget/__init__.py
@@ -5,7 +5,7 @@ API endpoints for budget management.
 """
 
 from fastapi import APIRouter
-from app.api.routes.budget import categories, accounts, transactions, allocations, payees, month, transfers, reports, categorization_rules, goals, recurring_transactions, months, recycle_bin, saved_filters, tags, export, custom_reports, receipt_drafts, items, a2a_webhook as _a2a
+from app.api.routes.budget import categories, accounts, transactions, allocations, payees, month, transfers, reports, categorization_rules, goals, recurring_transactions, months, recycle_bin, saved_filters, tags, export, custom_reports, receipt_drafts, items, a2a_webhook as _a2a, price_comparison as _price_comparison
 
 router = APIRouter()
 
@@ -30,5 +30,10 @@ router.include_router(custom_reports.router, prefix="/custom-reports", tags=["bu
 router.include_router(receipt_drafts.router, prefix="/receipt-drafts", tags=["budget-receipt-drafts"])
 router.include_router(items.router, prefix="/items", tags=["budget-items"])
 router.include_router(_a2a.router, prefix="/a2a-webhook", tags=["budget-a2a"])
+router.include_router(
+    _price_comparison.router,
+    prefix="/price-comparison",
+    tags=["budget-price-comparison"],
+)
 
 __all__ = ["router"]

--- a/backend/app/api/routes/budget/price_comparison.py
+++ b/backend/app/api/routes/budget/price_comparison.py
@@ -1,0 +1,74 @@
+"""Server-side proxy to the price-checker agent's read endpoint.
+
+Signs the outbound request with the family's webhook secret. The secret
+stays in the FastAPI process — Astro and the browser never see it.
+"""
+
+import hashlib
+import hmac
+import logging
+import os
+from uuid import UUID
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_db
+from app.core.dependencies import get_current_user
+from app.core.type_utils import to_uuid_required
+from app.models import User
+from app.services.budget.a2a_webhook_service import A2AWebhookService
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+PRICE_CHECKER_URL = os.environ.get(
+    "PRICE_CHECKER_URL", "https://price-checker.agent-ia.mx"
+)
+TIMEOUT_SECONDS = 10.0
+
+
+@router.get("/{transaction_id}")
+async def get_comparison(
+    transaction_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    family_id = to_uuid_required(current_user.family_id)
+    cfg = await A2AWebhookService.get_config(db, family_id)
+    if cfg is None or not cfg.enabled:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND,
+            "no a2a webhook configured for this family",
+        )
+
+    tx_str = str(transaction_id)
+    sig = "sha256=" + hmac.new(
+        cfg.secret.encode("utf-8"), tx_str.encode("utf-8"), hashlib.sha256
+    ).hexdigest()
+
+    url = f"{PRICE_CHECKER_URL}/v1/receipts/{tx_str}/comparisons"
+    try:
+        async with httpx.AsyncClient(timeout=TIMEOUT_SECONDS) as client:
+            resp = await client.get(url, headers={
+                "X-A2A-Family": str(family_id),
+                "X-A2A-Signature": sig,
+            })
+    except httpx.HTTPError as exc:
+        logger.warning("price-checker unreachable: %s", exc)
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            "price-checker temporarily unreachable",
+        )
+
+    if resp.status_code == 404:
+        raise HTTPException(404, "no comparisons yet")
+    if resp.status_code >= 400:
+        logger.warning("price-checker returned %d: %s",
+                       resp.status_code, resp.text[:200])
+        raise HTTPException(
+            status.HTTP_502_BAD_GATEWAY,
+            "price-checker upstream error",
+        )
+    return resp.json()

--- a/backend/tests/test_price_comparison_proxy.py
+++ b/backend/tests/test_price_comparison_proxy.py
@@ -1,0 +1,101 @@
+"""Tests for the price-comparison proxy: backend signs server-side,
+forwards to the price-checker, secret never reaches the browser."""
+
+import hashlib
+import hmac
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Patch target: the httpx.AsyncClient used inside the route module
+_PATCH_TARGET = "app.api.routes.budget.price_comparison.httpx.AsyncClient"
+
+
+def _make_mock_client(status_code: int, body: dict, captured: dict | None = None):
+    """Return a mock AsyncClient context manager that records outbound calls."""
+    mock_resp = MagicMock()
+    mock_resp.status_code = status_code
+    mock_resp.json = MagicMock(return_value=body)
+    mock_resp.text = ""
+
+    async def fake_get(url, headers=None, **kw):
+        if captured is not None:
+            captured["url"] = url
+            captured["headers"] = dict(headers or {})
+        return mock_resp
+
+    mock_client_instance = MagicMock()
+    mock_client_instance.get = fake_get
+    mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+    mock_client_instance.__aexit__ = AsyncMock(return_value=False)
+
+    mock_cls = MagicMock(return_value=mock_client_instance)
+    return mock_cls
+
+
+@pytest.mark.asyncio
+async def test_proxy_signs_with_family_secret_and_forwards(
+    client, auth_headers, db_session, test_family,
+):
+    """Backend should sign the transaction_id with the family's webhook
+    secret and forward to the price-checker, then return the upstream body."""
+    from app.models.a2a import FamilyA2AWebhook
+
+    db_session.add(FamilyA2AWebhook(
+        family_id=test_family.id, url="https://x", secret="topsecret", enabled=True,
+    ))
+    await db_session.commit()
+
+    tx_id = "11111111-1111-1111-1111-111111111111"
+    upstream_body = {"transaction_id": tx_id, "city": "Monterrey", "items": []}
+
+    captured = {}
+    mock_cls = _make_mock_client(200, upstream_body, captured)
+
+    with patch(_PATCH_TARGET, new=mock_cls):
+        r = await client.get(
+            f"/api/budget/price-comparison/{tx_id}",
+            headers=auth_headers,
+        )
+
+    assert r.status_code == 200, f"status={r.status_code} body={r.text}"
+    assert r.json() == upstream_body
+    assert tx_id in captured.get("url", ""), f"captured={captured}"
+    expected_sig = "sha256=" + hmac.new(
+        b"topsecret", tx_id.encode(), hashlib.sha256
+    ).hexdigest()
+    got_headers = captured.get("headers", {})
+    assert got_headers.get("X-A2A-Signature") == expected_sig, f"headers={got_headers}"
+    assert got_headers.get("X-A2A-Family") == str(test_family.id)
+
+
+@pytest.mark.asyncio
+async def test_proxy_404_when_no_webhook(
+    client, auth_headers, db_session, test_family,
+):
+    tx_id = "11111111-1111-1111-1111-111111111111"
+    r = await client.get(
+        f"/api/budget/price-comparison/{tx_id}",
+        headers=auth_headers,
+    )
+    assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_proxy_passes_through_upstream_404(
+    client, auth_headers, db_session, test_family,
+):
+    from app.models.a2a import FamilyA2AWebhook
+    db_session.add(FamilyA2AWebhook(
+        family_id=test_family.id, url="https://x", secret="s", enabled=True,
+    ))
+    await db_session.commit()
+
+    mock_cls = _make_mock_client(404, {"detail": "no comparisons yet"})
+
+    with patch(_PATCH_TARGET, new=mock_cls):
+        r = await client.get(
+            f"/api/budget/price-comparison/11111111-1111-1111-1111-111111111111",
+            headers=auth_headers,
+        )
+    assert r.status_code == 404

--- a/frontend/src/pages/budget/transactions.astro
+++ b/frontend/src/pages/budget/transactions.astro
@@ -370,6 +370,16 @@ const categoriesJson = JSON.stringify(allCategoriesForEdit);
 
                     <div id="edit-error" class="hidden text-sm text-red-600 mb-3 px-1"></div>
 
+                    <!-- Price Comparison Panel -->
+                    <section id="price-comparison-panel" class="mt-6 mb-4 hidden" data-tx="">
+                        <h2 class="text-base font-display font-extrabold text-brand-ink mb-2">
+                            {lang === "es" ? "Comparación de precios" : "Price comparison"}
+                        </h2>
+                        <div id="pc-content" class="text-sm text-brand-ink-soft">
+                            {lang === "es" ? "Cargando…" : "Loading…"}
+                        </div>
+                    </section>
+
                     <div class="flex gap-3">
                         <button id="edit-cancel-btn" class="flex-1 py-3 bg-brand-cream-deep hover:bg-brand-cream-deep text-brand-ink font-semibold rounded-xl transition">
                             {es ? "Cancelar" : "Cancel"}
@@ -615,5 +625,129 @@ document.addEventListener("astro:after-swap", initFilters);
     document.addEventListener("astro:after-swap", () => {
         initEditModal();
     });
+})();
+</script>
+
+<script define:vars={{ lang }}>
+(function initPriceComparison() {
+    function attachPriceComparison() {
+        const modal = document.getElementById("edit-modal");
+        const panel = document.getElementById("price-comparison-panel");
+        const out = document.getElementById("pc-content");
+        if (!modal || !panel || !out) return;
+
+        // Observe when the modal slides into view by watching for class removal
+        document.querySelectorAll(".tx-row").forEach((row) => {
+            row.addEventListener("click", async () => {
+                const txId = row.dataset.txId;
+                if (!txId) return;
+
+                panel.dataset.tx = txId;
+                panel.classList.remove("hidden");
+                out.textContent = lang === "es" ? "Cargando…" : "Loading…";
+
+                try {
+                    const r = await fetch(`/api/budget/price-comparison/${txId}`, {
+                        credentials: "include",
+                    });
+                    if (r.status === 404) {
+                        out.textContent = lang === "es"
+                            ? "Pendiente — revisa en 5 minutos."
+                            : "Pending — check back in 5 min.";
+                        return;
+                    }
+                    if (!r.ok) {
+                        out.textContent = lang === "es"
+                            ? "No disponible por ahora."
+                            : "Not available right now.";
+                        return;
+                    }
+                    const data = await r.json();
+                    const items = Array.isArray(data.items) ? data.items : [];
+                    if (!items.length) {
+                        out.textContent = lang === "es" ? "Sin artículos." : "No items.";
+                        return;
+                    }
+
+                    out.innerHTML = "";
+                    const list = document.createElement("ul");
+                    list.className = "space-y-3 divide-y divide-brand-ink/10";
+                    for (const it of items) {
+                        const li = document.createElement("li");
+                        li.className = "pt-3 first:pt-0";
+
+                        const head = document.createElement("div");
+                        head.className = "flex justify-between items-baseline";
+                        const name = document.createElement("span");
+                        name.className = "font-semibold text-brand-ink";
+                        name.textContent = it.item_name || it.normalized_name || "?";
+                        const paid = document.createElement("span");
+                        paid.className = "text-brand-ink-soft text-xs";
+                        paid.textContent = `$${(it.line_total_cents / 100).toFixed(2)} MXN`;
+                        head.append(name, paid);
+                        li.append(head);
+
+                        if (it.status === "done" && it.cheapest) {
+                            const row2 = document.createElement("div");
+                            row2.className = "mt-1 text-xs";
+                            const savings = it.cheapest.savings_cents;
+                            const verb = savings > 0
+                                ? (lang === "es" ? "ahorras" : "save")
+                                : (lang === "es" ? "ya tienes el mejor precio" : "you have the best price");
+                            const text = savings > 0
+                                ? `${it.cheapest.store}: $${it.cheapest.price_mxn} MXN — ${verb} $${(savings / 100).toFixed(2)}`
+                                : `${it.cheapest.store}: $${it.cheapest.price_mxn} MXN — ${verb}`;
+                            row2.textContent = text;
+                            if (it.cheapest.url) {
+                                const a = document.createElement("a");
+                                a.href = it.cheapest.url;
+                                a.target = "_blank";
+                                a.rel = "noopener";
+                                a.className = "ml-2 underline text-brand-coral-deep";
+                                a.textContent = lang === "es" ? "Ver →" : "View →";
+                                row2.append(a);
+                            }
+                            li.append(row2);
+                        } else if (it.status === "pending") {
+                            const row2 = document.createElement("div");
+                            row2.className = "mt-1 text-xs text-brand-ink-soft";
+                            row2.textContent = lang === "es" ? "Comparando…" : "Comparing…";
+                            li.append(row2);
+                        } else {
+                            const row2 = document.createElement("div");
+                            row2.className = "mt-1 text-xs text-brand-ink-soft";
+                            row2.textContent = lang === "es"
+                                ? "Sin datos disponibles."
+                                : "No data available.";
+                            li.append(row2);
+                        }
+
+                        list.append(li);
+                    }
+                    out.innerHTML = "";
+                    out.append(list);
+                } catch (e) {
+                    out.textContent = lang === "es"
+                        ? "Error cargando comparación."
+                        : "Error loading comparison.";
+                }
+            });
+        });
+
+        // Hide panel when modal closes
+        const cancelBtn = document.getElementById("edit-cancel-btn");
+        const backdrop = document.getElementById("edit-backdrop");
+        function hidePanel() {
+            panel.classList.add("hidden");
+            panel.dataset.tx = "";
+            if (out) out.textContent = "";
+        }
+        cancelBtn?.addEventListener("click", hidePanel);
+        backdrop?.addEventListener("click", hidePanel);
+    }
+
+    attachPriceComparison();
+    document.addEventListener("astro:after-swap", attachPriceComparison);
+    document.addEventListener("astro:page-load", attachPriceComparison);
 })();
 </script>


### PR DESCRIPTION
## Summary

Companion to platform PR (price-checker receipt comparison worker). Wires the family-task-manager UI to display per-item price comparisons computed by the on-prem agent.

- `backend/app/api/routes/budget/price_comparison.py` — server-side proxy. Signs the outbound request with the family's webhook secret (the secret stays in FastAPI; Astro and the browser never see it). Forwards to `https://price-checker.agent-ia.mx/v1/receipts/{tx_id}/comparisons`.
- Transaction detail panel — lazy-loads when a row is opened. Shows per-item: line total, cheapest alternative store + price + savings + link.

## Test plan

- [x] 3 backend proxy tests (signs + forwards; 404 when no webhook; passes through upstream 404)
- [x] Astro check clean for transactions.astro
- [ ] Post-merge: open https://gcp-family.agent-ia.mx/budget/transactions, click a transaction, verify panel renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)