### PR TITLE
feat(invitations): pending list with resend + cancel

### DIFF
--- a/backend/app/api/routes/invitations.py
+++ b/backend/app/api/routes/invitations.py
@@ -212,3 +212,32 @@ async def cancel_invitation(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e)
         )
+
+
+@router.post("/{family_id}/{invitation_id}/resend", response_model=InvitationResponse)
+async def resend_invitation(
+    invitation_id: UUID,
+    family_id: UUID = Depends(verify_family_id),
+    current_user: User = Depends(require_parent_role),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Re-send a pending invitation email and refresh its expiry (parent only).
+    """
+    try:
+        invitation = await InvitationService.resend_invitation(
+            db,
+            invitation_id,
+            family_id,
+            base_url=settings.email_link_base,
+            fallback_user=current_user,
+        )
+        await db.commit()
+        return invitation
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e)
+        )

--- a/backend/app/services/invitation_service.py
+++ b/backend/app/services/invitation_service.py
@@ -192,6 +192,65 @@ class InvitationService:
         return invitations
 
     @staticmethod
+    async def resend_invitation(
+        db: AsyncSession,
+        invitation_id: UUID,
+        family_id: UUID,
+        base_url: str = "",
+        fallback_user: User | None = None,
+    ) -> FamilyInvitation:
+        """
+        Re-send the email for a pending invitation and refresh its expiry.
+
+        Args:
+            db: Database session
+            invitation_id: Invitation to resend
+            family_id: Family ID (authorization scope)
+            base_url: Frontend origin for the acceptance link
+            fallback_user: Used as the "invited by" sender if the original
+                inviter can no longer be found
+
+        Returns:
+            The (expiry-refreshed) invitation
+
+        Raises:
+            NotFoundException: If invitation not found
+            ValidationException: If invitation is not pending
+        """
+        invitation = (await db.execute(
+            select(FamilyInvitation).where(
+                FamilyInvitation.id == invitation_id,
+                FamilyInvitation.family_id == family_id
+            )
+        )).scalar_one_or_none()
+
+        if not invitation:
+            raise NotFoundException("Invitation not found")
+
+        if invitation.status != InvitationStatus.PENDING:
+            raise ValidationException("Only pending invitations can be resent")
+
+        # Refresh the window so a stale-but-pending invite is valid again.
+        invitation.expires_at = (
+            datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(days=30)
+        )
+        await db.flush()
+
+        inviter = (await db.execute(
+            select(User).where(User.id == invitation.invited_by_user_id)
+        )).scalar_one_or_none() or fallback_user
+
+        if inviter is not None:
+            await EmailService.send_invitation_email(
+                db=db,
+                invitation=invitation,
+                inviting_user=inviter,
+                base_url=base_url,
+            )
+
+        return invitation
+
+    @staticmethod
     async def cancel_invitation(
         db: AsyncSession,
         invitation_id: UUID,

--- a/backend/tests/test_invitations.py
+++ b/backend/tests/test_invitations.py
@@ -254,6 +254,42 @@ async def test_invitation_code_generation(client, test_family, test_parent_user,
 
 
 @pytest.mark.asyncio
+async def test_resend_invitation_success(
+    client, test_family, test_parent_user, db_session: AsyncSession, auth_headers
+):
+    """Resending a pending invitation returns 200 and refreshes its expiry."""
+    send = await client.post(
+        "/api/invitations/send",
+        json={"email": "resend-me@example.com", "family_id": str(test_family.id), "role": "parent"},
+        headers=auth_headers,
+    )
+    assert send.status_code == status.HTTP_201_CREATED
+    inv_id = send.json()["id"]
+    old_expiry = send.json()["expires_at"]
+
+    resp = await client.post(
+        f"/api/invitations/{test_family.id}/{inv_id}/resend",
+        headers=auth_headers,
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    body = resp.json()
+    assert body["id"] == inv_id
+    assert body["invited_email"] == "resend-me@example.com"
+    # expiry refreshed forward (or at least not earlier)
+    assert body["expires_at"] >= old_expiry
+
+
+@pytest.mark.asyncio
+async def test_resend_invitation_requires_auth(client, test_family):
+    """Resend requires authentication."""
+    import uuid
+    resp = await client.post(
+        f"/api/invitations/{test_family.id}/{uuid.uuid4()}/resend",
+    )
+    assert resp.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.asyncio
 async def test_invitation_email_link_uses_frontend_origin(
     test_family, test_parent_user, db_session: AsyncSession, monkeypatch
 ):

--- a/frontend/src/pages/api/invitations/[familyId]/[invitationId]/resend.ts
+++ b/frontend/src/pages/api/invitations/[familyId]/[invitationId]/resend.ts
@@ -1,0 +1,61 @@
+import type { APIRoute } from "astro";
+
+/**
+ * POST /api/invitations/:familyId/:invitationId/resend
+ * Re-sends a pending family invitation email (refreshes expiry).
+ * Requires authentication (parent only)
+ */
+export const POST: APIRoute = async ({ request, params, locals }) => {
+    try {
+        const token = locals.token;
+        if (!token) {
+            return new Response(
+                JSON.stringify({ detail: "Unauthorized" }),
+                { status: 401, headers: { "Content-Type": "application/json" } }
+            );
+        }
+
+        const familyId = params.familyId;
+        const invitationId = params.invitationId;
+
+        if (!familyId || !invitationId) {
+            return new Response(
+                JSON.stringify({ success: false, error: "family_id and invitation_id are required" }),
+                { status: 400, headers: { "Content-Type": "application/json" } }
+            );
+        }
+
+        const apiUrl = process.env.API_BASE_URL || "http://localhost:8002";
+        const response = await fetch(
+            `${apiUrl}/api/invitations/${familyId}/${invitationId}/resend`,
+            {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    "Authorization": `Bearer ${token}`,
+                },
+            }
+        );
+
+        const data = await response.json().catch(() => ({}));
+
+        if (response.ok) {
+            return new Response(
+                JSON.stringify({ success: true, data }),
+                { status: 200, headers: { "Content-Type": "application/json" } }
+            );
+        }
+
+        const errorMessage = data.detail || "Failed to resend invitation";
+        return new Response(
+            JSON.stringify({ success: false, error: errorMessage }),
+            { status: response.status, headers: { "Content-Type": "application/json" } }
+        );
+    } catch (e) {
+        console.error("Resend invitation error:", e);
+        return new Response(
+            JSON.stringify({ success: false, error: "An error occurred. Please try again." }),
+            { status: 500, headers: { "Content-Type": "application/json" } }
+        );
+    }
+};

--- a/frontend/src/pages/parent/members.astro
+++ b/frontend/src/pages/parent/members.astro
@@ -114,13 +114,14 @@ if (Astro.request.method === "POST") {
 const { data: family } = await apiFetch<any>("/api/families/me", { token });
 const members: any[] = family?.members ?? [];
 
-// Fetch pending invitations server-side
+// Fetch pending invitations server-side.
+// Backend route is path-param (/{family_id}/pending) and returns a plain list.
 const { data: pendingInvitationsResult, ok: pendingInvOk, error: pendingInvError } = await apiFetch<any>(
-  `/api/invitations/pending?family_id=${user.family_id}`,
+  `/api/invitations/${user.family_id}/pending`,
   { token }
 );
-const pendingInvitations: any[] = pendingInvOk && pendingInvitationsResult?.pending_invitations 
-  ? pendingInvitationsResult.pending_invitations 
+const pendingInvitations: any[] = pendingInvOk && Array.isArray(pendingInvitationsResult)
+  ? pendingInvitationsResult
   : [];
 if (!pendingInvOk && pendingInvError) {
   console.error("Error fetching pending invitations:", pendingInvError);
@@ -301,15 +302,24 @@ if (!joinCodeOk && joinCodeError) {
                         </span>
                       </div>
                     </div>
-                    <button
-                      onclick={`cancelInvitation('${inv.id}', '${lang}')`}
-                      class="ml-3 flex-shrink-0 p-2 text-red-600 hover:bg-red-100 rounded-lg transition-colors"
-                      title={lang === "es" ? "Cancelar invitación" : "Cancel invitation"}
-                    >
-                      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                      </svg>
-                    </button>
+                    <div class="ml-3 flex-shrink-0 flex items-center gap-1">
+                      <button
+                        onclick={`resendInvitation('${inv.id}', '${user.family_id}', '${lang}', this)`}
+                        class="px-3 py-1.5 text-xs font-semibold text-brand-sky-deep bg-brand-sky/15 hover:bg-brand-sky/30 rounded-lg transition-colors whitespace-nowrap"
+                        title={lang === "es" ? "Reenviar invitación" : "Resend invitation"}
+                      >
+                        {lang === "es" ? "Reenviar" : "Resend"}
+                      </button>
+                      <button
+                        onclick={`cancelInvitation('${inv.id}', '${user.family_id}', '${lang}')`}
+                        class="p-2 text-red-600 hover:bg-red-100 rounded-lg transition-colors"
+                        title={lang === "es" ? "Cancelar invitación" : "Cancel invitation"}
+                      >
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                 ))
               }
@@ -487,50 +497,50 @@ if (!joinCodeOk && joinCodeError) {
       }
     });
 
-    // Cancel pending invitation
-    (window as any).cancelInvitation = async (invitationId: string, lang = 'en') => {
+    // Cancel pending invitation. Auth rides the httpOnly cookie via
+    // credentials:'include' — the proxy reads it server-side (locals.token),
+    // so we must NOT try to read access_token from document.cookie here.
+    (window as any).cancelInvitation = async (invitationId: string, familyId: string, lang = 'en') => {
       if (!confirm(lang === "es" ? "¿Cancelar esta invitación?" : "Cancel this invitation?")) {
         return;
       }
-
       try {
-        // Get family_id from page context (it's in the hidden form data or we can extract from URL)
-        const familyIdEl = document.querySelector('input[name="family_id"]');
-        const familyId = (familyIdEl instanceof HTMLInputElement ? familyIdEl.value : null) ||
-                         window.location.pathname.split('/')[2]; // Fallback to extract from URL
-        
-        // Get token from localStorage or cookie
-        const token = document.cookie
-          .split('; ')
-          .find(row => row.startsWith('access_token='))
-          ?.split('=')[1];
-
-        if (!token) {
-          showToast(lang === "es" ? "Error de autenticación" : "Authentication error", 'error');
-          return;
-        }
-
         const response = await fetch(
           `/api/invitations/${familyId}/${invitationId}`,
-          {
-            method: "DELETE",
-            headers: {
-              "Content-Type": "application/json",
-            },
-            credentials: 'include'
-          }
+          { method: "DELETE", headers: { "Content-Type": "application/json" }, credentials: 'include' }
         );
-
         if (response.ok || response.status === 204) {
-          // Reload page to refresh the pending invitations list
           window.location.reload();
         } else {
-          const data = await response.json();
+          const data = await response.json().catch(() => ({}));
           showToast(data.error || (lang === "es" ? "Error al cancelar la invitación" : "Error canceling invitation"), 'error');
         }
       } catch (error) {
         console.error("Error canceling invitation:", error);
         showToast(lang === "es" ? "Error de conexión" : "Connection error", 'error');
+      }
+    };
+
+    // Resend pending invitation (refreshes expiry + re-sends the email).
+    (window as any).resendInvitation = async (invitationId: string, familyId: string, lang = 'en', btn?: HTMLButtonElement) => {
+      const original = btn?.textContent;
+      if (btn) { btn.disabled = true; btn.textContent = lang === "es" ? "Enviando…" : "Sending…"; }
+      try {
+        const response = await fetch(
+          `/api/invitations/${familyId}/${invitationId}/resend`,
+          { method: "POST", headers: { "Content-Type": "application/json" }, credentials: 'include' }
+        );
+        const data = await response.json().catch(() => ({}));
+        if (response.ok && data.success !== false) {
+          showToast(lang === "es" ? "Invitación reenviada" : "Invitation resent", 'success');
+        } else {
+          showToast(data.error || (lang === "es" ? "Error al reenviar la invitación" : "Error resending invitation"), 'error');
+        }
+      } catch (error) {
+        console.error("Error resending invitation:", error);
+        showToast(lang === "es" ? "Error de conexión" : "Connection error", 'error');
+      } finally {
+        if (btn) { btn.disabled = false; if (original) btn.textContent = original; }
       }
     };
     });


### PR DESCRIPTION
## What

Adds a working **Pending Invitations** section on `/parent/members`, each row with **Resend** and **Cancel** buttons.

## Why it wasn't showing

`members.astro` fetched `/api/invitations/pending?family_id=` — a 404, because the backend route is the path-param `/{family_id}/pending` — and parsed the response as `{pending_invitations: […]}` when the endpoint returns a plain list. Result: the list was always empty and the section stayed hidden even with active pending invites.

## Changes

- Fix the SSR fetch: correct path + treat the response as a list.
- **Resend**: new `POST /{family_id}/{invitation_id}/resend` → re-sends the invite email and refreshes expiry (+30d). `InvitationService.resend_invitation`. New Astro proxy. Resend button per row.
- **Cancel** (already existed, was broken): now gets `family_id` passed explicitly instead of scraping a non-existent input / the URL (which resolved to the string `"members"`). Both handlers stop reading `access_token` from `document.cookie` — it's httpOnly, so that returned `undefined` and produced a bogus "Authentication error"; auth now rides the cookie via `credentials:'include'` + the proxy's server-side `locals.token`.

## Tests

`test_resend_invitation_success`, `test_resend_invitation_requires_auth`. 14/14 invitation tests pass.

## Verified live

Deployed to prod, driven with a real browser: Pending section renders the existing invite (`mayra.escamilla79@gmail.com`) with Resend + Cancel. Resend route reachable end-to-end (bogus id → clean `400 "Invitation not found"`, no email sent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)