### PR TITLE
fix(frontend): dispatch astro:page-load on DOMContentLoaded, not bare rAF

### DIFF
--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -81,10 +81,23 @@ const bannerCopy = {
 
     <script define:vars={{ sentLabel: bannerCopy.sent, resendLabel: bannerCopy.resend }}>
         // ClientRouter removed — dispatch astro:page-load once on initial load.
-        // rAF ensures all module scripts have registered their listeners first.
-        requestAnimationFrame(() => {
-            document.dispatchEvent(new Event('astro:page-load'));
-        });
+        // Must fire AFTER deferred/module page scripts have executed and
+        // registered their listeners. Hoisted Astro scripts (any <script>
+        // with an import) ship as async-fetched `type=module` bundles, so a
+        // bare requestAnimationFrame can race ahead of them and the one-shot
+        // event gets missed (symptom: buttons whose handlers live in those
+        // bundles "do nothing"). DOMContentLoaded is the correct barrier —
+        // deferred + module scripts are guaranteed to have run by then.
+        (function firePageLoadOnce() {
+            var fire = function () {
+                document.dispatchEvent(new Event('astro:page-load'));
+            };
+            if (document.readyState === 'loading') {
+                document.addEventListener('DOMContentLoaded', fire, { once: true });
+            } else {
+                fire();
+            }
+        })();
 
         document.addEventListener('astro:page-load', () => {
             (async () => {


### PR DESCRIPTION
## The actual bug behind "Invite button does nothing"

Not email-related (that was a separate, already-fixed issue). The Invite-member button — and any control whose handler lives in a hoisted Astro script — silently did nothing on click.

## Root cause

ClientRouter was removed; `Layout.astro` synthesises a **one-shot** `astro:page-load` so existing handlers keep working. It fired via a bare `requestAnimationFrame`.

Hoisted Astro scripts (any `<script>` with an `import`, e.g. `members.astro`'s invite-modal opener) ship as **async-fetched `type=module` bundles**. rAF can fire the one-shot event *before* those bundles download + execute, so their `addEventListener('astro:page-load', …)` runs after the event already dispatched → the handler never binds. Confirmed against deployed HTML (external `<script type=module src>` + inline rAF dispatch). The Layout's own inline verify-banner handler survived because it registers synchronously — which is why the bug looked button-specific.

## Fix

Gate the dispatch on `DOMContentLoaded` (immediate fallback if already past it). Deferred + module scripts are guaranteed executed by `DOMContentLoaded`, so every handler is bound before the event fires. One change in `Layout.astro`, fixes every `astro:page-load` handler app-wide.

## Verification

Deployed to prod and driven with a real browser (throwaway parent account, cleaned up after): clicking **Invite** on `/parent/members` removes `hidden`, modal computes `display:flex`, title "Invite to family", 0 console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)