### PR TITLE
feat(budget): Actual-style categorization — seed defaults, AI suggest, payee learning

### DIFF
--- a/backend/app/api/routes/budget/transactions.py
+++ b/backend/app/api/routes/budget/transactions.py
@@ -160,6 +160,22 @@ async def deduplicate_transactions(
     return result
 
 
+@router.post("/auto-categorize")
+async def auto_categorize_transactions(
+    current_user: User = Depends(require_parent_role),
+    db: AsyncSession = Depends(get_db),
+):
+    """Categorize all uncategorized transactions for the family.
+
+    Per transaction: learned payee default category first, then an AI
+    suggestion against the family's category list. Assignments also teach the
+    payee a default category for future transactions. Parent only.
+    """
+    from app.services.budget.category_ai_service import CategoryAIService
+    family_id = to_uuid_required(current_user.family_id)
+    return await CategoryAIService.backfill(db, family_id)
+
+
 @router.get("/{transaction_id}/receipt")
 async def get_receipt_image(
     transaction_id: UUID,

--- a/backend/app/models/budget.py
+++ b/backend/app/models/budget.py
@@ -143,11 +143,18 @@ class BudgetPayee(Base):
     name: Mapped[str] = mapped_column(String(200), nullable=False)
     notes: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     is_favorite: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    default_category_id: Mapped[Optional[UUID]] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("budget_categories.id", ondelete="SET NULL"),
+        nullable=True,
+        comment="Learned category — transactions for this payee inherit it (Actual-style payee learning)",
+    )
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
 
     # Relationships
     family: Mapped["Family"] = relationship("Family", back_populates="budget_payees")
+    default_category: Mapped[Optional["BudgetCategory"]] = relationship("BudgetCategory", foreign_keys=[default_category_id])
     transactions: Mapped[list["BudgetTransaction"]] = relationship("BudgetTransaction", back_populates="payee")
     recurring_transactions: Mapped[list["BudgetRecurringTransaction"]] = relationship("BudgetRecurringTransaction", back_populates="payee")
 

--- a/backend/app/schemas/budget.py
+++ b/backend/app/schemas/budget.py
@@ -204,6 +204,7 @@ class PayeeUpdate(BaseModel):
     name: Optional[str] = Field(None, min_length=1, max_length=200)
     notes: Optional[str] = None
     is_favorite: Optional[bool] = None
+    default_category_id: Optional[UUID] = Field(None, description="Learned default category for this payee")
 
 
 class PayeeMergeRequest(BaseModel):
@@ -216,6 +217,7 @@ class PayeeResponse(PayeeBase):
     """Payee response with metadata"""
     id: UUID
     family_id: UUID
+    default_category_id: Optional[UUID] = None
     created_at: datetime
     updated_at: datetime
 

--- a/backend/app/services/budget/category_ai_service.py
+++ b/backend/app/services/budget/category_ai_service.py
@@ -1,0 +1,192 @@
+"""AI-assisted transaction categorization.
+
+Actual Budget solves categorization with rules + payee-learning, which both
+start empty (cold-start = everything uncategorized until taught). This service
+adds the lever Actual lacks: an LLM that already understands that
+"PETRO 7 PETROMAX / MAGNA" is gasoline and "Mei Laii ASIAN BUFFET" is a
+restaurant. Given the family's own category list it picks the best fit.
+
+Used as the LAST resort in the precedence chain
+    explicit rule  >  payee.default_category  >  AI suggestion  >  uncategorized
+so the (cheap, but non-zero) LLM call is skipped whenever a rule or a learned
+payee default already answers.
+
+Routes through the same LiteLLM proxy as the receipt scanner. Text-only and
+tiny output, so it is fast and cheap. Returns None on any failure — callers
+must treat categorization as best-effort.
+"""
+
+import json
+import logging
+import os
+import re
+from typing import Optional
+from uuid import UUID
+
+from openai import OpenAI
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.models.budget import BudgetCategory, BudgetCategoryGroup, BudgetPayee, BudgetTransaction
+
+logger = logging.getLogger(__name__)
+
+CATEGORIZER_MODEL = os.environ.get("CATEGORIZER_MODEL", "gemini-2.5-flash")
+
+
+class CategoryAIService:
+
+    @staticmethod
+    async def _load_categories(
+        db: AsyncSession, family_id: UUID, *, is_income: bool
+    ) -> list[tuple[UUID, str]]:
+        """Return [(category_id, "Group > Category")] for the income/expense
+        side, excluding hidden + soft-deleted rows. Ordered for stable prompts."""
+        rows = (await db.execute(
+            select(
+                BudgetCategory.id,
+                BudgetCategory.name,
+                BudgetCategoryGroup.name,
+            )
+            .join(BudgetCategoryGroup, BudgetCategory.group_id == BudgetCategoryGroup.id)
+            .where(
+                BudgetCategory.family_id == family_id,
+                BudgetCategory.deleted_at.is_(None),
+                BudgetCategory.hidden.is_(False),
+                BudgetCategoryGroup.deleted_at.is_(None),
+                BudgetCategoryGroup.hidden.is_(False),
+                BudgetCategoryGroup.is_income.is_(is_income),
+            )
+            .order_by(BudgetCategoryGroup.sort_order, BudgetCategory.sort_order)
+        )).all()
+        return [(r[0], f"{r[2]} > {r[1]}") for r in rows]
+
+    @classmethod
+    async def suggest(
+        cls,
+        db: AsyncSession,
+        family_id: UUID,
+        payee_name: Optional[str],
+        item_names: Optional[list[str]] = None,
+        *,
+        is_income: bool = False,
+        cache: Optional[dict] = None,
+    ) -> Optional[UUID]:
+        """Suggest a category_id for a purchase. None if no good fit / on error.
+
+        `cache` is an optional dict keyed by lowercased payee name; pass one
+        across a batch (e.g. backfill) so the same merchant isn't queried twice.
+        """
+        if not payee_name and not item_names:
+            return None
+        if not settings.LITELLM_API_KEY:
+            return None
+
+        cache_key = (payee_name or "").strip().lower()
+        if cache is not None and cache_key and cache_key in cache:
+            return cache[cache_key]
+
+        cats = await cls._load_categories(db, family_id, is_income=is_income)
+        if not cats:
+            return None
+
+        numbered = "\n".join(f"{i + 1}. {label}" for i, (_, label) in enumerate(cats))
+        items_str = ""
+        if item_names:
+            clean = [str(n).strip() for n in item_names if n and str(n).strip()]
+            if clean:
+                items_str = "\nArtículos: " + ", ".join(clean[:20])
+
+        prompt = (
+            "Eres un asistente de presupuesto familiar en México. Clasifica esta "
+            "compra en UNA sola categoría de la lista, eligiendo el mejor ajuste.\n"
+            f"Comercio: {payee_name or '(desconocido)'}{items_str}\n\n"
+            f"Categorías:\n{numbered}\n\n"
+            'Responde SOLO JSON: {"index": N} con el número de la mejor categoría, '
+            'o {"index": null} si ninguna aplica con claridad.'
+        )
+
+        try:
+            client = OpenAI(
+                base_url=f"{settings.LITELLM_API_BASE.rstrip('/')}/v1",
+                api_key=settings.LITELLM_API_KEY,
+            )
+            completion = client.chat.completions.create(
+                model=CATEGORIZER_MODEL,
+                max_tokens=50,
+                response_format={"type": "json_object"},
+                messages=[{"role": "user", "content": prompt}],
+                extra_body={"thinking_config": {"thinking_budget": 0}},
+            )
+            text = (completion.choices[0].message.content or "").strip()
+        except Exception:
+            logger.exception("category AI call failed for payee=%s", payee_name)
+            return None
+
+        result: Optional[UUID] = None
+        m = re.search(r"\{[\s\S]*\}", text)
+        if m:
+            try:
+                idx = json.loads(m.group()).get("index")
+                if isinstance(idx, int) and 1 <= idx <= len(cats):
+                    result = cats[idx - 1][0]
+            except (json.JSONDecodeError, TypeError, ValueError):
+                result = None
+
+        if cache is not None and cache_key:
+            cache[cache_key] = result
+        return result
+
+    @classmethod
+    async def backfill(cls, db: AsyncSession, family_id: UUID) -> dict:
+        """Categorize all uncategorized transactions for a family.
+
+        Precedence per transaction: payee.default_category → AI suggestion.
+        Learns: when AI assigns a category and the payee has no default yet,
+        the payee's default_category is set so future scans/imports skip the AI.
+
+        Returns {scanned, applied}.
+        """
+        rows = (await db.execute(
+            select(BudgetTransaction).where(
+                BudgetTransaction.family_id == family_id,
+                BudgetTransaction.category_id.is_(None),
+                BudgetTransaction.deleted_at.is_(None),
+                BudgetTransaction.parent_id.is_(None),
+            )
+        )).scalars().all()
+
+        cache: dict = {}
+        payee_cache: dict[UUID, BudgetPayee] = {}
+        applied = 0
+
+        for txn in rows:
+            payee: Optional[BudgetPayee] = None
+            if txn.payee_id:
+                payee = payee_cache.get(txn.payee_id)
+                if payee is None:
+                    payee = await db.get(BudgetPayee, txn.payee_id)
+                    if payee is not None:
+                        payee_cache[txn.payee_id] = payee
+
+            cat: Optional[UUID] = None
+            if payee and payee.default_category_id:
+                cat = payee.default_category_id
+            if cat is None:
+                cat = await cls.suggest(
+                    db, family_id,
+                    payee.name if payee else None,
+                    is_income=txn.amount > 0,
+                    cache=cache,
+                )
+
+            if cat is not None:
+                txn.category_id = cat
+                applied += 1
+                if payee is not None and not payee.default_category_id:
+                    payee.default_category_id = cat
+
+        await db.commit()
+        logger.info("backfill categorized %d/%d txns for family %s", applied, len(rows), family_id)
+        return {"scanned": len(rows), "applied": applied}

--- a/backend/app/services/budget/category_service.py
+++ b/backend/app/services/budget/category_service.py
@@ -104,6 +104,19 @@ class CategoryGroupService(BaseFamilyService[BudgetCategoryGroup]):
         """
         from sqlalchemy.orm import selectinload
 
+        # Lazy bootstrap: a family with no category tree gets the default
+        # MX-oriented groups/categories on its first budget visit. Idempotent
+        # (no-ops when groups already exist), so this is the single guaranteed
+        # seed point regardless of how the family was created.
+        from app.services.budget.default_categories import seed_default_categories
+        try:
+            await seed_default_categories(db, family_id)
+        except Exception:
+            import logging
+            logging.getLogger(__name__).exception(
+                "default category seed failed for family %s", family_id
+            )
+
         query = (
             select(BudgetCategoryGroup)
             .where(

--- a/backend/app/services/budget/default_categories.py
+++ b/backend/app/services/budget/default_categories.py
@@ -1,0 +1,88 @@
+"""Default budget category tree, seeded on a family's first budget visit.
+
+Mirrors Actual Budget's "premade categories" idea: every family starts with a
+sensible group → category structure so transactions always have somewhere to
+land. The tree is MX-oriented (Spanish names) and intentionally broad so the
+AI categorizer has clear, distinct targets (Gasolina vs Restaurantes vs
+Despensa, etc.).
+
+``seed_default_categories`` is idempotent: it no-ops when the family already
+has any (non-deleted) category group, so it is safe to call lazily on every
+budget page load.
+"""
+
+import logging
+from uuid import UUID
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.budget import BudgetCategory, BudgetCategoryGroup
+
+logger = logging.getLogger(__name__)
+
+# (group_name, is_income, [category names])
+DEFAULT_CATEGORY_TREE: list[tuple[str, bool, list[str]]] = [
+    ("Ingresos", True, ["Salario", "Ingresos Extra", "Reembolsos"]),
+    ("Mandado", False, [
+        "Despensa", "Fruta y Verdura", "Carne y Pescado", "Panadería y Tortillería",
+    ]),
+    ("Comida Fuera", False, ["Restaurantes", "Café", "Comida Rápida", "Domicilio"]),
+    ("Servicios", False, [
+        "Luz", "Agua", "Gas", "Internet", "Teléfono", "Streaming y Apps",
+    ]),
+    ("Transporte", False, [
+        "Gasolina", "Uber y Taxi", "Transporte Público",
+        "Casetas y Estacionamiento", "Mantenimiento Auto",
+    ]),
+    ("Hogar", False, [
+        "Renta o Hipoteca", "Muebles y Decoración", "Limpieza", "Reparaciones",
+    ]),
+    ("Salud", False, ["Farmacia", "Doctor y Consultas", "Seguro Médico"]),
+    ("Entretenimiento", False, ["Cine y Salidas", "Suscripciones", "Hobbies"]),
+    ("Educación", False, ["Colegiaturas", "Útiles", "Cursos"]),
+    ("Personal", False, ["Ropa", "Cuidado Personal", "Regalos"]),
+    ("Otros Gastos", False, ["Varios", "Comisiones Bancarias", "Impuestos"]),
+]
+
+
+async def seed_default_categories(db: AsyncSession, family_id: UUID) -> int:
+    """Create the default group/category tree for a family if it has none.
+
+    Idempotent — returns 0 (and writes nothing) when the family already has at
+    least one non-deleted category group. Returns the number of categories
+    created otherwise. Commits its own transaction.
+    """
+    existing = await db.scalar(
+        select(func.count())
+        .select_from(BudgetCategoryGroup)
+        .where(
+            BudgetCategoryGroup.family_id == family_id,
+            BudgetCategoryGroup.deleted_at.is_(None),
+        )
+    )
+    if existing and existing > 0:
+        return 0
+
+    created = 0
+    for gi, (group_name, is_income, cat_names) in enumerate(DEFAULT_CATEGORY_TREE):
+        group = BudgetCategoryGroup(
+            family_id=family_id,
+            name=group_name,
+            is_income=is_income,
+            sort_order=gi,
+        )
+        db.add(group)
+        await db.flush()
+        for ci, cat_name in enumerate(cat_names):
+            db.add(BudgetCategory(
+                family_id=family_id,
+                group_id=group.id,
+                name=cat_name,
+                sort_order=ci,
+            ))
+            created += 1
+
+    await db.commit()
+    logger.info("seeded %d default categories for family %s", created, family_id)
+    return created

--- a/backend/app/services/budget/receipt_scanner_service.py
+++ b/backend/app/services/budget/receipt_scanner_service.py
@@ -716,8 +716,26 @@ async def scan_and_create_transaction(
         payee=receipt.payee_name,
         description=_header_notes_for_match,
     )
+    # Precedence: explicit rule > learned payee default > AI suggestion.
+    payee_row = await db.get(BudgetPayee, payee_id) if payee_id else None
+    if not header_cat and payee_row is not None and payee_row.default_category_id:
+        header_cat = payee_row.default_category_id
+    if not header_cat:
+        from app.services.budget.category_ai_service import CategoryAIService
+        try:
+            header_cat = await CategoryAIService.suggest(
+                db, family_id, receipt.payee_name,
+                [i.get("name") for i in (receipt.items or []) if isinstance(i, dict)],
+                is_income=final_amount > 0,
+            )
+        except Exception:
+            logger.exception("AI categorization failed for txn %s", txn.id)
     if header_cat:
         txn.category_id = header_cat
+        # Learning: remember this category for the payee so future scans and
+        # imports inherit it without an AI call (Actual-style payee default).
+        if payee_row is not None and not payee_row.default_category_id:
+            payee_row.default_category_id = header_cat
     for it in items_persisted:
         it.category_id = CategorizationRuleService.match_with_cached_rules(
             cached_rules,

--- a/backend/app/services/budget/transaction_service.py
+++ b/backend/app/services/budget/transaction_service.py
@@ -162,6 +162,18 @@ class TransactionService(BaseFamilyService[BudgetTransaction]):
             from app.services.budget.account_service import AccountService
             await AccountService.get_by_id(db, update_data["transfer_account_id"], family_id)
 
+        # Category learning (Actual-style, on by default): when a category is
+        # assigned to a transaction that has a payee, remember it as that
+        # payee's default so future scans/imports inherit it. Last write wins
+        # — the user's most recent correction is the best signal.
+        new_cat = update_data.get("category_id")
+        eff_payee_id = update_data.get("payee_id", existing_txn.payee_id)
+        if new_cat and eff_payee_id:
+            from app.models.budget import BudgetPayee
+            payee = await db.get(BudgetPayee, eff_payee_id)
+            if payee is not None and payee.family_id == family_id:
+                payee.default_category_id = new_cat
+
         return await cls.update_by_id(db, transaction_id, family_id, update_data)
 
     @classmethod

--- a/backend/migrations/versions/2026_05_31_payee_default_category.py
+++ b/backend/migrations/versions/2026_05_31_payee_default_category.py
@@ -1,0 +1,39 @@
+"""add default_category_id to budget_payees (payee category learning)
+
+Revision ID: payee_default_category
+Revises: receipt_image_path
+Create Date: 2026-05-31
+
+Mirrors Actual Budget's payee default-category: once a payee is associated
+with a category, future transactions for that payee inherit it automatically.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "payee_default_category"
+down_revision = "receipt_image_path"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "budget_payees",
+        sa.Column("default_category_id", sa.UUID(), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_budget_payees_default_category",
+        "budget_payees",
+        "budget_categories",
+        ["default_category_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "fk_budget_payees_default_category", "budget_payees", type_="foreignkey"
+    )
+    op.drop_column("budget_payees", "default_category_id")

--- a/backend/tests/test_categorization_v2.py
+++ b/backend/tests/test_categorization_v2.py
@@ -1,0 +1,189 @@
+"""Tests for Actual-style categorization: default seeding, payee learning,
+AI suggestion mapping, and the backfill precedence chain."""
+
+from datetime import date
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import func, select
+
+from app.models.budget import (
+    BudgetAccount,
+    BudgetCategory,
+    BudgetCategoryGroup,
+    BudgetPayee,
+    BudgetTransaction,
+)
+from app.services.budget.category_ai_service import CategoryAIService
+from app.services.budget.default_categories import (
+    DEFAULT_CATEGORY_TREE,
+    seed_default_categories,
+)
+
+
+@pytest.mark.asyncio
+async def test_seed_default_categories_creates_tree(db_session, test_family):
+    created = await seed_default_categories(db_session, test_family.id)
+    assert created > 0
+
+    groups = (await db_session.execute(
+        select(func.count()).select_from(BudgetCategoryGroup).where(
+            BudgetCategoryGroup.family_id == test_family.id
+        )
+    )).scalar_one()
+    assert groups == len(DEFAULT_CATEGORY_TREE)
+
+    income = (await db_session.execute(
+        select(BudgetCategoryGroup).where(
+            BudgetCategoryGroup.family_id == test_family.id,
+            BudgetCategoryGroup.is_income.is_(True),
+        )
+    )).scalars().all()
+    assert len(income) == 1  # exactly one income group
+
+
+@pytest.mark.asyncio
+async def test_seed_default_categories_is_idempotent(db_session, test_family):
+    first = await seed_default_categories(db_session, test_family.id)
+    second = await seed_default_categories(db_session, test_family.id)
+    assert first > 0
+    assert second == 0  # no-op on second call
+
+    total = (await db_session.execute(
+        select(func.count()).select_from(BudgetCategory).where(
+            BudgetCategory.family_id == test_family.id
+        )
+    )).scalar_one()
+    assert total == first  # not doubled
+
+
+@pytest.mark.asyncio
+async def test_ai_suggest_maps_index_to_category(db_session, test_family):
+    await seed_default_categories(db_session, test_family.id)
+    # Grab an expense category to be the "right" answer (index 1 of the list).
+    cats = await CategoryAIService._load_categories(
+        db_session, test_family.id, is_income=False
+    )
+    assert cats, "expected expense categories after seeding"
+    target_id = cats[0][0]
+
+    class _Msg:
+        content = '{"index": 1}'
+
+    class _Choice:
+        message = _Msg()
+
+    class _Resp:
+        choices = [_Choice()]
+
+    with patch("app.services.budget.category_ai_service.OpenAI") as mock_openai, \
+         patch("app.services.budget.category_ai_service.settings") as mock_settings:
+        mock_settings.LITELLM_API_KEY = "sk-test"
+        mock_settings.LITELLM_API_BASE = "http://proxy"
+        mock_openai.return_value.chat.completions.create.return_value = _Resp()
+
+        result = await CategoryAIService.suggest(
+            db_session, test_family.id, "PETRO 7 PETROMAX", ["MAGNA"],
+        )
+    assert result == target_id
+
+
+@pytest.mark.asyncio
+async def test_ai_suggest_null_index_returns_none(db_session, test_family):
+    await seed_default_categories(db_session, test_family.id)
+
+    class _Msg:
+        content = '{"index": null}'
+
+    class _Choice:
+        message = _Msg()
+
+    class _Resp:
+        choices = [_Choice()]
+
+    with patch("app.services.budget.category_ai_service.OpenAI") as mock_openai, \
+         patch("app.services.budget.category_ai_service.settings") as mock_settings:
+        mock_settings.LITELLM_API_KEY = "sk-test"
+        mock_settings.LITELLM_API_BASE = "http://proxy"
+        mock_openai.return_value.chat.completions.create.return_value = _Resp()
+
+        result = await CategoryAIService.suggest(
+            db_session, test_family.id, "UNKNOWN MERCHANT", [],
+        )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_ai_suggest_no_api_key_returns_none(db_session, test_family):
+    await seed_default_categories(db_session, test_family.id)
+    with patch("app.services.budget.category_ai_service.settings") as mock_settings:
+        mock_settings.LITELLM_API_KEY = ""
+        result = await CategoryAIService.suggest(
+            db_session, test_family.id, "PETRO 7", ["MAGNA"],
+        )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_backfill_uses_payee_default_before_ai(db_session, test_family):
+    await seed_default_categories(db_session, test_family.id)
+    cat = (await db_session.execute(
+        select(BudgetCategory).where(BudgetCategory.family_id == test_family.id).limit(1)
+    )).scalar_one()
+
+    acct = BudgetAccount(family_id=test_family.id, name="Card", type="checking")
+    db_session.add(acct)
+    await db_session.flush()
+
+    # Payee already has a learned default — backfill must use it, NOT call AI.
+    payee = BudgetPayee(family_id=test_family.id, name="OXXO", default_category_id=cat.id)
+    db_session.add(payee)
+    await db_session.flush()
+
+    txn = BudgetTransaction(
+        family_id=test_family.id, account_id=acct.id, payee_id=payee.id,
+        date=date(2026, 5, 1), amount=-5000,
+    )
+    db_session.add(txn)
+    await db_session.commit()
+
+    with patch.object(CategoryAIService, "suggest") as mock_suggest:
+        result = await CategoryAIService.backfill(db_session, test_family.id)
+        mock_suggest.assert_not_called()
+
+    assert result["applied"] == 1
+    await db_session.refresh(txn)
+    assert txn.category_id == cat.id
+
+
+@pytest.mark.asyncio
+async def test_backfill_learns_payee_default_from_ai(db_session, test_family):
+    await seed_default_categories(db_session, test_family.id)
+    cat = (await db_session.execute(
+        select(BudgetCategory).where(BudgetCategory.family_id == test_family.id).limit(1)
+    )).scalar_one()
+
+    acct = BudgetAccount(family_id=test_family.id, name="Card", type="checking")
+    db_session.add(acct)
+    await db_session.flush()
+    payee = BudgetPayee(family_id=test_family.id, name="NEW MERCHANT")
+    db_session.add(payee)
+    await db_session.flush()
+    txn = BudgetTransaction(
+        family_id=test_family.id, account_id=acct.id, payee_id=payee.id,
+        date=date(2026, 5, 1), amount=-9900,
+    )
+    db_session.add(txn)
+    await db_session.commit()
+
+    async def _fake_suggest(*a, **k):
+        return cat.id
+
+    with patch.object(CategoryAIService, "suggest", side_effect=_fake_suggest):
+        result = await CategoryAIService.backfill(db_session, test_family.id)
+
+    assert result["applied"] == 1
+    await db_session.refresh(txn)
+    await db_session.refresh(payee)
+    assert txn.category_id == cat.id
+    assert payee.default_category_id == cat.id  # learned for next time

--- a/backend/tests/test_receipt_scanner.py
+++ b/backend/tests/test_receipt_scanner.py
@@ -89,9 +89,11 @@ class TestScanReceipt:
                 assert call_kwargs["base_url"] == "http://10.1.0.99:4000/v1"
                 assert call_kwargs["api_key"] == "sk-fake-virtual-key"
 
-                # Correct model alias passed through
+                # Correct model alias passed through (env-driven RECEIPT_MODEL,
+                # defaults to gemini-2.5-flash since the Gemini switch).
+                from app.services.budget.receipt_scanner_service import RECEIPT_MODEL
                 call_args = mock_client.chat.completions.create.call_args
-                assert call_args.kwargs["model"] == "claude-haiku"
+                assert call_args.kwargs["model"] == RECEIPT_MODEL
                 # Vision payload contains the image as a data URI
                 content = call_args.kwargs["messages"][0]["content"]
                 image_part = next(c for c in content if c["type"] == "image_url")

--- a/frontend/src/pages/budget/transactions.astro
+++ b/frontend/src/pages/budget/transactions.astro
@@ -191,6 +191,13 @@ const categoriesJson = JSON.stringify(allCategoriesForEdit);
                     {es ? "Dedup" : "Dedup"}
                 </button>
             )}
+            {user.role === "parent" && (
+                <button id="autocat-btn" title={es ? "Categorizar con IA" : "AI categorize"}
+                    class="text-xs px-2 py-1.5 rounded-lg border border-brand-ink/10 bg-brand-cream-deep text-brand-ink-soft hover:bg-violet-100 hover:text-violet-700 hover:border-violet-300 transition flex items-center gap-1 whitespace-nowrap">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" /></svg>
+                    {es ? "Auto-categorizar" : "Auto-categorize"}
+                </button>
+            )}
         </div>
 
         <!-- Transactions List -->
@@ -843,5 +850,34 @@ document.addEventListener("astro:after-swap", initFilters);
     }
     attachDedup();
     document.addEventListener("astro:page-load", attachDedup);
+
+    // Auto-categorize button
+    function attachAutoCat() {
+        const btn = document.getElementById("autocat-btn");
+        if (!btn) return;
+        btn.addEventListener("click", async () => {
+            const es = document.documentElement.lang === "es";
+            if (!confirm(es
+                ? "Categorizar con IA todas las transacciones sin categoría. ¿Continuar?"
+                : "AI-categorize all uncategorized transactions. Continue?")) return;
+            btn.disabled = true;
+            const label = btn.querySelector("svg")?.nextSibling;
+            btn.textContent = es ? "Categorizando..." : "Categorizing...";
+            try {
+                const res = await fetch("/api/budget/transactions/auto-categorize", { method: "POST" });
+                const r = await res.json();
+                alert(es
+                    ? `${r.applied} de ${r.scanned} categorizadas. Recargando...`
+                    : `${r.applied} of ${r.scanned} categorized. Reloading...`);
+                window.location.reload();
+            } catch (e) {
+                alert(es ? "Error al categorizar." : "Categorization error.");
+            } finally {
+                btn.disabled = false;
+            }
+        });
+    }
+    attachAutoCat();
+    document.addEventListener("astro:page-load", attachAutoCat);
 })();
 </script>


### PR DESCRIPTION
## Problem

Every transaction showed **"Sin categoría"**. Root cause (prod): the family had **0 category groups, 0 categories, 0 rules** for 75 transactions. Default categories only existed in a manual demo seed script; family registration seeds nothing. The scanner only applied (empty) rules.

## Approach — copy Actual Budget + add the AI lever it lacks

```
precedence:  explicit rule  >  learned payee default  >  AI suggestion  >  uncategorized
```

| Layer | What |
|---|---|
| **Seed defaults** | MX-oriented tree (Ingresos/Mandado/Servicios/Transporte/Comida Fuera/Hogar/Salud/…). Idempotent, runs lazily on first budget load → covers existing + future families. |
| **AI categorize** | `CategoryAIService.suggest()` — LLM picks best-fit from the family's own category list (LiteLLM, text-only, cheap). Solves the cold-start Actual suffers. |
| **Payee default** | `BudgetPayee.default_category_id` (migration). Transactions inherit the payee's learned category — Actual's core low-friction mechanism. |
| **Learning** | Scanner sets payee default on categorize; manual edits in `TransactionService.update` teach the payee too (last-write-wins). |
| **Backfill** | `POST /api/budget/transactions/auto-categorize` + "Auto-categorizar" button (parent only). Payee-default first, AI second. |

## How Actual does it (researched)

Rules engine (conditions→actions, pre/default/post stages, ranked least→most specific), payee `default_category` applied on import match, and "Category Learning" that auto-creates payee→category rules from your edits. We mirror the payee-default + learning, keep our existing rules engine, and add AI for cold-start.

## Tests

`test_categorization_v2.py` — seed idempotency, AI index→category mapping, no-API-key graceful path, backfill precedence + learning. 19/19 green (scanner + categorization). Fixed a stale `claude-haiku` model assertion left from the Gemini switch.

## Deploy plan

Migration `payee_default_category` runs on deploy. Then hit the budget page once (seeds the tree) and click **Auto-categorizar** (or POST the endpoint) to categorize the 75 existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)