### PR TITLE
feat(receipts): persist scanned receipt images to GCS bucket

### DIFF
--- a/backend/app/api/routes/budget/transactions.py
+++ b/backend/app/api/routes/budget/transactions.py
@@ -4,7 +4,7 @@ Transaction routes
 CRUD endpoints for budget transactions.
 """
 
-from fastapi import APIRouter, Body, Depends, Response, status, Query, File, UploadFile, Form
+from fastapi import APIRouter, Body, Depends, HTTPException, Response, status, Query, File, UploadFile, Form
 from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing import List, Optional, Dict
@@ -137,6 +137,36 @@ async def get_transaction(
         to_uuid_required(current_user.family_id),
     )
     return transaction
+
+
+@router.get("/{transaction_id}/receipt")
+async def get_receipt_image(
+    transaction_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """302-redirect to a 15-min GCS signed URL for the receipt image.
+
+    Auth-bound (transaction must belong to caller's family) so the signed
+    URL is never handed to an unauthenticated party.
+    """
+    from fastapi.responses import RedirectResponse
+    from app.services.storage.gcs_receipt_service import GCSReceiptStorage
+    from sqlalchemy import select
+    from app.models.budget import BudgetTransaction
+
+    family_id = to_uuid_required(current_user.family_id)
+    stmt = select(BudgetTransaction).where(
+        BudgetTransaction.id == transaction_id,
+        BudgetTransaction.family_id == family_id,
+    )
+    txn = (await db.execute(stmt)).scalar_one_or_none()
+    if txn is None:
+        raise HTTPException(404, "transaction not found")
+    if not txn.receipt_image_path:
+        raise HTTPException(404, "no receipt image")
+    url = GCSReceiptStorage.signed_url(txn.receipt_image_path, expires_in_seconds=900)
+    return RedirectResponse(url=url, status_code=302)
 
 
 @router.put("/{transaction_id}", response_model=TransactionResponse)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -155,6 +155,12 @@ class Settings(BaseSettings):
     # Anthropic API (for receipt scanning via Claude Vision)
     ANTHROPIC_API_KEY: str = ""
 
+    # Google Cloud Storage bucket for receipt image persistence. When
+    # empty (default in local dev / tests), the scanner skips the
+    # upload step and transactions are stored without an image.
+    # In production the VM .env sets this to `family-prod-receipts`.
+    GCS_RECEIPT_BUCKET: str = ""
+
     # Internal service-to-service token (for /api/internal/* endpoints).
     # If empty, all internal endpoints reject with 403.
     INTERNAL_API_TOKEN: str = ""

--- a/backend/app/models/budget.py
+++ b/backend/app/models/budget.py
@@ -184,6 +184,10 @@ class BudgetTransaction(Base):
         nullable=True,
         comment="User who originally created this transaction (for per-user last-used account fallback in receipt scanner)",
     )
+    receipt_image_path: Mapped[Optional[str]] = mapped_column(
+        Text, nullable=True,
+        comment="GCS object key under GCS_RECEIPT_BUCKET; null if no image stored.",
+    )
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
 

--- a/backend/app/schemas/budget.py
+++ b/backend/app/schemas/budget.py
@@ -281,6 +281,7 @@ class TransactionResponse(TransactionBase):
     fx_rate: Optional[Decimal] = None
     original_amount_cents: Optional[int] = None
     original_currency: Optional[str] = Field(None, min_length=3, max_length=3)
+    receipt_image_path: Optional[str] = None
 
     # Force JSON to emit a real number for Decimal fields. Pydantic v2's
     # default is to serialize Decimal as a string, which breaks strict

--- a/backend/app/services/budget/receipt_scanner_service.py
+++ b/backend/app/services/budget/receipt_scanner_service.py
@@ -18,6 +18,7 @@ leaks to the upstream provider.
 
 import base64
 import json
+import logging
 import os
 import re
 from dataclasses import dataclass
@@ -44,6 +45,9 @@ from app.schemas.budget import TransactionCreate
 from app.services.budget.transaction_service import TransactionService
 from app.services.budget.categorization_rule_service import CategorizationRuleService
 from app.services.budget.receipt_draft_service import ReceiptDraftService
+
+
+logger = logging.getLogger(__name__)
 
 
 # LiteLLM model alias. Registered in /mnt/nvme/docker-prod/litellm-proxy/
@@ -679,6 +683,22 @@ async def scan_and_create_transaction(
         )
     await db.commit()
     await db.refresh(txn)
+
+    # Persist the original image to GCS for audit / replay. Best-effort:
+    # an upload failure does NOT roll back the scan — the transaction stands
+    # without an image rather than losing the user's work.
+    try:
+        from app.services.storage.gcs_receipt_service import GCSReceiptStorage
+        gcs_path = GCSReceiptStorage.upload(
+            family_id=family_id,
+            transaction_id=txn.id,
+            image_bytes=image_bytes,
+            content_type=media_type,
+        )
+        txn.receipt_image_path = gcs_path
+        await db.commit()
+    except Exception:
+        logger.exception("GCS upload skipped for txn %s", txn.id)
 
     # (7a) Shopping auto-check ----------------------------------------------
     shopping_auto_checked: list[str] = []

--- a/backend/app/services/storage/gcs_receipt_service.py
+++ b/backend/app/services/storage/gcs_receipt_service.py
@@ -1,0 +1,83 @@
+"""Receipt image persistence in Google Cloud Storage.
+
+Bucket lifecycle (set externally): 30d → Nearline, 365d → Archive.
+VM service account has roles/storage.objectAdmin on the bucket; no key files.
+"""
+
+import logging
+from datetime import timedelta
+from typing import Optional
+from uuid import UUID
+
+from google.cloud import storage
+from google.cloud.exceptions import GoogleCloudError
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class GCSReceiptStorage:
+    """Thin wrapper around the GCS client for receipt images.
+
+    Object key: <family_id>/<txn_id>.<ext>. The family prefix makes it
+    trivial to delete all receipts for a family on account removal.
+    """
+
+    _client: Optional[storage.Client] = None
+
+    @classmethod
+    def _bucket(cls):
+        if cls._client is None:
+            cls._client = storage.Client()
+        if not settings.GCS_RECEIPT_BUCKET:
+            raise RuntimeError("GCS_RECEIPT_BUCKET is not configured")
+        return cls._client.bucket(settings.GCS_RECEIPT_BUCKET)
+
+    @staticmethod
+    def _ext_for(content_type: str) -> str:
+        return {
+            "image/jpeg": "jpg",
+            "image/png": "png",
+            "image/webp": "webp",
+            "image/gif": "gif",
+            "application/pdf": "pdf",
+        }.get(content_type, "bin")
+
+    @classmethod
+    def upload(
+        cls,
+        *,
+        family_id: UUID,
+        transaction_id: UUID,
+        image_bytes: bytes,
+        content_type: str,
+    ) -> str:
+        """Upload bytes and return the object path (key) used in the bucket."""
+        ext = cls._ext_for(content_type)
+        path = f"{family_id}/{transaction_id}.{ext}"
+        blob = cls._bucket().blob(path)
+        blob.cache_control = "private, max-age=900"
+        try:
+            blob.upload_from_string(image_bytes, content_type=content_type)
+        except GoogleCloudError as exc:
+            logger.exception("GCS upload failed for %s", path)
+            raise
+        return path
+
+    @classmethod
+    def signed_url(cls, path: str, *, expires_in_seconds: int = 900) -> str:
+        """Generate a v4 signed URL the browser can GET directly."""
+        blob = cls._bucket().blob(path)
+        return blob.generate_signed_url(
+            version="v4",
+            expiration=timedelta(seconds=expires_in_seconds),
+            method="GET",
+        )
+
+    @classmethod
+    def delete(cls, path: str) -> None:
+        try:
+            cls._bucket().blob(path).delete()
+        except GoogleCloudError:
+            logger.warning("GCS delete failed for %s (already gone?)", path)

--- a/backend/migrations/versions/2026_05_31_receipt_image_path.py
+++ b/backend/migrations/versions/2026_05_31_receipt_image_path.py
@@ -1,0 +1,25 @@
+"""receipt_image_path on budget_transactions
+
+Revision ID: receipt_image_path
+Revises: txn_created_by
+Create Date: 2026-05-31
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "receipt_image_path"
+down_revision = "txn_created_by"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "budget_transactions",
+        sa.Column("receipt_image_path", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("budget_transactions", "receipt_image_path")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -81,3 +81,8 @@ python-dateutil==2.8.2
 
 # CORS
 fastapi-cors==0.0.6
+
+# Google Cloud Storage — receipt image persistence. VM service account
+# has roles/storage.objectAdmin on the bucket; no JSON key files needed
+# (ADC via metadata server). See gcs_receipt_service.py.
+google-cloud-storage>=2.18

--- a/docker-compose.gcp.yml
+++ b/docker-compose.gcp.yml
@@ -85,6 +85,7 @@ services:
       BASE_URL: ${PUBLIC_API_URL}
       ALLOWED_ORIGINS: ${ALLOWED_ORIGINS}
       LITELLM_API_BASE: ${LITELLM_API_BASE:-https://litellm.agent-ia.mx}
+      GCS_RECEIPT_BUCKET: ${GCS_RECEIPT_BUCKET:-family-prod-receipts}
       ENVIRONMENT: production
       DEBUG: "false"
       VAULT_ENABLED: "false"

--- a/frontend/src/lib/api/budget.ts
+++ b/frontend/src/lib/api/budget.ts
@@ -73,6 +73,7 @@ export interface BudgetTransaction {
     parent_id?: string;
     is_parent: boolean;
     transfer_account_id?: string;
+    receipt_image_path?: string;
     created_at: string;
     updated_at: string;
 }

--- a/frontend/src/pages/budget/transactions.astro
+++ b/frontend/src/pages/budget/transactions.astro
@@ -232,6 +232,7 @@ const categoriesJson = JSON.stringify(allCategoriesForEdit);
                                                 data-tx-account={transaction.account_id}
                                                 data-tx-notes={transaction.notes || ""}
                                                 data-tx-cleared={transaction.cleared ? "1" : "0"}
+                                                data-has-receipt-image={transaction.receipt_image_path ? "1" : "0"}
                                                 aria-label={es ? "Editar transacción" : "Edit transaction"}
                                             >
                                                 <div class="flex-1 min-w-0">
@@ -358,6 +359,13 @@ const categoriesJson = JSON.stringify(allCategoriesForEdit);
                         <label class="block text-sm font-medium text-brand-ink-soft mb-1">{es ? "Nota" : "Note"}</label>
                         <input id="edit-notes" type="text"
                             class="w-full py-2 px-3 border border-brand-ink/10 rounded-lg focus:ring-2 focus:ring-brand-sky-deep outline-none text-sm" />
+                    </div>
+
+                    <!-- Receipt image thumbnail (when present) -->
+                    <div id="receipt-thumb-wrap" class="hidden mt-3">
+                        <a id="receipt-thumb-link" href="#" target="_blank" rel="noopener" class="block">
+                            <img id="receipt-thumb" src="" alt="Receipt" class="max-h-32 rounded-lg border border-brand-ink/10" />
+                        </a>
                     </div>
 
                     <!-- Cleared -->
@@ -524,8 +532,9 @@ document.addEventListener("astro:after-swap", initFilters);
     function attachRowHandlers() {
         document.querySelectorAll(".tx-row").forEach((row) => {
             row.addEventListener("click", () => {
+                const txId = row.dataset.txId;
                 openModal({
-                    id: row.dataset.txId,
+                    id: txId,
                     amount: row.dataset.txAmount,
                     date: row.dataset.txDate,
                     payee: row.dataset.txPayee,
@@ -534,6 +543,22 @@ document.addEventListener("astro:after-swap", initFilters);
                     notes: row.dataset.txNotes,
                     cleared: row.dataset.txCleared,
                 });
+
+                // Receipt thumbnail: show when this txn has an image,
+                // otherwise hide. The /receipt endpoint 302-redirects to a
+                // 15-min signed GCS URL.
+                const thumbWrap = document.getElementById("receipt-thumb-wrap");
+                const thumb = document.getElementById("receipt-thumb");
+                const thumbLink = document.getElementById("receipt-thumb-link");
+                if (thumbWrap && thumb && thumbLink && row.dataset.hasReceiptImage === "1") {
+                    const url = `/api/budget/transactions/${txId}/receipt`;
+                    thumb.src = url;
+                    thumbLink.href = url;
+                    thumbWrap.classList.remove("hidden");
+                } else if (thumbWrap) {
+                    thumbWrap.classList.add("hidden");
+                    if (thumb) thumb.src = "";
+                }
             });
         });
     }


### PR DESCRIPTION
## Summary

Save every scanned receipt image to GCS bucket family-prod-receipts (us-central1, lifecycle: Standard → Nearline @ 30d → Archive @ 365d). VM service account has roles/storage.objectAdmin on the bucket; no key files.

## Changes

- New service GCSReceiptStorage (upload, signed_url, delete)
- New nullable column budget_transactions.receipt_image_path
- Scanner success path uploads after the txn commit (failure is non-fatal, logged)
- GET /api/budget/transactions/{id}/receipt → 302 redirect to 15-min v4 signed URL (auth-bound)
- Frontend thumbnail in the tx-detail bottom sheet, opens full image on click
- Migration: receipt_image_path → revises txn_created_by
- google-cloud-storage>=2.18 added to backend deps

## Test plan

- [x] Backend full suite: 832 pass, 4 pre-existing failures (unrelated)
- [x] Astro check clean for transactions.astro
- [x] Migration applies cleanly
- [ ] Post-merge: snap a receipt at gcp-family.agent-ia.mx, verify a row appears in budget_transactions with receipt_image_path set and the thumbnail renders on the tx detail panel

## Storage cost

~$0.02/mo per 1 GB at Standard, drops to ~$0.001/mo per GB after 365d Archive. Egress 0 (same region us-central1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)