### PR TITLE
fix(gcs): stream receipt bytes (Compute Engine ADC can't sign)

### DIFF
--- a/backend/app/api/routes/budget/transactions.py
+++ b/backend/app/api/routes/budget/transactions.py
@@ -145,12 +145,14 @@ async def get_receipt_image(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """302-redirect to a 15-min GCS signed URL for the receipt image.
+    """Stream the receipt image through the backend.
 
-    Auth-bound (transaction must belong to caller's family) so the signed
-    URL is never handed to an unauthenticated party.
+    Auth-bound (transaction must belong to caller's family). We can't use a
+    GCS signed URL because Compute Engine ADC doesn't carry a private key —
+    streaming through the backend is the simplest auth-bound read path and
+    same-region GCS egress to the VM is free.
     """
-    from fastapi.responses import RedirectResponse
+    from fastapi.responses import Response
     from app.services.storage.gcs_receipt_service import GCSReceiptStorage
     from sqlalchemy import select
     from app.models.budget import BudgetTransaction
@@ -165,8 +167,13 @@ async def get_receipt_image(
         raise HTTPException(404, "transaction not found")
     if not txn.receipt_image_path:
         raise HTTPException(404, "no receipt image")
-    url = GCSReceiptStorage.signed_url(txn.receipt_image_path, expires_in_seconds=900)
-    return RedirectResponse(url=url, status_code=302)
+    data, content_type = GCSReceiptStorage.download_bytes(txn.receipt_image_path)
+    # Browser-cache for 15 min — the bytes are immutable per object key.
+    return Response(
+        content=data,
+        media_type=content_type,
+        headers={"Cache-Control": "private, max-age=900"},
+    )
 
 
 @router.put("/{transaction_id}", response_model=TransactionResponse)

--- a/backend/app/services/storage/gcs_receipt_service.py
+++ b/backend/app/services/storage/gcs_receipt_service.py
@@ -67,13 +67,35 @@ class GCSReceiptStorage:
 
     @classmethod
     def signed_url(cls, path: str, *, expires_in_seconds: int = 900) -> str:
-        """Generate a v4 signed URL the browser can GET directly."""
+        """Generate a v4 signed URL the browser can GET directly.
+
+        NOTE: Compute Engine ADC has no private key — calling this from a GCE
+        VM raises AttributeError unless the SA is granted
+        roles/iam.serviceAccountTokenCreator on itself (so it can self-sign
+        via the iamcredentials.signBlob API). Project's prod backend instead
+        streams bytes through `download_bytes()`; signed URLs are kept here
+        for environments that supply a JSON key file.
+        """
         blob = cls._bucket().blob(path)
         return blob.generate_signed_url(
             version="v4",
             expiration=timedelta(seconds=expires_in_seconds),
             method="GET",
         )
+
+    @classmethod
+    def download_bytes(cls, path: str) -> tuple[bytes, str]:
+        """Stream bytes back through the backend. Returns (data, content_type).
+
+        Used by the /transactions/{id}/receipt endpoint as the primary read
+        path because Compute Engine ADC cannot sign URLs (see signed_url
+        docstring). Backend-VM-to-bucket egress is free (same region).
+        """
+        blob = cls._bucket().blob(path)
+        # reload() populates metadata (content_type) without fetching the body
+        blob.reload()
+        data = blob.download_as_bytes()
+        return data, blob.content_type or "application/octet-stream"
 
     @classmethod
     def delete(cls, path: str) -> None:


### PR DESCRIPTION
GCE ADC has no private key → generate_signed_url raises. Stream bytes through backend (free same-region egress).