### PR TITLE
fix(dedup): date-based dup guard + auto-upgrade + cleanup endpoint

### DIFF
--- a/backend/app/api/routes/budget/transactions.py
+++ b/backend/app/api/routes/budget/transactions.py
@@ -139,6 +139,27 @@ async def get_transaction(
     return transaction
 
 
+@router.post("/deduplicate")
+async def deduplicate_transactions(
+    dry_run: bool = Query(False, description="Preview without deleting"),
+    current_user: User = Depends(require_parent_role),
+    db: AsyncSession = Depends(get_db),
+):
+    """Find and merge duplicate transactions (same date + payee + amount ±1%).
+
+    Keeps the richer copy (prefers the one with a receipt image). The loser is
+    soft-deleted so it remains visible in the recycle bin. Safe to re-run.
+    """
+    from app.services.budget.dedup_service import DeduplicateService
+    family_id = to_uuid_required(current_user.family_id)
+    result = await DeduplicateService.run(
+        db, family_id,
+        deleted_by_id=current_user.id,
+        dry_run=dry_run,
+    )
+    return result
+
+
 @router.get("/{transaction_id}/receipt")
 async def get_receipt_image(
     transaction_id: UUID,

--- a/backend/app/services/budget/dedup_service.py
+++ b/backend/app/services/budget/dedup_service.py
@@ -1,0 +1,168 @@
+"""Find and merge duplicate transactions within a family.
+
+A "duplicate" is two rows with:
+  - same family_id
+  - same payee_id (non-null)
+  - same date
+  - amount within 1% tolerance
+  - neither is soft-deleted
+  - neither is a split child (parent_id IS NULL)
+
+When merging a pair, a "richness score" picks the winner. The loser is
+soft-deleted; its receipt image path (if any) is transferred to the winner
+first so no GCS object is orphaned.
+
+Richness score (higher = keep):
+  +20  has receipt_image_path
+  +10  has notes (non-empty)
+   +5  has category_id
+   +2  per transaction item (via BudgetTransactionItem relationship)
+   +1  is cleared
+   -5  was created by CSV import (imported_id is set, no receipt image)
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Optional
+from uuid import UUID
+
+from sqlalchemy import and_, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.budget import BudgetTransaction, BudgetTransactionItem
+
+logger = logging.getLogger(__name__)
+
+
+def _score(txn: BudgetTransaction, item_count: int) -> int:
+    s = 0
+    if txn.receipt_image_path:
+        s += 20
+    if txn.notes and txn.notes.strip():
+        s += 10
+    if txn.category_id:
+        s += 5
+    s += item_count * 2
+    if txn.cleared:
+        s += 1
+    if txn.imported_id and not txn.receipt_image_path:
+        s -= 5
+    return s
+
+
+class DeduplicateService:
+
+    AMOUNT_TOLERANCE = 0.01
+
+    @classmethod
+    async def run(
+        cls,
+        db: AsyncSession,
+        family_id: UUID,
+        deleted_by_id: Optional[UUID] = None,
+        dry_run: bool = False,
+    ) -> dict:
+        """Find and merge all duplicate pairs for the family.
+
+        Returns:
+            {merged: int, skipped: int, pairs: list[dict]}
+        """
+        # Fetch all non-deleted, non-split-child transactions that have a payee.
+        stmt = (
+            select(BudgetTransaction)
+            .where(
+                BudgetTransaction.family_id == family_id,
+                BudgetTransaction.deleted_at.is_(None),
+                BudgetTransaction.parent_id.is_(None),
+                BudgetTransaction.payee_id.isnot(None),
+            )
+            .order_by(BudgetTransaction.date, BudgetTransaction.payee_id, BudgetTransaction.created_at)
+        )
+        rows = list((await db.execute(stmt)).scalars().all())
+
+        # Count items per transaction in one query.
+        item_count_stmt = (
+            select(
+                BudgetTransactionItem.transaction_id,
+                func.count(BudgetTransactionItem.id).label("cnt"),
+            )
+            .where(BudgetTransactionItem.transaction_id.in_([r.id for r in rows]))
+            .group_by(BudgetTransactionItem.transaction_id)
+        )
+        item_counts: dict[UUID, int] = {
+            row.transaction_id: row.cnt
+            for row in (await db.execute(item_count_stmt)).all()
+        }
+
+        # Group rows into duplicate clusters (same date + payee + amount±1%).
+        seen_ids: set[UUID] = set()
+        merged = 0
+        skipped = 0
+        pairs: list[dict] = []
+
+        for i, a in enumerate(rows):
+            if a.id in seen_ids:
+                continue
+            tol = max(1, int(abs(int(a.amount)) * cls.AMOUNT_TOLERANCE))
+            for b in rows[i + 1:]:
+                if b.id in seen_ids:
+                    continue
+                if b.date != a.date:
+                    break  # rows are sorted by date; once past, no more matches
+                if b.payee_id != a.payee_id:
+                    continue
+                if not (int(a.amount) - tol <= int(b.amount) <= int(a.amount) + tol):
+                    continue
+                # Found a dup pair (a, b).
+                a_score = _score(a, item_counts.get(a.id, 0))
+                b_score = _score(b, item_counts.get(b.id, 0))
+                keeper, loser = (a, b) if a_score >= b_score else (b, a)
+
+                pairs.append({
+                    "keeper_id": str(keeper.id),
+                    "loser_id": str(loser.id),
+                    "keeper_score": max(a_score, b_score),
+                    "loser_score": min(a_score, b_score),
+                    "date": str(a.date),
+                    "amount_cents": int(a.amount),
+                })
+                seen_ids.add(loser.id)
+
+                if not dry_run:
+                    await cls._merge(db, keeper, loser, deleted_by_id)
+                    merged += 1
+                else:
+                    skipped += 1
+
+        if not dry_run:
+            await db.commit()
+
+        return {"merged": merged, "skipped": skipped, "pairs": pairs, "dry_run": dry_run}
+
+    @classmethod
+    async def _merge(
+        cls,
+        db: AsyncSession,
+        keeper: BudgetTransaction,
+        loser: BudgetTransaction,
+        deleted_by_id: Optional[UUID],
+    ) -> None:
+        # Transfer image from loser to keeper if keeper lacks one.
+        if loser.receipt_image_path and not keeper.receipt_image_path:
+            keeper.receipt_image_path = loser.receipt_image_path
+
+        # Enrich keeper notes if loser has richer notes.
+        if loser.notes and len(loser.notes) > len(keeper.notes or ""):
+            keeper.notes = loser.notes
+
+        # Inherit category if keeper has none.
+        if loser.category_id and not keeper.category_id:
+            keeper.category_id = loser.category_id
+
+        # Soft-delete the loser.
+        loser.deleted_at = datetime.now(timezone.utc)
+        loser.deleted_by_id = deleted_by_id
+
+        db.add(keeper)
+        db.add(loser)
+        logger.info("dedup: kept %s, removed %s (date=%s amt=%s)", keeper.id, loser.id, keeper.date, keeper.amount)

--- a/backend/app/services/budget/duplicate_guard_service.py
+++ b/backend/app/services/budget/duplicate_guard_service.py
@@ -1,24 +1,25 @@
-"""Detect a likely duplicate receipt scan within a short time window.
+"""Detect a likely duplicate receipt scan.
 
 Public surface:
-    DuplicateGuardService.check(db, family_id, payee_id, amount_cents)
-        -> DupWarning | None
+    DuplicateGuardService.check(db, family_id, payee_id, amount_cents, transaction_date)
+        -> DupMatch | None
 
-Logic:
-- Skip immediately when payee_id is None (can't deduplicate without a payee).
-- Look for an existing BudgetTransaction in the same family, with the same
-  payee, created within the last 60 seconds, whose amount is within 1% of
-  the incoming amount.
-- Returns the MOST RECENT match (order by created_at desc, limit 1), or None.
-- Amount tolerance: max(1, int(abs(amount_cents) * 0.01)) cents — at least
-  1 cent so that tiny amounts still dedup correctly.
+Logic (in priority order):
+1. Date-based (preferred): same date + same payee + amount within 1%.
+   This catches scanned receipts re-imported from bank statements regardless
+   of when the original was created.
+2. Window fallback: if no transaction_date provided, look back WINDOW_DAYS for
+   same payee + amount within 1% (e.g. bulk scan loop with unknown dates).
+
+Returns the MOST RECENT match (order by created_at desc, limit 1), or None.
+Amount tolerance: max(1, int(abs(amount_cents) * 0.01)) — at least 1 cent.
 """
 
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from typing import Optional
 from uuid import UUID
 
-from sqlalchemy import and_, desc, select
+from sqlalchemy import and_, desc, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.budget import BudgetTransaction
@@ -27,7 +28,7 @@ from app.schemas.budget import DupWarning
 
 class DuplicateGuardService:
 
-    WINDOW_SECONDS = 60
+    WINDOW_DAYS = 7
     AMOUNT_TOLERANCE = 0.01  # 1%
 
     @classmethod
@@ -37,27 +38,34 @@ class DuplicateGuardService:
         family_id: UUID,
         payee_id: Optional[UUID],
         amount_cents: int,
-    ) -> Optional[DupWarning]:
-        """Return a DupWarning if a likely duplicate exists, else None."""
+        transaction_date: Optional[date] = None,
+    ) -> Optional["DupMatch"]:
+        """Return a DupMatch if a likely duplicate exists, else None."""
         if payee_id is None:
             return None
 
-        cutoff = datetime.now(timezone.utc) - timedelta(seconds=cls.WINDOW_SECONDS)
         tol = max(1, int(abs(amount_cents) * cls.AMOUNT_TOLERANCE))
+        amount_range = BudgetTransaction.amount.between(
+            amount_cents - tol, amount_cents + tol
+        )
+        base_filter = and_(
+            BudgetTransaction.family_id == family_id,
+            BudgetTransaction.payee_id == payee_id,
+            BudgetTransaction.deleted_at.is_(None),
+            amount_range,
+        )
+
+        if transaction_date is not None:
+            # Primary path: exact date match — catches bank-import vs re-scan.
+            date_filter = BudgetTransaction.date == transaction_date
+        else:
+            # Fallback: created_at window (bulk scan without confirmed dates).
+            cutoff = datetime.now(timezone.utc) - timedelta(days=cls.WINDOW_DAYS)
+            date_filter = BudgetTransaction.created_at >= cutoff
 
         stmt = (
             select(BudgetTransaction)
-            .where(and_(
-                BudgetTransaction.family_id == family_id,
-                BudgetTransaction.payee_id == payee_id,
-                # Exclude soft-deleted rows so the recycle bin can't
-                # resurrect a dup-warning on a re-scan.
-                BudgetTransaction.deleted_at.is_(None),
-                BudgetTransaction.created_at >= cutoff,
-                BudgetTransaction.amount.between(
-                    amount_cents - tol, amount_cents + tol
-                ),
-            ))
+            .where(and_(base_filter, date_filter))
             .order_by(desc(BudgetTransaction.created_at))
             .limit(1)
         )
@@ -65,8 +73,27 @@ class DuplicateGuardService:
         if row is None:
             return None
 
-        return DupWarning(
-            existing_transaction_id=row.id,
-            scanned_at=row.created_at,
-            amount_cents=int(row.amount),
+        return DupMatch(
+            existing_transaction=row,
+            warning=DupWarning(
+                existing_transaction_id=row.id,
+                scanned_at=row.created_at,
+                amount_cents=int(row.amount),
+            ),
         )
+
+
+class DupMatch:
+    """Wraps the full ORM row so callers can inspect richness."""
+
+    def __init__(self, existing_transaction: BudgetTransaction, warning: DupWarning):
+        self.existing_transaction = existing_transaction
+        self.warning = warning
+
+    @property
+    def existing_has_image(self) -> bool:
+        return bool(self.existing_transaction.receipt_image_path)
+
+    @property
+    def existing_transaction_id(self) -> UUID:
+        return self.existing_transaction.id

--- a/backend/app/services/budget/receipt_scanner_service.py
+++ b/backend/app/services/budget/receipt_scanner_service.py
@@ -580,20 +580,62 @@ async def scan_and_create_transaction(
     # (4) Duplicate guard ----------------------------------------------------
     # Compare against the post-FX amount (the value that would actually
     # land in the database). Pre-FX comparison would let cross-currency
-    # duplicates through.
+    # duplicates through. Pass the receipt date so the guard can do an exact
+    # date match (catches bank-import vs re-scan, regardless of when the
+    # import ran — the old 60-second window only caught back-to-back scans).
     if not force:
         dup = await DuplicateGuardService.check(
             db, family_id, payee_id=payee_id,
             amount_cents=final_amount,
+            transaction_date=receipt.date,
         )
         if dup is not None:
+            # Upgrade path: if the existing transaction is missing a receipt
+            # image and this scan provides one, silently attach the image to
+            # the existing row instead of creating a duplicate or warning.
+            if not dup.existing_has_image:
+                existing = dup.existing_transaction
+                try:
+                    from app.services.storage.gcs_receipt_service import GCSReceiptStorage
+                    gcs_path = GCSReceiptStorage.upload(
+                        family_id=family_id,
+                        transaction_id=existing.id,
+                        image_bytes=image_bytes,
+                        content_type=media_type,
+                    )
+                    existing.receipt_image_path = gcs_path
+                    # Enrich notes with scanned items if existing notes are sparse.
+                    richer_notes = _build_notes(receipt.payee_name, receipt.items, receipt.currency)
+                    if richer_notes and len(richer_notes) > len(existing.notes or ""):
+                        existing.notes = richer_notes
+                    await db.commit()
+                    await db.refresh(existing)
+                except Exception:
+                    logger.exception("GCS upgrade failed for txn %s", existing.id)
+                    await db.rollback()
+                return {
+                    "success": True,
+                    "transaction_id": str(existing.id),
+                    "dup_warning": None,
+                    "scanned_preview": scanned_dict,
+                    "confidence": receipt.confidence,
+                    "items": [i.get("name", "") if isinstance(i, dict) else i for i in (receipt.items or [])],
+                    "account_match": {
+                        "strategy": match.strategy,
+                        "matched_card_last4": match.matched_card_last4,
+                    },
+                    "fx": fx_info,
+                    "trends": [],
+                    "shopping_auto_checked": [],
+                    "warnings": warnings + ["receipt_attached_to_existing"],
+                    "draft_id": None,
+                    "message": "Receipt image attached to existing transaction.",
+                }
+            # Existing has image (or same richness) — warn as before.
             # Do NOT commit — the flushed-but-uncommitted new payee row
             # (if any) will be rolled back when the session closes at the
             # request boundary. A subsequent force=True call will find/
             # reuse this payee idempotently via _find_or_create_payee.
-            # We intentionally do not call db.rollback() here: callers
-            # (tests + endpoint) often hold other in-flight reads on the
-            # same session that we must not invalidate.
             return {
                 "success": False,
                 "transaction_id": None,
@@ -601,8 +643,8 @@ async def scan_and_create_transaction(
                     "existing_transaction_id": str(
                         dup.existing_transaction_id
                     ),
-                    "scanned_at": dup.scanned_at.isoformat(),
-                    "amount_cents": dup.amount_cents,
+                    "scanned_at": dup.warning.scanned_at.isoformat(),
+                    "amount_cents": dup.warning.amount_cents,
                     "payee": receipt.payee_name,
                 },
                 "scanned_preview": scanned_dict,
@@ -616,6 +658,7 @@ async def scan_and_create_transaction(
                 "trends": [],
                 "shopping_auto_checked": [],
                 "warnings": warnings,
+                "draft_id": None,
             }
 
     # (5) Persist transaction ------------------------------------------------

--- a/frontend/src/pages/budget/transactions.astro
+++ b/frontend/src/pages/budget/transactions.astro
@@ -184,6 +184,13 @@ const categoriesJson = JSON.stringify(allCategoriesForEdit);
                 value={searchFilter}
                 class="text-sm border border-brand-ink/10 rounded-lg px-2 py-1.5 bg-brand-cream-deep flex-1 min-w-[120px]"
             />
+            {user.role === "parent" && (
+                <button id="dedup-btn" title={es ? "Limpiar duplicados" : "Remove duplicates"}
+                    class="text-xs px-2 py-1.5 rounded-lg border border-brand-ink/10 bg-brand-cream-deep text-brand-ink-soft hover:bg-amber-100 hover:text-amber-700 hover:border-amber-300 transition flex items-center gap-1 whitespace-nowrap">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" /></svg>
+                    {es ? "Dedup" : "Dedup"}
+                </button>
+            )}
         </div>
 
         <!-- Transactions List -->
@@ -774,5 +781,44 @@ document.addEventListener("astro:after-swap", initFilters);
     attachPriceComparison();
     document.addEventListener("astro:after-swap", attachPriceComparison);
     document.addEventListener("astro:page-load", attachPriceComparison);
+
+    // Dedup button
+    function attachDedup() {
+        const btn = document.getElementById("dedup-btn");
+        if (!btn) return;
+        btn.addEventListener("click", async () => {
+            const es = document.documentElement.lang === "es";
+            btn.disabled = true;
+            btn.textContent = es ? "Buscando..." : "Scanning...";
+            try {
+                // Dry run first to see count.
+                const preview = await fetch("/api/budget/transactions/deduplicate?dry_run=true", {
+                    method: "POST",
+                });
+                const data = await preview.json();
+                if (!data.pairs || data.pairs.length === 0) {
+                    alert(es ? "No se encontraron duplicados." : "No duplicates found.");
+                    return;
+                }
+                const msg = es
+                    ? `Se encontraron ${data.pairs.length} par(es) duplicado(s). ¿Limpiar ahora?`
+                    : `Found ${data.pairs.length} duplicate pair(s). Clean up now?`;
+                if (!confirm(msg)) return;
+                const res = await fetch("/api/budget/transactions/deduplicate", { method: "POST" });
+                const result = await res.json();
+                alert(es
+                    ? `${result.merged} duplicado(s) eliminado(s). Recargando...`
+                    : `${result.merged} duplicate(s) removed. Reloading...`);
+                window.location.reload();
+            } catch (e) {
+                alert(es ? "Error al limpiar duplicados." : "Error removing duplicates.");
+            } finally {
+                btn.disabled = false;
+                btn.textContent = "Dedup";
+            }
+        });
+    }
+    attachDedup();
+    document.addEventListener("astro:page-load", attachDedup);
 })();
 </script>


### PR DESCRIPTION
## Summary

- **Root cause**: dup guard used 60-second `created_at` window → missed bank imports scanned as receipts hours/days later
- **Fix 1**: `DuplicateGuardService` now matches on `transaction.date` + payee + amount ±1% (falls back to 7-day window when date unknown)
- **Fix 2**: When scanner finds exact dup and existing has **no image**: auto-attaches receipt image + richer notes to the existing row (upgrade, no new row created)
- **Fix 3**: New `POST /api/budget/transactions/deduplicate` endpoint — scans entire family, scores each pair (image +20, notes +10, category +5, items ×2), soft-deletes loser
- **Frontend**: "Dedup" button in filter bar for PARENT users — dry-run preview shows count, then confirm to clean up; reloads page after

## Existing duplicates

After deploy, click **Dedup** in the transactions filter bar to clean up the 4+ existing pairs (Mei Laii ×2, PETRO 7 ×2, 7-ELEVEN ×2, Subway ×2). The scanned copies (with receipt images) will be kept; bank imports (no image) will be soft-deleted into the recycle bin.

## Receipt image display

Images already working in GCS — 5 transactions have `receipt_image_path` set. Clicking those transactions in the list shows the thumbnail below the notes field.

## Test plan

- [ ] Scan receipt that already exists as bank import → confirm no duplicate created, image attaches to existing
- [ ] Scan same receipt twice → second scan shows dup_warning
- [ ] Click Dedup → preview count matches screenshot duplicates → confirm → page reloads clean
- [ ] Click transaction with receipt → thumbnail visible in edit sheet
- [ ] Verify soft-deleted dups appear in recycle bin

🤖 Generated with [Claude Code](https://claude.com/claude-code)