### PR TITLE
refactor: rename Frankie AI assistant to Jarvis

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -15,7 +15,7 @@ push_subs_v1
  → kiosk_v1           W3.3  kiosk devices
  → gig_mode_v1        W4.1  gig modes (claim/rotation/competition/collaboration)
  → pet_v1             W4.3  virtual pet (status: UNCERTAIN per user — do not expand)
- → frankie_v1         W6.1  Frankie copilot chat history
+ → jarvis_v1         W6.1  Jarvis copilot chat history
  → pup_hist_v1        W6.3  PUP score snapshot history
  → meals_v1           W7.2  recipes + meal plan entries
  → fchat_v1           W8.1  family chat messages
@@ -35,8 +35,8 @@ Apply with: `docker compose exec backend alembic upgrade head`
 - `notification_service` — in-app feed + push fan-out + rate limit (10/hr/user)
 - `pet_service` — KidPet CRUD + decay + task hooks + treats catalog
 - `analytics_service` — PUP score + snapshot history
-- `frankie_service` — LiteLLM chat + tool calling + SSE streaming + daily cap
-- `frankie_tools` — flat REGISTRY of 10 tools (definition + handler)
+- `jarvis_service` — LiteLLM chat + tool calling + SSE streaming + daily cap
+- `jarvis_tools` — flat REGISTRY of 10 tools (definition + handler)
 - `meal_service` — recipes + plan entries + auto-shop sync + qty parser
 - `recipe_importer` — LLM URL scraper for recipes
 - `family_chat_service` — messages, SSE poll-stream, reactions, read receipts
@@ -48,7 +48,7 @@ Apply with: `docker compose exec backend alembic upgrade head`
 - `pet_decay_sweep` — 08:00 daily; pet stat decay + sad/starving notifs
 - `pup_snapshot_sweep` — 23:30 daily; PUP score snapshot per family
 
-### Frankie tools (10)
+### Jarvis tools (10)
 | Tool | Domain | Write/Read |
 |---|---|---|
 | create_task_template | Tasks | W |
@@ -65,7 +65,7 @@ Apply with: `docker compose exec backend alembic upgrade head`
 ### Notable settings
 - `GIG_AUTO_APPROVE_STREAK` (default 3)
 - `GIG_AI_AUTO_APPROVE_THRESHOLD` (default 0.8)
-- `FRANKIE_DAILY_MESSAGE_CAP` (default 100 per family)
+- `JARVIS_DAILY_MESSAGE_CAP` (default 100 per family)
 
 ## Frontend pages new
 - `/shopping` — multi-list grocery with check/uncheck
@@ -76,7 +76,7 @@ Apply with: `docker compose exec backend alembic upgrade head`
 - `/kiosk` — fullscreen wall display (token-gated, no auth)
 - `/parent/kiosk` — device token management
 - `/parent/analytics` — PUP score + 30-day sparkline + per-member completion
-- `/parent/frankie` — copilot chat with SSE streaming + live tool badges
+- `/parent/jarvis` — copilot chat with SSE streaming + live tool badges
 - `/meals` — week grid + recipe form + URL importer
 - `/pet` — pet view + treats shop (UNCERTAIN feature)
 - `/chat` — family chat with realtime SSE + emoji reactions + read receipts
@@ -86,9 +86,9 @@ Apply with: `docker compose exec backend alembic upgrade head`
   shopping_list, calendar_service, calendar_scanner, notifications, kiosk,
   gig_modes, gig_modes_award, gig_rotation_shuffle, kid_pet, pet_treats,
   analytics_pup, receipt_shopping_match, meal_service, meal_shopping_sync,
-  recipe_importer, integration_gig_lifecycle, frankie_tools, frankie_sse,
+  recipe_importer, integration_gig_lifecycle, jarvis_tools, jarvis_sse,
   family_chat, chat_read_react
-- 5 new E2E specs: shopping, calendar-events, notifications, frankie,
+- 5 new E2E specs: shopping, calendar-events, notifications, jarvis,
   kiosk-admin, chat
 
 ## Memory entries (private)
@@ -106,5 +106,5 @@ Apply with: `docker compose exec backend alembic upgrade head`
 - Realtime broker (Redis) — replace SSE poll for sub-second latency
 - Meal: drag-drop reorder week
 - Calendar: drag-create on month grid
-- Frankie: streaming token output (currently events only, not chunked reply)
-- Frankie: scheduled prompts (e.g. weekly summary email)
+- Jarvis: streaming token output (currently events only, not chunked reply)
+- Jarvis: scheduled prompts (e.g. weekly summary email)

--- a/backend/app/api/routes/budget/__init__.py
+++ b/backend/app/api/routes/budget/__init__.py
@@ -5,7 +5,7 @@ API endpoints for budget management.
 """
 
 from fastapi import APIRouter
-from app.api.routes.budget import categories, accounts, transactions, allocations, payees, month, transfers, reports, categorization_rules, goals, recurring_transactions, months, recycle_bin, saved_filters, tags, export, custom_reports, receipt_drafts, items, a2a_webhook as _a2a, price_comparison as _price_comparison, bank_sync as _bank_sync
+from app.api.routes.budget import categories, accounts, transactions, allocations, payees, month, transfers, reports, categorization_rules, goals, recurring_transactions, months, recycle_bin, saved_filters, tags, export, custom_reports, receipt_drafts, items, a2a_webhook as _a2a, price_comparison as _price_comparison, bank_sync as _bank_sync, ai_settings as _ai_settings
 
 router = APIRouter()
 
@@ -36,5 +36,6 @@ router.include_router(
     tags=["budget-price-comparison"],
 )
 router.include_router(_bank_sync.router, prefix="/bank-sync", tags=["budget-bank-sync"])
+router.include_router(_ai_settings.router, prefix="/ai-settings", tags=["budget-ai-settings"])
 
 __all__ = ["router"]

--- a/backend/app/api/routes/budget/ai_settings.py
+++ b/backend/app/api/routes/budget/ai_settings.py
@@ -1,0 +1,113 @@
+"""
+AI & Scanner settings
+
+GET  /api/budget/ai-settings/models  — list available vision models + current selection
+PUT  /api/budget/ai-settings/models  — update model selection (stored per-family in Redis)
+GET  /api/budget/ai-settings/usage   — proxy to LiteLLM /key/info for spend data
+"""
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from app.core.config import settings
+from app.core.dependencies import require_parent_role
+from app.models import User
+
+router = APIRouter()
+
+# LiteLLM-registered model aliases. Add new entries when a model is
+# registered in litellm_config.yaml on the platform side.
+VISION_MODELS = [
+    {"id": "gemini-2.5-flash", "label": "Gemini 2.5 Flash"},
+    {"id": "qwen-vl", "label": "Qwen2-VL-2B-AWQ (on-prem, GPU 0)"},
+    {"id": "claude-haiku", "label": "Claude Haiku"},
+    {"id": "claude-sonnet", "label": "Claude Sonnet"},
+    {"id": "gpt-4o", "label": "GPT-4o"},
+]
+
+_KNOWN_MODEL_IDS = {m["id"] for m in VISION_MODELS}
+
+
+def _redis_model_key(family_id) -> str:
+    return f"family_settings:{family_id}:receipt_model"
+
+
+async def _redis():
+    import redis.asyncio as aioredis
+    return aioredis.from_url(settings.REDIS_URL, decode_responses=True)
+
+
+@router.get("/models")
+async def get_vision_models(
+    current_user: User = Depends(require_parent_role),
+):
+    r = await _redis()
+    try:
+        selected = await r.get(_redis_model_key(current_user.family_id))
+    finally:
+        await r.aclose()
+    return {
+        "current_model": selected or settings.RECEIPT_MODEL,
+        "default_model": settings.RECEIPT_MODEL,
+        "models": VISION_MODELS,
+    }
+
+
+class ModelUpdate(BaseModel):
+    model: str
+
+
+@router.put("/models")
+async def set_vision_model(
+    body: ModelUpdate,
+    current_user: User = Depends(require_parent_role),
+):
+    if body.model not in _KNOWN_MODEL_IDS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown model '{body.model}'. Known: {sorted(_KNOWN_MODEL_IDS)}",
+        )
+    r = await _redis()
+    try:
+        await r.set(_redis_model_key(current_user.family_id), body.model)
+    finally:
+        await r.aclose()
+    return {"model": body.model}
+
+
+@router.get("/usage")
+async def get_ai_usage(
+    current_user: User = Depends(require_parent_role),
+):
+    """Proxy LiteLLM /key/info for the configured virtual key's spend data."""
+    if not settings.LITELLM_API_KEY or not settings.LITELLM_API_BASE:
+        raise HTTPException(status_code=503, detail="LiteLLM not configured")
+
+    base = settings.LITELLM_API_BASE.rstrip("/")
+    headers = {"Authorization": f"Bearer {settings.LITELLM_API_KEY}"}
+
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        try:
+            resp = await client.get(f"{base}/key/info", headers=headers)
+            resp.raise_for_status()
+            data = resp.json()
+        except httpx.HTTPStatusError as exc:
+            raise HTTPException(
+                status_code=502,
+                detail=f"LiteLLM returned {exc.response.status_code}",
+            )
+        except httpx.RequestError as exc:
+            raise HTTPException(status_code=502, detail=f"LiteLLM unreachable: {exc}")
+
+    info = data.get("info", data)
+    return {
+        "spend": info.get("spend", 0),
+        "max_budget": info.get("max_budget"),
+        "budget_duration": info.get("budget_duration"),
+        "budget_reset_at": info.get("budget_reset_at"),
+        "key_alias": info.get("key_alias") or info.get("key_name"),
+        "models": info.get("models", []),
+        "tpm_limit": info.get("tpm_limit"),
+        "rpm_limit": info.get("rpm_limit"),
+    }

--- a/backend/app/api/routes/gigs.py
+++ b/backend/app/api/routes/gigs.py
@@ -63,6 +63,10 @@ class GigClaimResponse(BaseModel):
     points_awarded: Optional[int]
     approved_by: Optional[UUID]
     approval_notes: Optional[str]
+    # Enriched fields (populated on list endpoints)
+    claimer_name: Optional[str] = None
+    gig_title: Optional[str] = None
+    gig_points: Optional[int] = None
 
     class Config:
         from_attributes = True
@@ -174,10 +178,18 @@ async def pending_approvals(
     current_user: User = Depends(require_parent_role),
     db: AsyncSession = Depends(get_db),
 ):
-    claims = await GigClaimService.get_pending_approvals(
+    items = await GigClaimService.get_pending_approvals(
         db, family_id=to_uuid_required(current_user.family_id)
     )
-    return claims
+    return [
+        GigClaimResponse(
+            **{k: v for k, v in GigClaimResponse.model_validate(item["claim"]).model_dump().items()},
+            claimer_name=item["claimer_name"],
+            gig_title=item["gig_title"],
+            gig_points=item["gig_points"],
+        )
+        for item in items
+    ]
 
 
 @router.get("/claims/my", response_model=List[GigClaimResponse])
@@ -185,12 +197,19 @@ async def my_claims(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    claims = await GigClaimService.get_my_claims(
+    items = await GigClaimService.get_my_claims_enriched(
         db,
         user_id=to_uuid_required(current_user.id),
         family_id=to_uuid_required(current_user.family_id),
     )
-    return claims
+    return [
+        GigClaimResponse(
+            **{k: v for k, v in GigClaimResponse.model_validate(item["claim"]).model_dump().items()},
+            gig_title=item["gig_title"],
+            gig_points=item["gig_points"],
+        )
+        for item in items
+    ]
 
 
 @router.post("/claims/{claim_id}/complete", response_model=GigClaimResponse)

--- a/backend/app/api/routes/gigs.py
+++ b/backend/app/api/routes/gigs.py
@@ -1,0 +1,241 @@
+from fastapi import APIRouter, Depends, status, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from pydantic import BaseModel, Field
+from typing import List, Optional, Any
+from uuid import UUID
+
+from app.core.database import get_db
+from app.core.dependencies import get_current_user, require_parent_role
+from app.core.type_utils import to_uuid_required
+from app.models import User
+from app.models.gig import GigClaimStatus
+from app.services.gig_offering_service import GigOfferingService
+from app.services.gig_claim_service import GigClaimService
+from app.core.exceptions import ValidationException
+
+router = APIRouter()
+
+
+# ── Schemas ─────────────────────────────────────────────────────────────────
+
+class GigOfferingCreate(BaseModel):
+    title: str = Field(..., max_length=200)
+    description: Optional[str] = None
+    points: int = Field(..., gt=0)
+    difficulty: int = Field(1, ge=1, le=3)
+    category: str = "other"
+    allowed_roles: Optional[List[str]] = None
+
+
+class GigOfferingUpdate(BaseModel):
+    title: Optional[str] = Field(None, max_length=200)
+    description: Optional[str] = None
+    points: Optional[int] = Field(None, gt=0)
+    difficulty: Optional[int] = Field(None, ge=1, le=3)
+    category: Optional[str] = None
+    allowed_roles: Optional[List[str]] = None
+    is_active: Optional[bool] = None
+
+
+class GigOfferingResponse(BaseModel):
+    id: UUID
+    family_id: UUID
+    title: str
+    description: Optional[str]
+    points: int
+    difficulty: int
+    category: str
+    allowed_roles: Optional[List[str]]
+    is_active: bool
+
+    class Config:
+        from_attributes = True
+
+
+class GigClaimResponse(BaseModel):
+    id: UUID
+    gig_id: UUID
+    family_id: UUID
+    claimed_by: UUID
+    status: str
+    proof_text: Optional[str]
+    proof_image_url: Optional[str]
+    points_awarded: Optional[int]
+    approved_by: Optional[UUID]
+    approval_notes: Optional[str]
+
+    class Config:
+        from_attributes = True
+
+
+class EnrichedOfferingResponse(BaseModel):
+    offering: GigOfferingResponse
+    my_claim: Optional[GigClaimResponse]
+
+
+class CompleteClaimRequest(BaseModel):
+    proof_text: Optional[str] = None
+    proof_image_url: Optional[str] = None
+
+
+class ApproveClaimRequest(BaseModel):
+    approved: bool
+    notes: Optional[str] = None
+
+
+# ── Offering endpoints ───────────────────────────────────────────────────────
+
+@router.get("/offerings", response_model=List[EnrichedOfferingResponse])
+async def list_offerings(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    family_id = to_uuid_required(current_user.family_id)
+    user_id = to_uuid_required(current_user.id)
+    items = await GigOfferingService.list_for_family(db, family_id, user_id)
+    return [
+        EnrichedOfferingResponse(
+            offering=GigOfferingResponse.model_validate(item["offering"]),
+            my_claim=GigClaimResponse.model_validate(item["my_claim"]) if item["my_claim"] else None,
+        )
+        for item in items
+    ]
+
+
+@router.post("/offerings", response_model=GigOfferingResponse, status_code=status.HTTP_201_CREATED)
+async def create_offering(
+    data: GigOfferingCreate,
+    current_user: User = Depends(require_parent_role),
+    db: AsyncSession = Depends(get_db),
+):
+    offering = await GigOfferingService.create(
+        db,
+        family_id=to_uuid_required(current_user.family_id),
+        created_by=to_uuid_required(current_user.id),
+        **data.model_dump(),
+    )
+    return offering
+
+
+@router.put("/offerings/{offering_id}", response_model=GigOfferingResponse)
+async def update_offering(
+    offering_id: UUID,
+    data: GigOfferingUpdate,
+    current_user: User = Depends(require_parent_role),
+    db: AsyncSession = Depends(get_db),
+):
+    offering = await GigOfferingService.update(
+        db,
+        offering_id=offering_id,
+        family_id=to_uuid_required(current_user.family_id),
+        **{k: v for k, v in data.model_dump().items() if v is not None},
+    )
+    return offering
+
+
+@router.delete("/offerings/{offering_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def deactivate_offering(
+    offering_id: UUID,
+    current_user: User = Depends(require_parent_role),
+    db: AsyncSession = Depends(get_db),
+):
+    await GigOfferingService.deactivate(
+        db,
+        offering_id=offering_id,
+        family_id=to_uuid_required(current_user.family_id),
+    )
+
+
+# ── Claim endpoints ──────────────────────────────────────────────────────────
+
+@router.post("/offerings/{offering_id}/claim", response_model=GigClaimResponse, status_code=status.HTTP_201_CREATED)
+async def claim_offering(
+    offering_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    from app.models.user import UserRole
+    if current_user.role == UserRole.PARENT:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Padres no pueden reclamar gigs")
+    try:
+        claim = await GigClaimService.claim(
+            db,
+            gig_id=offering_id,
+            user_id=to_uuid_required(current_user.id),
+            family_id=to_uuid_required(current_user.family_id),
+        )
+    except ValidationException as e:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
+    return claim
+
+
+@router.get("/claims/pending-approvals", response_model=List[GigClaimResponse])
+async def pending_approvals(
+    current_user: User = Depends(require_parent_role),
+    db: AsyncSession = Depends(get_db),
+):
+    claims = await GigClaimService.get_pending_approvals(
+        db, family_id=to_uuid_required(current_user.family_id)
+    )
+    return claims
+
+
+@router.get("/claims/my", response_model=List[GigClaimResponse])
+async def my_claims(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    claims = await GigClaimService.get_my_claims(
+        db,
+        user_id=to_uuid_required(current_user.id),
+        family_id=to_uuid_required(current_user.family_id),
+    )
+    return claims
+
+
+@router.post("/claims/{claim_id}/complete", response_model=GigClaimResponse)
+async def complete_claim(
+    claim_id: UUID,
+    data: CompleteClaimRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    claim = await GigClaimService.complete(
+        db,
+        claim_id=claim_id,
+        user_id=to_uuid_required(current_user.id),
+        proof_text=data.proof_text,
+        proof_image_url=data.proof_image_url,
+    )
+    return claim
+
+
+@router.post("/claims/{claim_id}/unclaim", status_code=status.HTTP_204_NO_CONTENT)
+async def unclaim(
+    claim_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    await GigClaimService.unclaim(
+        db,
+        claim_id=claim_id,
+        user_id=to_uuid_required(current_user.id),
+    )
+
+
+@router.post("/claims/{claim_id}/approve", response_model=GigClaimResponse)
+async def approve_claim(
+    claim_id: UUID,
+    data: ApproveClaimRequest,
+    current_user: User = Depends(require_parent_role),
+    db: AsyncSession = Depends(get_db),
+):
+    claim = await GigClaimService.approve(
+        db,
+        claim_id=claim_id,
+        approver_id=to_uuid_required(current_user.id),
+        family_id=to_uuid_required(current_user.family_id),
+        approved=data.approved,
+        notes=data.notes,
+    )
+    return claim

--- a/backend/app/api/routes/jarvis.py
+++ b/backend/app/api/routes/jarvis.py
@@ -1,4 +1,4 @@
-"""Frankie copilot routes (W6.1)."""
+"""Jarvis copilot routes (W6.1)."""
 
 from datetime import datetime
 from typing import List, Optional
@@ -14,7 +14,7 @@ from app.core.dependencies import require_parent_role
 from app.core.exceptions import ValidationError
 from app.core.type_utils import to_uuid_required
 from app.models import User
-from app.services.frankie_service import FrankieService
+from app.services.jarvis_service import JarvisService
 
 
 router = APIRouter()
@@ -51,7 +51,7 @@ async def chat(
 ):
     model = data.model if data.model in ALLOWED_MODELS else None
     try:
-        return await FrankieService.chat(
+        return await JarvisService.chat(
             db,
             family_id=to_uuid_required(current_user.family_id),
             user_id=to_uuid_required(current_user.id),
@@ -70,7 +70,7 @@ async def chat_stream(
 ):
     """SSE stream of chat progress. Client consumes via fetch + ReadableStream."""
     model = data.model if data.model in ALLOWED_MODELS else None
-    gen = FrankieService.chat_stream(
+    gen = JarvisService.chat_stream(
         db,
         family_id=to_uuid_required(current_user.family_id),
         user_id=to_uuid_required(current_user.id),
@@ -92,7 +92,7 @@ async def history(
     current_user: User = Depends(require_parent_role),
     db: AsyncSession = Depends(get_db),
 ):
-    rows = await FrankieService.list_history(
+    rows = await JarvisService.list_history(
         db, to_uuid_required(current_user.family_id)
     )
     return [HistoryItem.model_validate(r) for r in rows]
@@ -103,7 +103,7 @@ async def clear_history(
     current_user: User = Depends(require_parent_role),
     db: AsyncSession = Depends(get_db),
 ):
-    await FrankieService.clear_history(
+    await JarvisService.clear_history(
         db, to_uuid_required(current_user.family_id)
     )
     return None

--- a/backend/app/api/routes/jarvis_schedules.py
+++ b/backend/app/api/routes/jarvis_schedules.py
@@ -1,4 +1,4 @@
-"""Frankie schedule routes (W9.1)."""
+"""Jarvis schedule routes (W9.1)."""
 
 from datetime import datetime
 from typing import List, Optional
@@ -13,7 +13,7 @@ from app.core.dependencies import require_parent_role
 from app.core.exceptions import NotFoundException, ValidationException
 from app.core.type_utils import to_uuid_required
 from app.models import User
-from app.services.frankie_schedule_service import FrankieScheduleService
+from app.services.jarvis_schedule_service import JarvisScheduleService
 
 
 router = APIRouter()
@@ -45,7 +45,7 @@ async def list_schedules(
     current_user: User = Depends(require_parent_role),
     db: AsyncSession = Depends(get_db),
 ):
-    rows = await FrankieScheduleService.list(
+    rows = await JarvisScheduleService.list(
         db, to_uuid_required(current_user.family_id)
     )
     return [ScheduleOut.model_validate(r) for r in rows]
@@ -62,7 +62,7 @@ async def create_schedule(
     db: AsyncSession = Depends(get_db),
 ):
     try:
-        s = await FrankieScheduleService.create(
+        s = await JarvisScheduleService.create(
             db,
             family_id=to_uuid_required(current_user.family_id),
             created_by=to_uuid_required(current_user.id),
@@ -83,7 +83,7 @@ async def toggle(
     db: AsyncSession = Depends(get_db),
 ):
     try:
-        s = await FrankieScheduleService.toggle(
+        s = await JarvisScheduleService.toggle(
             db, schedule_id, to_uuid_required(current_user.family_id)
         )
     except NotFoundException as exc:
@@ -98,7 +98,7 @@ async def delete_schedule(
     db: AsyncSession = Depends(get_db),
 ):
     try:
-        await FrankieScheduleService.delete(
+        await JarvisScheduleService.delete(
             db, schedule_id, to_uuid_required(current_user.family_id)
         )
     except NotFoundException as exc:

--- a/backend/app/api/routes/points_conversion.py
+++ b/backend/app/api/routes/points_conversion.py
@@ -36,7 +36,9 @@ router = APIRouter()
 
 # Configuration
 FINANCE_API_URL = os.getenv("FINANCE_API_URL", "http://finance-api:5007")
-POINTS_TO_MONEY_RATE = float(os.getenv("POINTS_TO_MONEY_RATE", "0.10"))
+# 1 point = 1 MXN. Matches the gig board's 1:1 points↔pesos display so a
+# gig labeled "$50" cashes out to exactly $50. Override via env if needed.
+POINTS_TO_MONEY_RATE = float(os.getenv("POINTS_TO_MONEY_RATE", "1.0"))
 CURRENCY = os.getenv("POINTS_TO_MONEY_CURRENCY", "MXN")
 
 

--- a/backend/app/api/routes/task_assignments.py
+++ b/backend/app/api/routes/task_assignments.py
@@ -465,6 +465,7 @@ def _assignment_to_detail(assignment) -> dict:
         "template_title_es": template.title_es if template else None,
         "template_description_es": template.description_es if template else None,
         "template_points": template.points if template else 0,
+        "template_effort_level": template.effort_level if template else 1,
         "template_is_bonus": template.is_bonus if template else False,
         "template_gig_mode": (template.gig_mode if template else "claim") or "claim",
         "template_collaboration_min_count": (

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -152,6 +152,11 @@ class Settings(BaseSettings):
     LITELLM_API_KEY: str = ""
     LITELLM_MODEL: str = "mistral-nemo"
 
+    # Vision model used for receipt scanning. Must be a registered alias in
+    # litellm_config.yaml. Per-family override stored in Redis takes precedence
+    # when set via /api/budget/ai-settings/models.
+    RECEIPT_MODEL: str = "gemini-2.5-flash"
+
     # Anthropic API (for receipt scanning via Claude Vision)
     ANTHROPIC_API_KEY: str = ""
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -44,10 +44,10 @@ class Settings(BaseSettings):
     # Jarvis copilot daily message cap per family. Each user → assistant
     # exchange counts as one message. Prevents accidental spend overruns
     # on the LiteLLM proxy. 0 = unlimited.
-    FRANKIE_DAILY_MESSAGE_CAP: int = 100
+    JARVIS_DAILY_MESSAGE_CAP: int = 100
     # LiteLLM model alias for Jarvis chat. Defaults to receipt scanner's
-    # claude-haiku for shared budget. Override via FRANKIE_MODEL env.
-    FRANKIE_MODEL: str = "claude-haiku"
+    # claude-haiku for shared budget. Override via JARVIS_MODEL env.
+    JARVIS_MODEL: str = "claude-haiku"
 
     # Stripe settings removed 2026-05-24. PayPal is the canonical
     # billing path. See feedback_no_stripe memory entry.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,14 +12,14 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from app.core.config import settings
 from app.core.database import engine, Base, AsyncSessionLocal
 from app.core.exception_handlers import register_exception_handlers
-from app.api.routes import auth, users, rewards, consequences, families, task_templates, task_assignments, sync, oauth, payment, points_conversion, invitations, subscriptions, push, shopping, calendar, notifications, kiosk, pet, analytics, frankie, meals, family_chat, frankie_schedules, dm
+from app.api.routes import auth, users, rewards, consequences, families, task_templates, task_assignments, sync, oauth, payment, points_conversion, invitations, subscriptions, push, shopping, calendar, notifications, kiosk, pet, analytics, jarvis, meals, family_chat, jarvis_schedules, dm
 from app.api.routes.budget import router as budget_router
 from app.api.routes.gigs import router as gigs_router
 from app.jobs.subscription_sweep import run_sweep
 from app.services.task_assignment_service import TaskAssignmentService
 from app.services.pet_service import PetService
 from app.services.analytics_service import AnalyticsService
-from app.services.frankie_schedule_service import FrankieScheduleService
+from app.services.jarvis_schedule_service import JarvisScheduleService
 
 # Configure logging
 logging.basicConfig(
@@ -83,15 +83,15 @@ async def lifespan(app: FastAPI):
     scheduler.add_job(_pet_decay_sweep, "cron", hour=8, minute=0, id="pet_decay_sweep")
     scheduler.add_job(_pup_snapshot_sweep, "cron", hour=23, minute=30, id="pup_snapshot_sweep")
 
-    async def _frankie_schedule_sweep():
+    async def _jarvis_schedule_sweep():
         async with AsyncSessionLocal() as session:
             try:
-                n = await FrankieScheduleService.sweep_due(session)
+                n = await JarvisScheduleService.sweep_due(session)
                 if n:
                     logger.info("Jarvis schedule sweep fired %d", n)
             except Exception:
                 logger.exception("Jarvis schedule sweep failed")
-    scheduler.add_job(_frankie_schedule_sweep, "cron", minute="*/5", id="frankie_sched_sweep")
+    scheduler.add_job(_jarvis_schedule_sweep, "cron", minute="*/5", id="jarvis_sched_sweep")
 
     scheduler.start()
 
@@ -177,10 +177,10 @@ app.include_router(notifications.router, prefix="/api/notifications", tags=["Not
 app.include_router(kiosk.router, prefix="/api/kiosk", tags=["Kiosk"])
 app.include_router(pet.router, prefix="/api/pet", tags=["Pet"])
 app.include_router(analytics.router, prefix="/api/analytics", tags=["Analytics"])
-app.include_router(frankie.router, prefix="/api/frankie", tags=["Frankie"])
+app.include_router(jarvis.router, prefix="/api/jarvis", tags=["Jarvis"])
 app.include_router(meals.router, prefix="/api/meals", tags=["Meals"])
 app.include_router(family_chat.router, prefix="/api/chat", tags=["Chat"])
-app.include_router(frankie_schedules.router, prefix="/api/frankie/schedules", tags=["Frankie Schedules"])
+app.include_router(jarvis_schedules.router, prefix="/api/jarvis/schedules", tags=["Jarvis Schedules"])
 app.include_router(dm.router, prefix="/api/dm", tags=["DM"])
 from app.api.routes.internal import a2a_retry as _internal_a2a  # noqa: E402
 app.include_router(_internal_a2a.router, prefix="/api/internal", tags=["internal"])

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,6 +14,7 @@ from app.core.database import engine, Base, AsyncSessionLocal
 from app.core.exception_handlers import register_exception_handlers
 from app.api.routes import auth, users, rewards, consequences, families, task_templates, task_assignments, sync, oauth, payment, points_conversion, invitations, subscriptions, push, shopping, calendar, notifications, kiosk, pet, analytics, frankie, meals, family_chat, frankie_schedules, dm
 from app.api.routes.budget import router as budget_router
+from app.api.routes.gigs import router as gigs_router
 from app.jobs.subscription_sweep import run_sweep
 from app.services.task_assignment_service import TaskAssignmentService
 from app.services.pet_service import PetService
@@ -159,6 +160,7 @@ app.include_router(
 )
 app.include_router(invitations.router, prefix="/api/invitations", tags=["Invitations"])
 app.include_router(budget_router, prefix="/api/budget", tags=["Budget"])
+app.include_router(gigs_router, prefix="/api/gigs", tags=["Gigs"])
 app.include_router(points_conversion.router, prefix="/api/points-conversion", tags=["Points Conversion"])
 app.include_router(subscriptions.router, prefix="/api/subscriptions", tags=["Subscriptions"])
 from app.api.routes import subscriptions_webhook  # noqa: E402

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -49,6 +49,7 @@ from app.models.family_chat import FamilyChatMessage
 from app.models.family_chat_reaction import FamilyChatReaction
 from app.models.frankie_schedule import FrankieSchedule
 from app.models.dm import DMThread, DMMessage
+from app.models.gig import GigOffering, GigClaim, GigCategory, GigClaimStatus
 
 __all__ = [
     "Base",
@@ -107,6 +108,11 @@ __all__ = [
     # DM
     "DMThread",
     "DMMessage",
+    # Gigs
+    "GigOffering",
+    "GigClaim",
+    "GigCategory",
+    "GigClaimStatus",
     # Enums
     "UserRole",
     "TaskStatus",

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -42,12 +42,12 @@ from app.models.calendar_event import CalendarEvent
 from app.models.notification import Notification, NotificationType
 from app.models.kiosk_device import KioskDevice
 from app.models.kid_pet import KidPet
-from app.models.frankie_message import FrankieMessage
+from app.models.jarvis_message import JarvisMessage
 from app.models.pup_snapshot import PupScoreSnapshot
 from app.models.meal import Recipe, MealPlanEntry
 from app.models.family_chat import FamilyChatMessage
 from app.models.family_chat_reaction import FamilyChatReaction
-from app.models.frankie_schedule import FrankieSchedule
+from app.models.jarvis_schedule import JarvisSchedule
 from app.models.dm import DMThread, DMMessage
 from app.models.gig import GigOffering, GigClaim, GigCategory, GigClaimStatus
 
@@ -93,8 +93,8 @@ __all__ = [
     "KioskDevice",
     # Virtual pet
     "KidPet",
-    # Frankie copilot
-    "FrankieMessage",
+    # Jarvis copilot
+    "JarvisMessage",
     # Analytics snapshots
     "PupScoreSnapshot",
     # Meals
@@ -103,8 +103,8 @@ __all__ = [
     # Family chat
     "FamilyChatMessage",
     "FamilyChatReaction",
-    # Frankie schedules
-    "FrankieSchedule",
+    # Jarvis schedules
+    "JarvisSchedule",
     # DM
     "DMThread",
     "DMMessage",

--- a/backend/app/models/gig.py
+++ b/backend/app/models/gig.py
@@ -1,0 +1,129 @@
+from sqlalchemy import (
+    Column,
+    String,
+    Integer,
+    Boolean,
+    DateTime,
+    ForeignKey,
+    Text,
+    UniqueConstraint,
+    Enum as SQLEnum,
+)
+from sqlalchemy.dialects.postgresql import UUID, JSONB
+from sqlalchemy.orm import relationship
+from datetime import datetime
+from enum import Enum
+import uuid
+
+from app.core.database import Base
+
+
+class GigCategory(str, Enum):
+    CHORES = "chores"
+    ERRANDS = "errands"
+    CREATIVE = "creative"
+    LEARNING = "learning"
+    OUTDOOR = "outdoor"
+    OTHER = "other"
+
+
+class GigClaimStatus(str, Enum):
+    CLAIMED = "claimed"
+    COMPLETED = "completed"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+
+
+class GigOffering(Base):
+    """A gig posted by a parent that kids can claim independently."""
+
+    __tablename__ = "gig_offerings"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, index=True)
+    family_id = Column(
+        UUID(as_uuid=True), ForeignKey("families.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    title = Column(String(200), nullable=False)
+    description = Column(Text, nullable=True)
+    points = Column(Integer, nullable=False)  # 1 point = $1 MXN
+    difficulty = Column(Integer, nullable=False, default=1)  # 1=Easy 2=Medium 3=Hard
+    category = Column(
+        SQLEnum(GigCategory, values_callable=lambda x: [e.value for e in x]),
+        nullable=False,
+        default=GigCategory.OTHER,
+        server_default=GigCategory.OTHER.value,
+    )
+    allowed_roles = Column(
+        JSONB,
+        nullable=True,
+        comment="List of role strings eligible to claim; null = all non-parent roles",
+    )
+    is_active = Column(Boolean, nullable=False, default=True, server_default="true", index=True)
+    created_by = Column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+    created_at = Column(DateTime(timezone=True), default=datetime.utcnow, nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True), default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )
+
+    # Relationships
+    family = relationship("Family")
+    creator = relationship("User", foreign_keys=[created_by])
+    claims = relationship("GigClaim", back_populates="offering", cascade="all, delete-orphan")
+
+    def __repr__(self):
+        return f"<GigOffering(id={self.id}, title={self.title!r}, points={self.points})>"
+
+
+class GigClaim(Base):
+    """One kid's claim on a gig offering."""
+
+    __tablename__ = "gig_claims"
+    __table_args__ = (
+        UniqueConstraint(
+            "gig_id",
+            "claimed_by",
+            name="uq_gig_claim_active",
+            # Partial unique enforced via CHECK + application logic:
+            # only one non-REJECTED claim per user per gig.
+            # Full partial unique index added in migration.
+        ),
+    )
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, index=True)
+    gig_id = Column(
+        UUID(as_uuid=True), ForeignKey("gig_offerings.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    family_id = Column(
+        UUID(as_uuid=True), ForeignKey("families.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    claimed_by = Column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    status = Column(
+        SQLEnum(GigClaimStatus, values_callable=lambda x: [e.value for e in x]),
+        nullable=False,
+        default=GigClaimStatus.CLAIMED,
+        server_default=GigClaimStatus.CLAIMED.value,
+        index=True,
+    )
+    proof_text = Column(Text, nullable=True)
+    proof_image_url = Column(String(500), nullable=True)
+    points_awarded = Column(Integer, nullable=True)  # snapshot at approval time
+    completed_at = Column(DateTime(timezone=True), nullable=True)
+    approved_by = Column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+    approved_at = Column(DateTime(timezone=True), nullable=True)
+    approval_notes = Column(Text, nullable=True)
+    created_at = Column(DateTime(timezone=True), default=datetime.utcnow, nullable=False, index=True)
+
+    # Relationships
+    offering = relationship("GigOffering", back_populates="claims")
+    claimer = relationship("User", foreign_keys=[claimed_by])
+    approver = relationship("User", foreign_keys=[approved_by])
+    point_transactions = relationship("PointTransaction", back_populates="gig_claim")
+
+    def __repr__(self):
+        return f"<GigClaim(id={self.id}, gig_id={self.gig_id}, claimed_by={self.claimed_by}, status={self.status})>"

--- a/backend/app/models/jarvis_message.py
+++ b/backend/app/models/jarvis_message.py
@@ -1,6 +1,6 @@
-"""Frankie chat history model (W6.1).
+"""Jarvis chat history model (W6.1).
 
-Persisted conversation between a parent and the Frankie copilot, scoped
+Persisted conversation between a parent and the Jarvis copilot, scoped
 per family. Kept so the assistant remembers prior turns within a session
 and so we can audit suggestions later.
 """
@@ -14,12 +14,12 @@ from sqlalchemy.dialects.postgresql import UUID
 from app.core.database import Base
 
 
-class FrankieMessage(Base):
-    __tablename__ = "frankie_messages"
+class JarvisMessage(Base):
+    __tablename__ = "jarvis_messages"
     __table_args__ = (
         CheckConstraint(
             "role IN ('user', 'assistant', 'system')",
-            name="chk_frankie_role",
+            name="chk_jarvis_role",
         ),
     )
 

--- a/backend/app/models/jarvis_schedule.py
+++ b/backend/app/models/jarvis_schedule.py
@@ -1,6 +1,6 @@
-"""FrankieSchedule (W9.1) — recurring prompts auto-run on cron.
+"""JarvisSchedule (W9.1) — recurring prompts auto-run on cron.
 
-Each schedule fires the stored prompt through FrankieService.chat with a
+Each schedule fires the stored prompt through JarvisService.chat with a
 synthetic user (the creator) when next_run_at <= now. Output is delivered
 to the chosen channel:
   - notification: family-wide in-app notification + push
@@ -27,11 +27,11 @@ from app.core.database import Base
 VALID_CHANNELS = {"notification", "chat"}
 
 
-class FrankieSchedule(Base):
-    __tablename__ = "frankie_schedules"
+class JarvisSchedule(Base):
+    __tablename__ = "jarvis_schedules"
     __table_args__ = (
         CheckConstraint(
-            "channel IN ('notification', 'chat')", name="chk_frankie_channel"
+            "channel IN ('notification', 'chat')", name="chk_jarvis_channel"
         ),
     )
 

--- a/backend/app/models/point_transaction.py
+++ b/backend/app/models/point_transaction.py
@@ -47,6 +47,7 @@ class PointTransaction(Base):
     task_id = Column(UUID(as_uuid=True), ForeignKey("tasks.id", ondelete="SET NULL"), nullable=True)  # Legacy, to be removed
     assignment_id = Column(UUID(as_uuid=True), ForeignKey("task_assignments.id", ondelete="SET NULL"), nullable=True)
     reward_id = Column(UUID(as_uuid=True), ForeignKey("rewards.id", ondelete="SET NULL"), nullable=True)
+    gig_claim_id = Column(UUID(as_uuid=True), ForeignKey("gig_claims.id", ondelete="SET NULL"), nullable=True)
     
     # Metadata
     created_at = Column(DateTime(timezone=True), default=datetime.utcnow, nullable=False, index=True)
@@ -57,6 +58,7 @@ class PointTransaction(Base):
     task = relationship("Task", back_populates="point_transactions")  # Legacy
     assignment = relationship("TaskAssignment", back_populates="point_transactions")
     reward = relationship("Reward", back_populates="redemptions")
+    gig_claim = relationship("GigClaim", back_populates="point_transactions")
     created_by_user = relationship("User", foreign_keys=[created_by])
 
     def __repr__(self):
@@ -98,6 +100,18 @@ class PointTransaction(Base):
             balance_before=balance_before,
             balance_after=balance_before + points,
             description=f"Gig approved — earned {points} points",
+        )
+
+    @classmethod
+    def create_gig_claim_approval(cls, user_id, gig_claim_id, points: int, balance_before: int):
+        return cls(
+            type=TransactionType.GIG_APPROVED,
+            user_id=user_id,
+            gig_claim_id=gig_claim_id,
+            points=points,
+            balance_before=balance_before,
+            balance_after=balance_before + points,
+            description=f"Gig aprobada — ganaste {points} puntos (${points} MXN)",
         )
 
     @classmethod

--- a/backend/app/services/budget/receipt_scanner_service.py
+++ b/backend/app/services/budget/receipt_scanner_service.py
@@ -50,13 +50,10 @@ from app.services.budget.receipt_draft_service import ReceiptDraftService
 logger = logging.getLogger(__name__)
 
 
-# LiteLLM model alias. Registered in /mnt/nvme/docker-prod/litellm-proxy/
-# litellm_config.yaml. Override via env RECEIPT_MODEL without redeploy.
-# Default `gemini-2.5-flash` (cheap vision: ~$0.30/M input, ~$2.50/M output
-# vs claude-haiku ~$1/$5 — and bypasses the Anthropic credit balance issue
-# that bricked the previous "claude-haiku" default on 2026-05-30).
-# Alternatives: "claude-haiku", "claude-sonnet", "gpt-4o" (also registered).
-RECEIPT_MODEL = os.environ.get("RECEIPT_MODEL", "gemini-2.5-flash")
+# Fallback model alias when no per-family override is stored in Redis.
+# settings.RECEIPT_MODEL is the env-configured default (gemini-2.5-flash).
+# Alternatives: "qwen-vl", "claude-haiku", "claude-sonnet", "gpt-4o".
+RECEIPT_MODEL = settings.RECEIPT_MODEL
 
 RECEIPT_UPLOADS_DIR = "/app/uploads/receipt-drafts"
 
@@ -196,7 +193,23 @@ Rules:
 - If you cannot read the receipt at all, set confidence to 0 and all values to null"""
 
 
-async def scan_receipt(image_bytes: bytes, media_type: str) -> ScannedReceipt:
+async def _get_family_model(family_id: UUID) -> str:
+    """Return per-family model override from Redis, or the global default."""
+    try:
+        import redis.asyncio as aioredis
+        r = aioredis.from_url(settings.REDIS_URL, decode_responses=True)
+        try:
+            val = await r.get(f"family_settings:{family_id}:receipt_model")
+        finally:
+            await r.aclose()
+        return val or RECEIPT_MODEL
+    except Exception:
+        return RECEIPT_MODEL
+
+
+async def scan_receipt(
+    image_bytes: bytes, media_type: str, model: Optional[str] = None
+) -> ScannedReceipt:
     """Extract transaction data from a receipt image via LiteLLM proxy.
 
     Uses the OpenAI-compatible Chat Completions endpoint exposed by
@@ -245,15 +258,22 @@ async def scan_receipt(image_bytes: bytes, media_type: str) -> ScannedReceipt:
     # forwarding to claude-haiku / claude-sonnet / claude-opus.
     data_uri = f"data:{media_type};base64,{image_b64}"
 
-    # max_tokens is sized for the *output* JSON only; Gemini 2.5 Flash also
-    # burns "reasoning_tokens" before emitting text, so a 1024 cap can cut the
-    # JSON mid-array on a long receipt. 4096 fits ~80 items easily.
-    # response_format json_object forces LiteLLM/Gemini to skip the prose
-    # wrapper ("I see a HEB receipt. Here is the JSON:...") and emit a single
-    # JSON value — eliminates the regex-extraction failure mode.
+    active_model = model or RECEIPT_MODEL
+
+    # thinking_config disables Gemini 2.5 Flash's default reasoning mode,
+    # which otherwise burns the 4096-token budget before emitting JSON.
+    # Only send it for Gemini models — vLLM backends (qwen-vl, etc.) don't
+    # understand the parameter and will 422 if it reaches them.
+    extra: dict = {}
+    if "gemini" in active_model.lower():
+        extra = {"thinking_config": {"thinking_budget": 0}}
+
+    # max_tokens sized for JSON output only; 4096 fits ~80 line items.
+    # response_format json_object forces a single JSON value, eliminating
+    # the "Here is the JSON:" prose-wrapper failure mode.
     try:
         completion = client.chat.completions.create(
-            model=RECEIPT_MODEL,
+            model=active_model,
             max_tokens=4096,
             response_format={"type": "json_object"},
             messages=[
@@ -265,14 +285,7 @@ async def scan_receipt(image_bytes: bytes, media_type: str) -> ScannedReceipt:
                     ],
                 }
             ],
-            # Gemini 2.5 Flash defaults to "thinking" mode which spends
-            # hundreds of reasoning tokens BEFORE emitting any text. On a
-            # 4096-token budget that frequently leaves zero tokens for the
-            # actual JSON response → empty content → ValidationError. Disable
-            # thinking entirely; structured JSON extraction does not benefit
-            # from chain-of-thought. (LiteLLM forwards thinking_config via
-            # extra_body to the Gemini-vertex backend.)
-            extra_body={"thinking_config": {"thinking_budget": 0}},
+            extra_body=extra if extra else None,
         )
     except Exception as exc:
         # Surface all proxy-side failures (budget exceeded, rate limits,
@@ -454,8 +467,11 @@ async def scan_and_create_transaction(
     from app.services.budget.a2a_webhook_service import A2AWebhookService
     from app.services.fx_service import FXService
 
+    # (0) Resolve per-family model preference --------------------------------
+    family_model = await _get_family_model(family_id)
+
     # (1) Vision extract -----------------------------------------------------
-    receipt = await scan_receipt(image_bytes, media_type)
+    receipt = await scan_receipt(image_bytes, media_type, model=family_model)
 
     scanned_dict = {
         "date": receipt.date.isoformat() if receipt.date else None,

--- a/backend/app/services/gig_claim_service.py
+++ b/backend/app/services/gig_claim_service.py
@@ -1,0 +1,227 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select, and_
+from typing import List, Optional
+from uuid import UUID
+from datetime import datetime, timezone
+
+from app.models.gig import GigClaim, GigClaimStatus, GigOffering
+from app.models.point_transaction import PointTransaction
+from app.core.exceptions import (
+    NotFoundException,
+    ForbiddenException,
+    ValidationException,
+)
+
+
+async def _get_user(db: AsyncSession, user_id: UUID):
+    from app.models.user import User
+    user = await db.get(User, user_id)
+    if not user:
+        raise NotFoundException(f"User {user_id} not found")
+    return user
+
+
+class GigClaimService:
+
+    @staticmethod
+    async def claim(
+        db: AsyncSession,
+        gig_id: UUID,
+        user_id: UUID,
+        family_id: UUID,
+    ) -> GigClaim:
+        """Create a new claim. Raises 409-like ValidationException if active claim exists."""
+        # Verify offering exists and is active
+        result = await db.execute(
+            select(GigOffering).where(
+                and_(
+                    GigOffering.id == gig_id,
+                    GigOffering.family_id == family_id,
+                    GigOffering.is_active == True,
+                )
+            )
+        )
+        offering = result.scalar_one_or_none()
+        if not offering:
+            raise NotFoundException(f"Gig offering {gig_id} not found or not active")
+
+        # Check allowed_roles
+        user = await _get_user(db, user_id)
+        if offering.allowed_roles and user.role.value not in offering.allowed_roles:
+            raise ForbiddenException("Tu rol no puede reclamar esta gig")
+
+        # Check no active (non-rejected) claim already exists for this user+gig
+        existing = await db.execute(
+            select(GigClaim).where(
+                and_(
+                    GigClaim.gig_id == gig_id,
+                    GigClaim.claimed_by == user_id,
+                    GigClaim.status != GigClaimStatus.REJECTED,
+                )
+            )
+        )
+        if existing.scalar_one_or_none():
+            raise ValidationException("Ya tienes un reclamo activo para esta gig")
+
+        claim = GigClaim(
+            gig_id=gig_id,
+            family_id=family_id,
+            claimed_by=user_id,
+            status=GigClaimStatus.CLAIMED,
+        )
+        db.add(claim)
+        await db.commit()
+        await db.refresh(claim)
+        return claim
+
+    @staticmethod
+    async def complete(
+        db: AsyncSession,
+        claim_id: UUID,
+        user_id: UUID,
+        proof_text: Optional[str] = None,
+        proof_image_url: Optional[str] = None,
+    ) -> GigClaim:
+        """Submit proof and move claim to COMPLETED."""
+        result = await db.execute(
+            select(GigClaim).where(
+                and_(GigClaim.id == claim_id, GigClaim.claimed_by == user_id)
+            )
+        )
+        claim = result.scalar_one_or_none()
+        if not claim:
+            raise NotFoundException(f"Claim {claim_id} not found")
+        if claim.status != GigClaimStatus.CLAIMED:
+            raise ValidationException(f"Claim is {claim.status.value}, expected claimed")
+
+        claim.proof_text = proof_text
+        claim.proof_image_url = proof_image_url
+        claim.status = GigClaimStatus.COMPLETED
+        claim.completed_at = datetime.now(timezone.utc)
+        await db.commit()
+        await db.refresh(claim)
+        return claim
+
+    @staticmethod
+    async def unclaim(
+        db: AsyncSession,
+        claim_id: UUID,
+        user_id: UUID,
+    ) -> None:
+        """Delete a CLAIMED (not yet submitted) claim."""
+        result = await db.execute(
+            select(GigClaim).where(
+                and_(GigClaim.id == claim_id, GigClaim.claimed_by == user_id)
+            )
+        )
+        claim = result.scalar_one_or_none()
+        if not claim:
+            raise NotFoundException(f"Claim {claim_id} not found")
+        if claim.status != GigClaimStatus.CLAIMED:
+            raise ValidationException("Only CLAIMED (not yet submitted) claims can be unclaimed")
+
+        await db.delete(claim)
+        await db.commit()
+
+    @staticmethod
+    async def get_my_claims(
+        db: AsyncSession,
+        user_id: UUID,
+        family_id: UUID,
+    ) -> List[GigClaim]:
+        result = await db.execute(
+            select(GigClaim).where(
+                and_(
+                    GigClaim.claimed_by == user_id,
+                    GigClaim.family_id == family_id,
+                )
+            ).order_by(GigClaim.created_at.desc())
+        )
+        return result.scalars().all()
+
+    @staticmethod
+    async def get_pending_approvals(
+        db: AsyncSession,
+        family_id: UUID,
+    ) -> List[GigClaim]:
+        result = await db.execute(
+            select(GigClaim).where(
+                and_(
+                    GigClaim.family_id == family_id,
+                    GigClaim.status == GigClaimStatus.COMPLETED,
+                )
+            ).order_by(GigClaim.completed_at.asc())
+        )
+        return result.scalars().all()
+
+    @staticmethod
+    async def approve(
+        db: AsyncSession,
+        claim_id: UUID,
+        approver_id: UUID,
+        family_id: UUID,
+        approved: bool,
+        notes: Optional[str] = None,
+    ) -> GigClaim:
+        from app.models.user import UserRole
+
+        approver = await _get_user(db, approver_id)
+        if approver.family_id != family_id or approver.role != UserRole.PARENT:
+            raise ForbiddenException("Solo padres pueden aprobar gigs")
+
+        result = await db.execute(
+            select(GigClaim).where(
+                and_(GigClaim.id == claim_id, GigClaim.family_id == family_id)
+            )
+        )
+        claim = result.scalar_one_or_none()
+        if not claim:
+            raise NotFoundException(f"Claim {claim_id} not found")
+        if claim.status != GigClaimStatus.COMPLETED:
+            raise ValidationException(
+                f"Claim is {claim.status.value}, expected completed"
+            )
+
+        claim.approved_by = approver_id
+        claim.approved_at = datetime.now(timezone.utc)
+        claim.approval_notes = notes
+
+        if approved:
+            # Load offering for points value
+            offering = await db.get(GigOffering, claim.gig_id)
+            points = offering.points
+
+            claimer = await _get_user(db, claim.claimed_by)
+            txn = PointTransaction.create_gig_claim_approval(
+                user_id=claim.claimed_by,
+                gig_claim_id=claim.id,
+                points=points,
+                balance_before=claimer.points,
+            )
+            claimer.points += points
+            claim.points_awarded = points
+            claim.status = GigClaimStatus.APPROVED
+            db.add(txn)
+
+            # Push notification
+            try:
+                from app.services.notification_service import NotificationService
+                from app.models.notification import NotificationType as NT
+                await db.commit()
+                await NotificationService.create(
+                    db,
+                    family_id=family_id,
+                    user_id=claim.claimed_by,
+                    type=NT.GIG_APPROVED,
+                    title=f"✅ +{points} pts / ${points} MXN",
+                    body=f"'{offering.title}' aprobada por tu padre/madre.",
+                    link="/gigs/my-gigs",
+                )
+            except Exception:
+                pass
+        else:
+            claim.status = GigClaimStatus.REJECTED
+
+        await db.commit()
+        await db.refresh(claim)
+        return claim

--- a/backend/app/services/gig_claim_service.py
+++ b/backend/app/services/gig_claim_service.py
@@ -82,7 +82,10 @@ class GigClaimService:
         proof_text: Optional[str] = None,
         proof_image_url: Optional[str] = None,
     ) -> GigClaim:
-        """Submit proof and move claim to COMPLETED."""
+        """Submit proof. Auto-approves for trusted kids; otherwise moves to
+        COMPLETED and notifies parents that a gig awaits review."""
+        from app.core.config import settings
+
         result = await db.execute(
             select(GigClaim).where(
                 and_(GigClaim.id == claim_id, GigClaim.claimed_by == user_id)
@@ -96,11 +99,93 @@ class GigClaimService:
 
         claim.proof_text = proof_text
         claim.proof_image_url = proof_image_url
-        claim.status = GigClaimStatus.COMPLETED
         claim.completed_at = datetime.now(timezone.utc)
+
+        claimer = await _get_user(db, claim.claimed_by)
+        offering = await db.get(GigOffering, claim.gig_id)
+
+        threshold = max(1, settings.GIG_AUTO_APPROVE_STREAK)
+        if claimer.gig_trust_streak >= threshold:
+            # Trusted kid — auto-approve on submission, award points immediately.
+            points = offering.points if offering else 0
+            txn = PointTransaction.create_gig_claim_approval(
+                user_id=claim.claimed_by,
+                gig_claim_id=claim.id,
+                points=points,
+                balance_before=claimer.points,
+            )
+            claimer.points += points
+            claimer.gig_trust_streak += 1
+            claim.points_awarded = points
+            claim.status = GigClaimStatus.APPROVED
+            claim.approved_at = datetime.now(timezone.utc)
+            db.add(txn)
+            await db.commit()
+            await db.refresh(claim)
+            await GigClaimService._notify_claimer_approved(
+                db, claim, offering, points, auto=True
+            )
+            return claim
+
+        # Normal path — awaits parent review.
+        claim.status = GigClaimStatus.COMPLETED
         await db.commit()
         await db.refresh(claim)
+        await GigClaimService._notify_parents_pending(db, claim, offering, claimer)
         return claim
+
+    @staticmethod
+    async def _notify_parents_pending(db, claim, offering, claimer) -> None:
+        """In-app + push to every parent that a gig awaits review."""
+        try:
+            from app.services.notification_service import NotificationService
+            from app.models.notification import NotificationType as NT
+            from app.models.user import User, UserRole
+
+            parents = (
+                await db.scalars(
+                    select(User).where(
+                        and_(
+                            User.family_id == claim.family_id,
+                            User.role == UserRole.PARENT,
+                            User.is_active.is_(True),
+                        )
+                    )
+                )
+            ).all()
+            title = offering.title if offering else "Gig"
+            for parent in parents:
+                await NotificationService.create(
+                    db,
+                    family_id=claim.family_id,
+                    user_id=parent.id,
+                    type=NT.GIG_PENDING_REVIEW,
+                    title="📋 Gig por revisar",
+                    body=f"{claimer.name} completó '{title}' — revisa y aprueba.",
+                    link="/parent/gigs?tab=pending",
+                )
+        except Exception:
+            pass
+
+    @staticmethod
+    async def _notify_claimer_approved(db, claim, offering, points, auto=False) -> None:
+        try:
+            from app.services.notification_service import NotificationService
+            from app.models.notification import NotificationType as NT
+
+            title = offering.title if offering else "Gig"
+            prefix = "⚡ Auto-aprobada" if auto else "✅"
+            await NotificationService.create(
+                db,
+                family_id=claim.family_id,
+                user_id=claim.claimed_by,
+                type=NT.GIG_APPROVED,
+                title=f"{prefix} +{points} pts / ${points} MXN",
+                body=f"'{title}' " + ("aprobada al instante (¡buena racha!)." if auto else "aprobada."),
+                link="/gigs/my-gigs",
+            )
+        except Exception:
+            pass
 
     @staticmethod
     async def unclaim(
@@ -233,12 +318,11 @@ class GigClaimService:
         claim.approved_at = datetime.now(timezone.utc)
         claim.approval_notes = notes
 
-        if approved:
-            # Load offering for points value
-            offering = await db.get(GigOffering, claim.gig_id)
-            points = offering.points
+        offering = await db.get(GigOffering, claim.gig_id)
+        claimer = await _get_user(db, claim.claimed_by)
 
-            claimer = await _get_user(db, claim.claimed_by)
+        if approved:
+            points = offering.points if offering else 0
             txn = PointTransaction.create_gig_claim_approval(
                 user_id=claim.claimed_by,
                 gig_claim_id=claim.id,
@@ -246,29 +330,35 @@ class GigClaimService:
                 balance_before=claimer.points,
             )
             claimer.points += points
+            # Build trust toward auto-approval on future gigs.
+            claimer.gig_trust_streak += 1
             claim.points_awarded = points
             claim.status = GigClaimStatus.APPROVED
             db.add(txn)
-
-            # Push notification
+            await db.commit()
+            await db.refresh(claim)
+            await GigClaimService._notify_claimer_approved(
+                db, claim, offering, points, auto=False
+            )
+            return claim
+        else:
+            # Rejection breaks the trust streak.
+            claimer.gig_trust_streak = 0
+            claim.status = GigClaimStatus.REJECTED
+            await db.commit()
+            await db.refresh(claim)
             try:
                 from app.services.notification_service import NotificationService
                 from app.models.notification import NotificationType as NT
-                await db.commit()
                 await NotificationService.create(
                     db,
                     family_id=family_id,
                     user_id=claim.claimed_by,
-                    type=NT.GIG_APPROVED,
-                    title=f"✅ +{points} pts / ${points} MXN",
-                    body=f"'{offering.title}' aprobada por tu padre/madre.",
+                    type=NT.GIG_REJECTED,
+                    title="↩️ Gig necesita otro intento",
+                    body=(notes or (offering.title if offering else "Tu gig")),
                     link="/gigs/my-gigs",
                 )
             except Exception:
                 pass
-        else:
-            claim.status = GigClaimStatus.REJECTED
-
-        await db.commit()
-        await db.refresh(claim)
-        return claim
+            return claim

--- a/backend/app/services/gig_claim_service.py
+++ b/backend/app/services/gig_claim_service.py
@@ -143,16 +143,63 @@ class GigClaimService:
     async def get_pending_approvals(
         db: AsyncSession,
         family_id: UUID,
-    ) -> List[GigClaim]:
+    ) -> List[dict]:
+        """Return COMPLETED claims enriched with claimer name and gig title."""
+        from app.models.user import User
+        from sqlalchemy.orm import joinedload
+
         result = await db.execute(
-            select(GigClaim).where(
+            select(GigClaim)
+            .options(
+                joinedload(GigClaim.offering),
+                joinedload(GigClaim.claimer),
+            )
+            .where(
                 and_(
                     GigClaim.family_id == family_id,
                     GigClaim.status == GigClaimStatus.COMPLETED,
                 )
             ).order_by(GigClaim.completed_at.asc())
         )
-        return result.scalars().all()
+        claims = result.unique().scalars().all()
+        return [
+            {
+                "claim": c,
+                "claimer_name": c.claimer.name if c.claimer else str(c.claimed_by),
+                "gig_title": c.offering.title if c.offering else "—",
+                "gig_points": c.offering.points if c.offering else 0,
+            }
+            for c in claims
+        ]
+
+    @staticmethod
+    async def get_my_claims_enriched(
+        db: AsyncSession,
+        user_id: UUID,
+        family_id: UUID,
+    ) -> List[dict]:
+        """Return the user's claims enriched with the offering title and points."""
+        from sqlalchemy.orm import joinedload
+
+        result = await db.execute(
+            select(GigClaim)
+            .options(joinedload(GigClaim.offering))
+            .where(
+                and_(
+                    GigClaim.claimed_by == user_id,
+                    GigClaim.family_id == family_id,
+                )
+            ).order_by(GigClaim.created_at.desc())
+        )
+        claims = result.unique().scalars().all()
+        return [
+            {
+                "claim": c,
+                "gig_title": c.offering.title if c.offering else "—",
+                "gig_points": c.offering.points if c.offering else 0,
+            }
+            for c in claims
+        ]
 
     @staticmethod
     async def approve(

--- a/backend/app/services/gig_offering_service.py
+++ b/backend/app/services/gig_offering_service.py
@@ -1,0 +1,119 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select, and_
+from typing import List, Optional
+from uuid import UUID
+from datetime import datetime, timezone
+
+from app.models.gig import GigOffering, GigClaimStatus
+from app.core.exceptions import NotFoundException, ForbiddenException
+
+
+class GigOfferingService:
+
+    @staticmethod
+    async def list_for_family(
+        db: AsyncSession,
+        family_id: UUID,
+        requesting_user_id: UUID,
+        include_inactive: bool = False,
+    ) -> List[dict]:
+        """List offerings enriched with the requesting user's active claim status."""
+        from app.models.gig import GigClaim
+
+        stmt = select(GigOffering).where(
+            GigOffering.family_id == family_id,
+        )
+        if not include_inactive:
+            stmt = stmt.where(GigOffering.is_active == True)
+        stmt = stmt.order_by(GigOffering.created_at.desc())
+
+        result = await db.execute(stmt)
+        offerings = result.scalars().all()
+
+        # Batch-load the requesting user's non-rejected claims for these offerings
+        offering_ids = [o.id for o in offerings]
+        claim_map: dict[UUID, GigClaim] = {}
+        if offering_ids:
+            claim_stmt = select(GigClaim).where(
+                and_(
+                    GigClaim.gig_id.in_(offering_ids),
+                    GigClaim.claimed_by == requesting_user_id,
+                    GigClaim.status != GigClaimStatus.REJECTED,
+                )
+            )
+            claim_result = await db.execute(claim_stmt)
+            for claim in claim_result.scalars():
+                claim_map[claim.gig_id] = claim
+
+        enriched = []
+        for offering in offerings:
+            claim = claim_map.get(offering.id)
+            enriched.append({
+                "offering": offering,
+                "my_claim": claim,
+            })
+        return enriched
+
+    @staticmethod
+    async def get_by_id(db: AsyncSession, offering_id: UUID, family_id: UUID) -> GigOffering:
+        result = await db.execute(
+            select(GigOffering).where(
+                and_(GigOffering.id == offering_id, GigOffering.family_id == family_id)
+            )
+        )
+        offering = result.scalar_one_or_none()
+        if not offering:
+            raise NotFoundException(f"Gig offering {offering_id} not found")
+        return offering
+
+    @staticmethod
+    async def create(
+        db: AsyncSession,
+        family_id: UUID,
+        created_by: UUID,
+        title: str,
+        points: int,
+        difficulty: int = 1,
+        category: str = "other",
+        description: Optional[str] = None,
+        allowed_roles: Optional[list] = None,
+    ) -> GigOffering:
+        offering = GigOffering(
+            family_id=family_id,
+            created_by=created_by,
+            title=title,
+            description=description,
+            points=points,
+            difficulty=difficulty,
+            category=category,
+            allowed_roles=allowed_roles,
+        )
+        db.add(offering)
+        await db.commit()
+        await db.refresh(offering)
+        return offering
+
+    @staticmethod
+    async def update(
+        db: AsyncSession,
+        offering_id: UUID,
+        family_id: UUID,
+        **fields,
+    ) -> GigOffering:
+        offering = await GigOfferingService.get_by_id(db, offering_id, family_id)
+        for key, value in fields.items():
+            if hasattr(offering, key) and value is not None:
+                setattr(offering, key, value)
+        offering.updated_at = datetime.now(timezone.utc)
+        await db.commit()
+        await db.refresh(offering)
+        return offering
+
+    @staticmethod
+    async def deactivate(db: AsyncSession, offering_id: UUID, family_id: UUID) -> GigOffering:
+        offering = await GigOfferingService.get_by_id(db, offering_id, family_id)
+        offering.is_active = False
+        offering.updated_at = datetime.now(timezone.utc)
+        await db.commit()
+        await db.refresh(offering)
+        return offering

--- a/backend/app/services/jarvis_schedule_service.py
+++ b/backend/app/services/jarvis_schedule_service.py
@@ -1,4 +1,4 @@
-"""Frankie schedule service (W9.1).
+"""Jarvis schedule service (W9.1).
 
 Stores recurring prompts + handles cron tick that fires due ones. Uses
 APScheduler's CronTrigger to compute next_run_at from the stored
@@ -15,7 +15,7 @@ from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.exceptions import NotFoundException, ValidationException
-from app.models.frankie_schedule import FrankieSchedule, VALID_CHANNELS
+from app.models.jarvis_schedule import JarvisSchedule, VALID_CHANNELS
 
 
 def _translate_dow_linux_to_apscheduler(field: str) -> str:
@@ -81,7 +81,7 @@ def _next_fire(trigger: CronTrigger, after: datetime) -> datetime:
     return nxt
 
 
-class FrankieScheduleService:
+class JarvisScheduleService:
     @staticmethod
     async def create(
         db: AsyncSession,
@@ -92,7 +92,7 @@ class FrankieScheduleService:
         prompt: str,
         cron_expr: str,
         channel: str = "notification",
-    ) -> FrankieSchedule:
+    ) -> JarvisSchedule:
         if channel not in VALID_CHANNELS:
             raise ValidationException(f"channel must be one of {sorted(VALID_CHANNELS)}")
         if not name.strip() or not prompt.strip():
@@ -100,7 +100,7 @@ class FrankieScheduleService:
         trigger = _parse_cron(cron_expr)
         now = datetime.now(timezone.utc)
         nxt = _next_fire(trigger, now)
-        s = FrankieSchedule(
+        s = JarvisSchedule(
             family_id=family_id,
             created_by=created_by,
             name=name.strip()[:120],
@@ -118,11 +118,11 @@ class FrankieScheduleService:
     @staticmethod
     async def list(
         db: AsyncSession, family_id: UUID
-    ) -> List[FrankieSchedule]:
+    ) -> List[JarvisSchedule]:
         q = (
-            select(FrankieSchedule)
-            .where(FrankieSchedule.family_id == family_id)
-            .order_by(FrankieSchedule.created_at.desc())
+            select(JarvisSchedule)
+            .where(JarvisSchedule.family_id == family_id)
+            .order_by(JarvisSchedule.created_at.desc())
         )
         return list((await db.execute(q)).scalars().all())
 
@@ -130,10 +130,10 @@ class FrankieScheduleService:
     async def delete(
         db: AsyncSession, schedule_id: UUID, family_id: UUID
     ) -> None:
-        q = select(FrankieSchedule).where(
+        q = select(JarvisSchedule).where(
             and_(
-                FrankieSchedule.id == schedule_id,
-                FrankieSchedule.family_id == family_id,
+                JarvisSchedule.id == schedule_id,
+                JarvisSchedule.family_id == family_id,
             )
         )
         s = (await db.execute(q)).scalar_one_or_none()
@@ -145,11 +145,11 @@ class FrankieScheduleService:
     @staticmethod
     async def toggle(
         db: AsyncSession, schedule_id: UUID, family_id: UUID
-    ) -> FrankieSchedule:
-        q = select(FrankieSchedule).where(
+    ) -> JarvisSchedule:
+        q = select(JarvisSchedule).where(
             and_(
-                FrankieSchedule.id == schedule_id,
-                FrankieSchedule.family_id == family_id,
+                JarvisSchedule.id == schedule_id,
+                JarvisSchedule.family_id == family_id,
             )
         )
         s = (await db.execute(q)).scalar_one_or_none()
@@ -168,11 +168,11 @@ class FrankieScheduleService:
     async def sweep_due(db: AsyncSession) -> int:
         """Fire every schedule whose next_run_at <= now. Returns count fired.
 
-        Each fire calls FrankieService.chat with the stored prompt as the
+        Each fire calls JarvisService.chat with the stored prompt as the
         creator's message, then delivers the reply to the chosen channel.
         Failures are logged and don't stop other schedules in the same sweep.
         """
-        from app.services.frankie_service import FrankieService
+        from app.services.jarvis_service import JarvisService
         from app.services.notification_service import NotificationService
         from app.services.family_chat_service import FamilyChatService
         from app.models.notification import NotificationType
@@ -180,12 +180,12 @@ class FrankieScheduleService:
 
         now = datetime.now(timezone.utc)
         q = (
-            select(FrankieSchedule)
+            select(JarvisSchedule)
             .where(
                 and_(
-                    FrankieSchedule.is_active.is_(True),
-                    FrankieSchedule.next_run_at.isnot(None),
-                    FrankieSchedule.next_run_at <= now,
+                    JarvisSchedule.is_active.is_(True),
+                    JarvisSchedule.next_run_at.isnot(None),
+                    JarvisSchedule.next_run_at <= now,
                 )
             )
             .limit(50)
@@ -194,7 +194,7 @@ class FrankieScheduleService:
         fired = 0
         for s in due:
             try:
-                result = await FrankieService.chat(
+                result = await JarvisService.chat(
                     db,
                     family_id=s.family_id,
                     user_id=s.created_by or s.family_id,  # fallback
@@ -214,7 +214,7 @@ class FrankieScheduleService:
                         type=NotificationType.SHOPPING_ITEM_ADDED,
                         title=f"🤖 {s.name}",
                         body=reply[:200],
-                        link="/parent/frankie",
+                        link="/parent/jarvis",
                     )
                 fired += 1
             except ValidationError:

--- a/backend/app/services/jarvis_service.py
+++ b/backend/app/services/jarvis_service.py
@@ -1,4 +1,4 @@
-"""Frankie copilot service (W6.1 + W6.8).
+"""Jarvis copilot service (W6.1 + W6.8).
 
 Conversational parental coach. Reuses the LiteLLM proxy (same model alias
 as the receipt scanner) for centralized spend tracking. Each call:
@@ -6,7 +6,7 @@ as the receipt scanner) for centralized spend tracking. Each call:
 1. Pulls fresh family context (PUP score + today's task summary + pet states).
 2. Loads last N chat turns for the family.
 3. Builds an OpenAI-format messages array with a load-bearing system prompt.
-4. Calls LiteLLM with tool definitions from ``frankie_tools.REGISTRY``.
+4. Calls LiteLLM with tool definitions from ``jarvis_tools.REGISTRY``.
 5. Multi-hop tool execution (max ``MAX_TOOL_HOPS``).
 6. Persists both the user's message and the reply.
 """
@@ -22,18 +22,18 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.core.exceptions import ValidationError
-from app.models.frankie_message import FrankieMessage
+from app.models.jarvis_message import JarvisMessage
 from app.models.kid_pet import KidPet
 from app.models.task_assignment import TaskAssignment, AssignmentStatus
 from app.models.user import User
 from app.services.analytics_service import AnalyticsService
 from app.services.budget.receipt_scanner_service import RECEIPT_MODEL
-from app.services.frankie_tools import REGISTRY, dispatch, tool_definitions
+from app.services.jarvis_tools import REGISTRY, dispatch, tool_definitions
 
 
-# Frankie model alias — defaults to receipt scanner's claude-haiku for
-# shared LiteLLM budget. Override via FRANKIE_MODEL env var.
-CHAT_MODEL = settings.FRANKIE_MODEL or RECEIPT_MODEL
+# Jarvis model alias — defaults to receipt scanner's claude-haiku for
+# shared LiteLLM budget. Override via JARVIS_MODEL env var.
+CHAT_MODEL = settings.JARVIS_MODEL or RECEIPT_MODEL
 
 SYSTEM_BASE = (
     "You are Jarvis, a calm, practical family-routines copilot. You help "
@@ -48,11 +48,11 @@ MAX_TOOL_HOPS = 4
 
 
 # Module-level alias kept for tests that import TOOL_DEFINITIONS directly.
-# Source of truth is ``frankie_tools.REGISTRY``.
+# Source of truth is ``jarvis_tools.REGISTRY``.
 TOOL_DEFINITIONS: list[dict] = tool_definitions()
 
 
-class FrankieService:
+class JarvisService:
     @staticmethod
     async def _build_context(db: AsyncSession, family_id: UUID) -> str:
         """Fetch live family state and render it as a system-prompt block."""
@@ -113,11 +113,11 @@ class FrankieService:
     @staticmethod
     async def _load_history(
         db: AsyncSession, family_id: UUID, limit: int
-    ) -> List[FrankieMessage]:
+    ) -> List[JarvisMessage]:
         q = (
-            select(FrankieMessage)
-            .where(FrankieMessage.family_id == family_id)
-            .order_by(FrankieMessage.created_at.desc())
+            select(JarvisMessage)
+            .where(JarvisMessage.family_id == family_id)
+            .order_by(JarvisMessage.created_at.desc())
             .limit(limit)
         )
         rows = list((await db.execute(q)).scalars().all())
@@ -145,12 +145,12 @@ class FrankieService:
         )
         q = (
             select(func.count())
-            .select_from(FrankieMessage)
+            .select_from(JarvisMessage)
             .where(
                 and_(
-                    FrankieMessage.family_id == family_id,
-                    FrankieMessage.role == "user",
-                    FrankieMessage.created_at >= cutoff,
+                    JarvisMessage.family_id == family_id,
+                    JarvisMessage.role == "user",
+                    JarvisMessage.created_at >= cutoff,
                 )
             )
         )
@@ -183,19 +183,19 @@ class FrankieService:
             msg = (message or "").strip()
             if not msg:
                 raise ValidationError("Message is empty.")
-            cap = int(settings.FRANKIE_DAILY_MESSAGE_CAP or 0)
+            cap = int(settings.JARVIS_DAILY_MESSAGE_CAP or 0)
             if cap > 0:
-                if await FrankieService._today_message_count(db, family_id) >= cap:
+                if await JarvisService._today_message_count(db, family_id) >= cap:
                     raise ValidationError(
                         f"Daily Jarvis cap reached ({cap}). Try again tomorrow."
                     )
 
             yield "event: thinking\ndata: {}\n\n"
 
-            history = await FrankieService._load_history(
+            history = await JarvisService._load_history(
                 db, family_id, limit=MAX_HISTORY_TURNS
             )
-            context_block = await FrankieService._build_context(db, family_id)
+            context_block = await JarvisService._build_context(db, family_id)
             msgs: list[dict[str, Any]] = [
                 {"role": "system", "content": SYSTEM_BASE + "\n\n" + context_block}
             ]
@@ -270,10 +270,10 @@ class FrankieService:
             if not reply:
                 reply = "I had nothing useful to say. Try rephrasing?"
 
-            user_row = FrankieMessage(
+            user_row = JarvisMessage(
                 family_id=family_id, user_id=user_id, role="user", content=msg
             )
-            bot_row = FrankieMessage(
+            bot_row = JarvisMessage(
                 family_id=family_id,
                 user_id=None,
                 role="assistant",
@@ -320,18 +320,18 @@ class FrankieService:
         if not message:
             raise ValidationError("Message is empty.")
 
-        cap = int(settings.FRANKIE_DAILY_MESSAGE_CAP or 0)
+        cap = int(settings.JARVIS_DAILY_MESSAGE_CAP or 0)
         if cap > 0:
-            sent_today = await FrankieService._today_message_count(db, family_id)
+            sent_today = await JarvisService._today_message_count(db, family_id)
             if sent_today >= cap:
                 raise ValidationError(
                     f"Daily Jarvis cap reached ({cap}). Try again tomorrow."
                 )
 
-        history = await FrankieService._load_history(
+        history = await JarvisService._load_history(
             db, family_id, limit=MAX_HISTORY_TURNS
         )
-        context_block = await FrankieService._build_context(db, family_id)
+        context_block = await JarvisService._build_context(db, family_id)
 
         msgs: list[dict[str, Any]] = [
             {"role": "system", "content": SYSTEM_BASE + "\n\n" + context_block}
@@ -405,10 +405,10 @@ class FrankieService:
         if not reply:
             reply = "I had nothing useful to say. Try rephrasing?"
 
-        user_msg = FrankieMessage(
+        user_msg = JarvisMessage(
             family_id=family_id, user_id=user_id, role="user", content=message
         )
-        bot_msg = FrankieMessage(
+        bot_msg = JarvisMessage(
             family_id=family_id,
             user_id=None,
             role="assistant",
@@ -428,14 +428,14 @@ class FrankieService:
     @staticmethod
     async def list_history(
         db: AsyncSession, family_id: UUID, limit: int = HISTORY_RETURN_LIMIT
-    ) -> List[FrankieMessage]:
-        return await FrankieService._load_history(db, family_id, limit=limit)
+    ) -> List[JarvisMessage]:
+        return await JarvisService._load_history(db, family_id, limit=limit)
 
     @staticmethod
     async def clear_history(db: AsyncSession, family_id: UUID) -> int:
         from sqlalchemy import delete as sql_delete
         result = await db.execute(
-            sql_delete(FrankieMessage).where(FrankieMessage.family_id == family_id)
+            sql_delete(JarvisMessage).where(JarvisMessage.family_id == family_id)
         )
         await db.commit()
         return result.rowcount or 0

--- a/backend/app/services/jarvis_tools.py
+++ b/backend/app/services/jarvis_tools.py
@@ -1,4 +1,4 @@
-"""Frankie tool registry (W6.8).
+"""Jarvis tool registry (W6.8).
 
 Each tool is a small async handler bundled with its OpenAI-format function
 schema. A flat REGISTRY maps tool name → (definition, handler). The chat
@@ -219,10 +219,10 @@ async def _list_recent_notifications(db, family_id, user_id, args):
     }
 
 
-async def _schedule_frankie_prompt(db, family_id, user_id, args):
-    from app.services.frankie_schedule_service import FrankieScheduleService
+async def _schedule_jarvis_prompt(db, family_id, user_id, args):
+    from app.services.jarvis_schedule_service import JarvisScheduleService
 
-    s = await FrankieScheduleService.create(
+    s = await JarvisScheduleService.create(
         db,
         family_id=family_id,
         created_by=user_id,
@@ -496,10 +496,10 @@ _DEF_SCHEDULE_MEAL = {
 }
 
 
-_DEF_SCHEDULE_FRANKIE = {
+_DEF_SCHEDULE_JARVIS = {
     "type": "function",
     "function": {
-        "name": "schedule_frankie_prompt",
+        "name": "schedule_jarvis_prompt",
         "description": (
             "Set up a recurring Jarvis prompt that runs on a cron schedule "
             "(e.g. 'weekly Sunday summary at 6pm'). Output goes to the "
@@ -540,7 +540,7 @@ REGISTRY: Dict[str, Tuple[dict, Handler]] = {
     "add_shopping_item":         (_DEF_ADD_SHOPPING,   _add_shopping_item),
     "add_recipe":                (_DEF_ADD_RECIPE,     _add_recipe),
     "schedule_meal":             (_DEF_SCHEDULE_MEAL,  _schedule_meal),
-    "schedule_frankie_prompt":   (_DEF_SCHEDULE_FRANKIE, _schedule_frankie_prompt),
+    "schedule_jarvis_prompt":   (_DEF_SCHEDULE_JARVIS, _schedule_jarvis_prompt),
 }
 
 

--- a/backend/migrations/versions/2026_06_01_gig_tables.py
+++ b/backend/migrations/versions/2026_06_01_gig_tables.py
@@ -1,0 +1,126 @@
+"""gig_offerings and gig_claims tables
+
+Revision ID: gig_tables
+Revises: receipt_image_path
+Create Date: 2026-06-01
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = 'gig_tables'
+down_revision = 'group_is_transfer'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Enums
+    gigcategory = postgresql.ENUM(
+        'chores', 'errands', 'creative', 'learning', 'outdoor', 'other',
+        name='gigcategory',
+        create_type=True,
+    )
+    gigclaimstatus = postgresql.ENUM(
+        'claimed', 'completed', 'approved', 'rejected',
+        name='gigclaimstatus',
+        create_type=True,
+    )
+
+    op.create_table(
+        'gig_offerings',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column('family_id', postgresql.UUID(as_uuid=True), sa.ForeignKey('families.id', ondelete='CASCADE'), nullable=False),
+        sa.Column('title', sa.String(200), nullable=False),
+        sa.Column('description', sa.Text, nullable=True),
+        sa.Column('points', sa.Integer, nullable=False),
+        sa.Column('difficulty', sa.Integer, nullable=False, server_default='1'),
+        sa.Column('category', gigcategory, nullable=False, server_default='other'),
+        sa.Column('allowed_roles', postgresql.JSONB, nullable=True),
+        sa.Column('is_active', sa.Boolean, nullable=False, server_default='true'),
+        sa.Column('created_by', postgresql.UUID(as_uuid=True), sa.ForeignKey('users.id', ondelete='SET NULL'), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.CheckConstraint('difficulty BETWEEN 1 AND 3', name='chk_gig_difficulty_range'),
+        sa.CheckConstraint('points > 0', name='chk_gig_points_positive'),
+    )
+    op.create_index('ix_gig_offerings_family_id', 'gig_offerings', ['family_id'])
+    op.create_index('ix_gig_offerings_is_active', 'gig_offerings', ['is_active'])
+
+    op.create_table(
+        'gig_claims',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column('gig_id', postgresql.UUID(as_uuid=True), sa.ForeignKey('gig_offerings.id', ondelete='CASCADE'), nullable=False),
+        sa.Column('family_id', postgresql.UUID(as_uuid=True), sa.ForeignKey('families.id', ondelete='CASCADE'), nullable=False),
+        sa.Column('claimed_by', postgresql.UUID(as_uuid=True), sa.ForeignKey('users.id', ondelete='CASCADE'), nullable=False),
+        sa.Column('status', gigclaimstatus, nullable=False, server_default='claimed'),
+        sa.Column('proof_text', sa.Text, nullable=True),
+        sa.Column('proof_image_url', sa.String(500), nullable=True),
+        sa.Column('points_awarded', sa.Integer, nullable=True),
+        sa.Column('completed_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('approved_by', postgresql.UUID(as_uuid=True), sa.ForeignKey('users.id', ondelete='SET NULL'), nullable=True),
+        sa.Column('approved_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('approval_notes', sa.Text, nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+    op.create_index('ix_gig_claims_gig_id', 'gig_claims', ['gig_id'])
+    op.create_index('ix_gig_claims_family_id', 'gig_claims', ['family_id'])
+    op.create_index('ix_gig_claims_claimed_by', 'gig_claims', ['claimed_by'])
+    op.create_index('ix_gig_claims_status', 'gig_claims', ['status'])
+    op.create_index('ix_gig_claims_created_at', 'gig_claims', ['created_at'])
+    # Partial unique: one active (non-rejected) claim per user per gig
+    op.execute(
+        "CREATE UNIQUE INDEX uq_gig_claim_active "
+        "ON gig_claims (gig_id, claimed_by) "
+        "WHERE status != 'rejected'"
+    )
+
+    # Add gig_claim_id FK to point_transactions
+    op.add_column(
+        'point_transactions',
+        sa.Column(
+            'gig_claim_id',
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey('gig_claims.id', ondelete='SET NULL'),
+            nullable=True,
+        )
+    )
+
+    # Data migration: copy existing is_bonus=TRUE task_templates → gig_offerings
+    op.execute("""
+        INSERT INTO gig_offerings (
+            id, family_id, title, description, points, difficulty,
+            category, allowed_roles, is_active, created_by, created_at, updated_at
+        )
+        SELECT
+            id,
+            family_id,
+            title,
+            description,
+            GREATEST(points, 1),
+            COALESCE(effort_level, 1),
+            'other'::gigcategory,
+            allowed_roles,
+            is_active,
+            created_by,
+            created_at,
+            updated_at
+        FROM task_templates
+        WHERE is_bonus = TRUE
+    """)
+
+    # Soft-delete migrated templates so they no longer appear in mandatory task views
+    op.execute("""
+        UPDATE task_templates
+        SET is_active = FALSE
+        WHERE is_bonus = TRUE
+    """)
+
+
+def downgrade() -> None:
+    op.execute("UPDATE task_templates SET is_active = TRUE WHERE is_bonus = TRUE")
+    op.drop_column('point_transactions', 'gig_claim_id')
+    op.drop_table('gig_claims')
+    op.drop_table('gig_offerings')
+    op.execute("DROP TYPE IF EXISTS gigclaimstatus")
+    op.execute("DROP TYPE IF EXISTS gigcategory")

--- a/backend/migrations/versions/2026_06_04_jarvis_rename.py
+++ b/backend/migrations/versions/2026_06_04_jarvis_rename.py
@@ -1,0 +1,63 @@
+"""rename frankie -> jarvis (tables, indexes, check constraints)
+
+Renames the AI-assistant tables created by frankie_v1 / frankie_sch_v1 to the
+new "jarvis" brand. Pure metadata operations in Postgres (ALTER ... RENAME) —
+fast, lock-light, fully data-preserving. No row rewrites.
+
+NOTE: the historical migrations (frankie_v1, frankie_sch_v1) are left untouched
+on purpose — they record the schema as it existed at that point. This migration
+carries the rename forward.
+
+Revision ID: jarvis_rename_v1
+Revises: gig_tables
+Create Date: 2026-06-04
+"""
+from alembic import op
+
+
+revision = "jarvis_rename_v1"
+down_revision = "gig_tables"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.rename_table("frankie_messages", "jarvis_messages")
+    op.rename_table("frankie_schedules", "jarvis_schedules")
+    op.execute(
+        "ALTER INDEX IF EXISTS ix_frankie_family_created "
+        "RENAME TO ix_jarvis_family_created"
+    )
+    op.execute(
+        "ALTER INDEX IF EXISTS ix_frankie_sched_active_next "
+        "RENAME TO ix_jarvis_sched_active_next"
+    )
+    op.execute(
+        "ALTER TABLE jarvis_messages "
+        "RENAME CONSTRAINT chk_frankie_role TO chk_jarvis_role"
+    )
+    op.execute(
+        "ALTER TABLE jarvis_schedules "
+        "RENAME CONSTRAINT chk_frankie_channel TO chk_jarvis_channel"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "ALTER TABLE jarvis_schedules "
+        "RENAME CONSTRAINT chk_jarvis_channel TO chk_frankie_channel"
+    )
+    op.execute(
+        "ALTER TABLE jarvis_messages "
+        "RENAME CONSTRAINT chk_jarvis_role TO chk_frankie_role"
+    )
+    op.execute(
+        "ALTER INDEX IF EXISTS ix_jarvis_sched_active_next "
+        "RENAME TO ix_frankie_sched_active_next"
+    )
+    op.execute(
+        "ALTER INDEX IF EXISTS ix_jarvis_family_created "
+        "RENAME TO ix_frankie_family_created"
+    )
+    op.rename_table("jarvis_schedules", "frankie_schedules")
+    op.rename_table("jarvis_messages", "frankie_messages")

--- a/backend/tests/test_gig_board.py
+++ b/backend/tests/test_gig_board.py
@@ -308,3 +308,63 @@ async def test_points_equal_gig_value(
 
     await db_session.refresh(test_child_user)
     assert test_child_user.points == initial_points + points_value
+
+
+async def _claim_complete_approve(client, parent_headers, child_headers, title, points, approve=True):
+    create = await client.post(
+        "/api/gigs/offerings", json={"title": title, "points": points}, headers=parent_headers
+    )
+    gig_id = create.json()["id"]
+    claim = await client.post(f"/api/gigs/offerings/{gig_id}/claim", headers=child_headers)
+    claim_id = claim.json()["id"]
+    await client.post(f"/api/gigs/claims/{claim_id}/complete", json={"proof_text": "x"}, headers=child_headers)
+    return await client.post(
+        f"/api/gigs/claims/{claim_id}/approve", json={"approved": approve}, headers=parent_headers
+    )
+
+
+@pytest.mark.asyncio
+async def test_streak_increments_on_approve_and_resets_on_reject(
+    client: AsyncClient, parent_headers, child_headers, test_child_user, db_session: AsyncSession
+):
+    assert test_child_user.gig_trust_streak == 0
+    await _claim_complete_approve(client, parent_headers, child_headers, "G1", 10)
+    await db_session.refresh(test_child_user)
+    assert test_child_user.gig_trust_streak == 1
+
+    await _claim_complete_approve(client, parent_headers, child_headers, "G2", 10)
+    await db_session.refresh(test_child_user)
+    assert test_child_user.gig_trust_streak == 2
+
+    # Rejection breaks the streak.
+    await _claim_complete_approve(client, parent_headers, child_headers, "G3", 10, approve=False)
+    await db_session.refresh(test_child_user)
+    assert test_child_user.gig_trust_streak == 0
+
+
+@pytest.mark.asyncio
+async def test_auto_approve_when_streak_at_threshold(
+    client: AsyncClient, parent_headers, child_headers, test_child_user, db_session: AsyncSession
+):
+    # Pre-seed streak at the threshold (GIG_AUTO_APPROVE_STREAK default 3).
+    test_child_user.gig_trust_streak = 3
+    db_session.add(test_child_user)
+    await db_session.commit()
+
+    create = await client.post(
+        "/api/gigs/offerings", json={"title": "Trusted gig", "points": 40}, headers=parent_headers
+    )
+    gig_id = create.json()["id"]
+    claim = await client.post(f"/api/gigs/offerings/{gig_id}/claim", headers=child_headers)
+    claim_id = claim.json()["id"]
+
+    # Completing alone should auto-approve (no parent action) for a trusted kid.
+    complete = await client.post(
+        f"/api/gigs/claims/{claim_id}/complete", json={"proof_text": "trusted"}, headers=child_headers
+    )
+    assert complete.status_code == 200
+    assert complete.json()["status"] == "approved"
+    assert complete.json()["points_awarded"] == 40
+
+    await db_session.refresh(test_child_user)
+    assert test_child_user.gig_trust_streak == 4  # incremented on auto-approve

--- a/backend/tests/test_gig_board.py
+++ b/backend/tests/test_gig_board.py
@@ -1,0 +1,310 @@
+"""Tests for the new gig board system (gig_offerings + gig_claims)."""
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+@pytest_asyncio.fixture
+async def parent_headers(client: AsyncClient, test_parent_user) -> dict:
+    res = await client.post(
+        "/api/auth/login",
+        json={"email": "parent@test.com", "password": "password123"},
+    )
+    token = res.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest_asyncio.fixture
+async def child_headers(client: AsyncClient, test_child_user) -> dict:
+    res = await client.post(
+        "/api/auth/login",
+        json={"email": "child@test.com", "password": "password123"},
+    )
+    token = res.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest_asyncio.fixture
+async def teen_headers(client: AsyncClient, test_teen_user) -> dict:
+    res = await client.post(
+        "/api/auth/login",
+        json={"email": "teen@test.local", "password": "password123"},
+    )
+    token = res.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ── Offering CRUD ─────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_parent_create_offering(client: AsyncClient, parent_headers, test_family):
+    res = await client.post(
+        "/api/gigs/offerings",
+        json={"title": "Wash the car", "points": 50, "difficulty": 2, "category": "chores"},
+        headers=parent_headers,
+    )
+    assert res.status_code == 201, res.text
+    data = res.json()
+    assert data["title"] == "Wash the car"
+    assert data["points"] == 50
+    assert data["difficulty"] == 2
+
+
+@pytest.mark.asyncio
+async def test_child_cannot_create_offering(client: AsyncClient, child_headers):
+    res = await client.post(
+        "/api/gigs/offerings",
+        json={"title": "Test", "points": 10, "difficulty": 1},
+        headers=child_headers,
+    )
+    assert res.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_list_offerings_shows_my_claim(
+    client: AsyncClient, parent_headers, child_headers, test_family
+):
+    # Parent creates gig
+    create_res = await client.post(
+        "/api/gigs/offerings",
+        json={"title": "Clean garage", "points": 30},
+        headers=parent_headers,
+    )
+    assert create_res.status_code == 201
+    gig_id = create_res.json()["id"]
+
+    # Kid claims it
+    claim_res = await client.post(f"/api/gigs/offerings/{gig_id}/claim", headers=child_headers)
+    assert claim_res.status_code == 201
+
+    # List shows my_claim populated
+    list_res = await client.get("/api/gigs/offerings", headers=child_headers)
+    assert list_res.status_code == 200
+    items = list_res.json()
+    my_item = next((i for i in items if i["offering"]["id"] == gig_id), None)
+    assert my_item is not None
+    assert my_item["my_claim"] is not None
+    assert my_item["my_claim"]["status"] == "claimed"
+
+
+@pytest.mark.asyncio
+async def test_edit_and_deactivate_offering(client: AsyncClient, parent_headers):
+    create_res = await client.post(
+        "/api/gigs/offerings",
+        json={"title": "Mow lawn", "points": 40},
+        headers=parent_headers,
+    )
+    gig_id = create_res.json()["id"]
+
+    edit_res = await client.put(
+        f"/api/gigs/offerings/{gig_id}",
+        json={"points": 60},
+        headers=parent_headers,
+    )
+    assert edit_res.status_code == 200
+    assert edit_res.json()["points"] == 60
+
+    del_res = await client.delete(f"/api/gigs/offerings/{gig_id}", headers=parent_headers)
+    assert del_res.status_code == 204
+
+    # Deactivated offering no longer appears in list
+    list_res = await client.get("/api/gigs/offerings", headers=parent_headers)
+    ids = [i["offering"]["id"] for i in list_res.json()]
+    assert gig_id not in ids
+
+
+# ── Claim lifecycle ───────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_claim_complete_approve_awards_points(
+    client: AsyncClient, parent_headers, child_headers, test_child_user, db_session: AsyncSession
+):
+    # Create gig
+    create_res = await client.post(
+        "/api/gigs/offerings",
+        json={"title": "Cook dinner", "points": 25},
+        headers=parent_headers,
+    )
+    gig_id = create_res.json()["id"]
+
+    # Child claims
+    claim_res = await client.post(f"/api/gigs/offerings/{gig_id}/claim", headers=child_headers)
+    assert claim_res.status_code == 201
+    claim_id = claim_res.json()["id"]
+
+    # Child submits proof
+    complete_res = await client.post(
+        f"/api/gigs/claims/{claim_id}/complete",
+        json={"proof_text": "Made pasta for everyone!"},
+        headers=child_headers,
+    )
+    assert complete_res.status_code == 200
+    assert complete_res.json()["status"] == "completed"
+
+    # Parent approves
+    approve_res = await client.post(
+        f"/api/gigs/claims/{claim_id}/approve",
+        json={"approved": True},
+        headers=parent_headers,
+    )
+    assert approve_res.status_code == 200
+    data = approve_res.json()
+    assert data["status"] == "approved"
+    assert data["points_awarded"] == 25
+
+    # Verify points on user
+    await db_session.refresh(test_child_user)
+    assert test_child_user.points == 125  # 100 initial + 25
+
+
+@pytest.mark.asyncio
+async def test_reject_claim_no_points(
+    client: AsyncClient, parent_headers, child_headers, test_child_user, db_session: AsyncSession
+):
+    create_res = await client.post(
+        "/api/gigs/offerings",
+        json={"title": "Rejected gig", "points": 20},
+        headers=parent_headers,
+    )
+    gig_id = create_res.json()["id"]
+
+    claim_res = await client.post(f"/api/gigs/offerings/{gig_id}/claim", headers=child_headers)
+    claim_id = claim_res.json()["id"]
+
+    await client.post(
+        f"/api/gigs/claims/{claim_id}/complete",
+        json={"proof_text": "done"},
+        headers=child_headers,
+    )
+
+    reject_res = await client.post(
+        f"/api/gigs/claims/{claim_id}/approve",
+        json={"approved": False, "notes": "Not done properly"},
+        headers=parent_headers,
+    )
+    assert reject_res.status_code == 200
+    assert reject_res.json()["status"] == "rejected"
+
+    await db_session.refresh(test_child_user)
+    assert test_child_user.points == 100  # unchanged
+
+
+@pytest.mark.asyncio
+async def test_two_kids_claim_same_gig_independently(
+    client: AsyncClient, parent_headers, child_headers, db_session: AsyncSession, test_family
+):
+    # Create a second child user with a valid email domain
+    from app.models.user import User, UserRole
+    from app.core.security import get_password_hash
+
+    kid2 = User(
+        email="kid2@example.com",
+        password_hash=get_password_hash("password123"),
+        name="Kid Two",
+        role=UserRole.CHILD,
+        family_id=test_family.id,
+        email_verified=True,
+        points=0,
+    )
+    db_session.add(kid2)
+    await db_session.commit()
+
+    login_res = await client.post(
+        "/api/auth/login",
+        json={"email": "kid2@example.com", "password": "password123"},
+    )
+    assert login_res.status_code == 200, f"Kid2 login failed: {login_res.text}"
+    kid2_headers = {"Authorization": f"Bearer {login_res.json()['access_token']}"}
+
+    create_res = await client.post(
+        "/api/gigs/offerings",
+        json={"title": "Help with groceries", "points": 15},
+        headers=parent_headers,
+    )
+    gig_id = create_res.json()["id"]
+
+    child_claim = await client.post(f"/api/gigs/offerings/{gig_id}/claim", headers=child_headers)
+    kid2_claim = await client.post(f"/api/gigs/offerings/{gig_id}/claim", headers=kid2_headers)
+
+    assert child_claim.status_code == 201
+    assert kid2_claim.status_code == 201
+    assert child_claim.json()["id"] != kid2_claim.json()["id"]
+
+
+@pytest.mark.asyncio
+async def test_duplicate_claim_rejected(
+    client: AsyncClient, parent_headers, child_headers
+):
+    create_res = await client.post(
+        "/api/gigs/offerings",
+        json={"title": "Unique gig", "points": 10},
+        headers=parent_headers,
+    )
+    gig_id = create_res.json()["id"]
+
+    first = await client.post(f"/api/gigs/offerings/{gig_id}/claim", headers=child_headers)
+    second = await client.post(f"/api/gigs/offerings/{gig_id}/claim", headers=child_headers)
+
+    assert first.status_code == 201
+    assert second.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_unclaim_removes_claim(
+    client: AsyncClient, parent_headers, child_headers
+):
+    create_res = await client.post(
+        "/api/gigs/offerings",
+        json={"title": "Unclaim test gig", "points": 10},
+        headers=parent_headers,
+    )
+    gig_id = create_res.json()["id"]
+
+    claim_res = await client.post(f"/api/gigs/offerings/{gig_id}/claim", headers=child_headers)
+    claim_id = claim_res.json()["id"]
+
+    unclaim_res = await client.post(f"/api/gigs/claims/{claim_id}/unclaim", headers=child_headers)
+    assert unclaim_res.status_code == 204
+
+    # Can now claim again
+    reclaim = await client.post(f"/api/gigs/offerings/{gig_id}/claim", headers=child_headers)
+    assert reclaim.status_code == 201
+
+
+@pytest.mark.asyncio
+async def test_parent_cannot_claim(
+    client: AsyncClient, parent_headers
+):
+    create_res = await client.post(
+        "/api/gigs/offerings",
+        json={"title": "Parent cannot claim", "points": 10},
+        headers=parent_headers,
+    )
+    gig_id = create_res.json()["id"]
+
+    res = await client.post(f"/api/gigs/offerings/{gig_id}/claim", headers=parent_headers)
+    assert res.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_points_equal_gig_value(
+    client: AsyncClient, parent_headers, child_headers, test_child_user, db_session: AsyncSession
+):
+    points_value = 75
+    create_res = await client.post(
+        "/api/gigs/offerings",
+        json={"title": "Big job", "points": points_value},
+        headers=parent_headers,
+    )
+    gig_id = create_res.json()["id"]
+    initial_points = test_child_user.points
+
+    claim_res = await client.post(f"/api/gigs/offerings/{gig_id}/claim", headers=child_headers)
+    claim_id = claim_res.json()["id"]
+    await client.post(f"/api/gigs/claims/{claim_id}/complete", json={"proof_text": "done"}, headers=child_headers)
+    await client.post(f"/api/gigs/claims/{claim_id}/approve", json={"approved": True}, headers=parent_headers)
+
+    await db_session.refresh(test_child_user)
+    assert test_child_user.points == initial_points + points_value

--- a/backend/tests/test_jarvis_sse.py
+++ b/backend/tests/test_jarvis_sse.py
@@ -1,4 +1,4 @@
-"""Frankie SSE streaming test (W7.10).
+"""Jarvis SSE streaming test (W7.10).
 
 Mocks the LLM to return a tool-call hop followed by a final reply, then
 walks the async generator and asserts the event sequence + persistence.
@@ -8,7 +8,7 @@ import json
 import pytest
 from unittest.mock import MagicMock
 
-from app.services.frankie_service import FrankieService
+from app.services.jarvis_service import JarvisService
 
 
 def _mk_message(content="", tool_calls=None):
@@ -39,7 +39,7 @@ def _stub_settings(monkeypatch):
     monkeypatch.setattr(
         config.settings, "LITELLM_API_BASE", "https://litellm.test"
     )
-    monkeypatch.setattr(config.settings, "FRANKIE_DAILY_MESSAGE_CAP", 0)
+    monkeypatch.setattr(config.settings, "JARVIS_DAILY_MESSAGE_CAP", 0)
 
 
 async def _collect_events(gen):
@@ -71,11 +71,11 @@ class TestSSEStream:
         client = MagicMock()
         client.chat.completions.create.return_value = completion
         monkeypatch.setattr(
-            "app.services.frankie_service.OpenAI", lambda *a, **kw: client
+            "app.services.jarvis_service.OpenAI", lambda *a, **kw: client
         )
 
         events = await _collect_events(
-            FrankieService.chat_stream(
+            JarvisService.chat_stream(
                 db_session, test_family.id, test_parent_user.id, "what now?"
             )
         )
@@ -100,11 +100,11 @@ class TestSSEStream:
         client = MagicMock()
         client.chat.completions.create.side_effect = [first, second]
         monkeypatch.setattr(
-            "app.services.frankie_service.OpenAI", lambda *a, **kw: client
+            "app.services.jarvis_service.OpenAI", lambda *a, **kw: client
         )
 
         events = await _collect_events(
-            FrankieService.chat_stream(
+            JarvisService.chat_stream(
                 db_session, test_family.id, test_parent_user.id, "status?"
             )
         )
@@ -121,7 +121,7 @@ class TestSSEStream:
         self, db_session, test_family, test_parent_user
     ):
         events = await _collect_events(
-            FrankieService.chat_stream(
+            JarvisService.chat_stream(
                 db_session, test_family.id, test_parent_user.id, "   "
             )
         )
@@ -136,16 +136,16 @@ class TestSSEStream:
         client = MagicMock()
         client.chat.completions.create.return_value = completion
         monkeypatch.setattr(
-            "app.services.frankie_service.OpenAI", lambda *a, **kw: client
+            "app.services.jarvis_service.OpenAI", lambda *a, **kw: client
         )
 
         await _collect_events(
-            FrankieService.chat_stream(
+            JarvisService.chat_stream(
                 db_session, test_family.id, test_parent_user.id, "ping"
             )
         )
 
-        history = await FrankieService.list_history(db_session, test_family.id)
+        history = await JarvisService.list_history(db_session, test_family.id)
         roles = [h.role for h in history]
         assert "user" in roles
         assert "assistant" in roles

--- a/backend/tests/test_jarvis_tools.py
+++ b/backend/tests/test_jarvis_tools.py
@@ -1,4 +1,4 @@
-"""Frankie tool execution (W6.4) — verify each tool runs end-to-end against
+"""Jarvis tool execution (W6.4) — verify each tool runs end-to-end against
 real DB fixtures without invoking the LLM."""
 
 import pytest
@@ -7,14 +7,14 @@ from sqlalchemy import select
 
 from app.models.calendar_event import CalendarEvent
 from app.models.task_template import TaskTemplate
-from app.services.frankie_service import FrankieService
+from app.services.jarvis_service import JarvisService
 
 
 class TestExecuteTool:
     async def test_create_task_template_gig(
         self, db_session, test_family, test_parent_user
     ):
-        result = await FrankieService._execute_tool(
+        result = await JarvisService._execute_tool(
             db_session,
             test_family.id,
             test_parent_user.id,
@@ -45,7 +45,7 @@ class TestExecuteTool:
         self, db_session, test_family, test_parent_user
     ):
         # Mandatory + points=20 must be clamped to 0 by the tool wrapper.
-        result = await FrankieService._execute_tool(
+        result = await JarvisService._execute_tool(
             db_session,
             test_family.id,
             test_parent_user.id,
@@ -59,7 +59,7 @@ class TestExecuteTool:
         self, db_session, test_family, test_parent_user
     ):
         start = datetime.now(timezone.utc) + timedelta(days=1)
-        result = await FrankieService._execute_tool(
+        result = await JarvisService._execute_tool(
             db_session,
             test_family.id,
             test_parent_user.id,
@@ -87,7 +87,7 @@ class TestExecuteTool:
         self, db_session, test_family, test_parent_user
     ):
         # Tool must accept naive ISO and treat as UTC.
-        result = await FrankieService._execute_tool(
+        result = await JarvisService._execute_tool(
             db_session,
             test_family.id,
             test_parent_user.id,
@@ -99,7 +99,7 @@ class TestExecuteTool:
     async def test_list_today_progress_empty(
         self, db_session, test_family, test_parent_user
     ):
-        result = await FrankieService._execute_tool(
+        result = await JarvisService._execute_tool(
             db_session,
             test_family.id,
             test_parent_user.id,
@@ -112,7 +112,7 @@ class TestExecuteTool:
     async def test_unknown_tool_returns_error(
         self, db_session, test_family, test_parent_user
     ):
-        result = await FrankieService._execute_tool(
+        result = await JarvisService._execute_tool(
             db_session,
             test_family.id,
             test_parent_user.id,
@@ -125,7 +125,7 @@ class TestExecuteTool:
     async def test_create_event_with_bad_iso_returns_error(
         self, db_session, test_family, test_parent_user
     ):
-        result = await FrankieService._execute_tool(
+        result = await JarvisService._execute_tool(
             db_session,
             test_family.id,
             test_parent_user.id,
@@ -137,7 +137,7 @@ class TestExecuteTool:
 
 class TestToolDefinitions:
     def test_all_tools_have_function_schema(self):
-        from app.services.frankie_service import TOOL_DEFINITIONS
+        from app.services.jarvis_service import TOOL_DEFINITIONS
         assert len(TOOL_DEFINITIONS) >= 8
         for t in TOOL_DEFINITIONS:
             assert t["type"] == "function"
@@ -152,7 +152,7 @@ class TestReadOnlyTools:
     async def test_list_pending_approvals_empty(
         self, db_session, test_family, test_parent_user
     ):
-        result = await FrankieService._execute_tool(
+        result = await JarvisService._execute_tool(
             db_session, test_family.id, test_parent_user.id,
             "list_pending_approvals", {},
         )
@@ -163,7 +163,7 @@ class TestReadOnlyTools:
     async def test_list_overdue_tasks_empty(
         self, db_session, test_family, test_parent_user
     ):
-        result = await FrankieService._execute_tool(
+        result = await JarvisService._execute_tool(
             db_session, test_family.id, test_parent_user.id,
             "list_overdue_tasks", {},
         )
@@ -173,7 +173,7 @@ class TestReadOnlyTools:
     async def test_list_recent_notifications_empty(
         self, db_session, test_family, test_parent_user
     ):
-        result = await FrankieService._execute_tool(
+        result = await JarvisService._execute_tool(
             db_session, test_family.id, test_parent_user.id,
             "list_recent_notifications", {},
         )
@@ -185,7 +185,7 @@ class TestAddShoppingItem:
     async def test_creates_default_list_when_none(
         self, db_session, test_family, test_parent_user
     ):
-        result = await FrankieService._execute_tool(
+        result = await JarvisService._execute_tool(
             db_session, test_family.id, test_parent_user.id,
             "add_shopping_item", {"name": "Bread", "qty": "1 loaf"},
         )
@@ -202,7 +202,7 @@ class TestAddShoppingItem:
             db_session, ShoppingListCreate(name="Costco"),
             test_family.id, test_parent_user.id,
         )
-        result = await FrankieService._execute_tool(
+        result = await JarvisService._execute_tool(
             db_session, test_family.id, test_parent_user.id,
             "add_shopping_item", {"name": "Milk"},
         )

--- a/backend/tests/test_premium_v2.py
+++ b/backend/tests/test_premium_v2.py
@@ -189,7 +189,7 @@ async def test_free_user_currency_mismatch_routes_to_drafts(
         raw_text="",
     )
 
-    async def fake_scan(_b, _t):
+    async def fake_scan(_b, _t, model=None):
         return fake_receipt
 
     monkeypatch.setattr(

--- a/backend/tests/test_receipt_scanner_v2.py
+++ b/backend/tests/test_receipt_scanner_v2.py
@@ -97,7 +97,7 @@ async def test_pipeline_creates_tx_with_items_and_fx(
         ],
     )
 
-    async def fake_scan(_b, _t):
+    async def fake_scan(_b, _t, model=None):
         return fake_receipt
 
     monkeypatch.setattr(
@@ -150,7 +150,7 @@ async def test_pipeline_returns_dup_warning_without_committing(
         payee_name=payee.name,
     )
 
-    async def fake_scan(_b, _t):
+    async def fake_scan(_b, _t, model=None):
         return fake_receipt
 
     monkeypatch.setattr(
@@ -206,7 +206,7 @@ async def test_force_true_bypasses_duplicate_guard(
         payee_name=payee.name,
     )
 
-    async def fake_scan(_b, _t):
+    async def fake_scan(_b, _t, model=None):
         return fake_receipt
 
     monkeypatch.setattr(
@@ -243,7 +243,7 @@ async def test_pipeline_stores_fx_when_currencies_differ(
         card_last4=None,
     )
 
-    async def fake_scan(_b, _t):
+    async def fake_scan(_b, _t, model=None):
         return fake_receipt
 
     monkeypatch.setattr(

--- a/backend/tests/test_w9_features.py
+++ b/backend/tests/test_w9_features.py
@@ -11,22 +11,22 @@ from app.core.exceptions import (
     ValidationException,
 )
 from app.models.calendar_event import CalendarEvent
-from app.models.frankie_schedule import FrankieSchedule
+from app.models.jarvis_schedule import JarvisSchedule
 from app.models.dm import DMThread, DMMessage
 from app.schemas.calendar_event import CalendarEventCreate
 from app.services.calendar_service import CalendarService, _expand_recurrence
 from app.services.dm_service import DMService
-from app.services.frankie_schedule_service import (
-    FrankieScheduleService,
+from app.services.jarvis_schedule_service import (
+    JarvisScheduleService,
     _parse_cron,
     _next_fire,
 )
 
 
-# ─── W9.1 Frankie schedules ────────────────────────────────────────────
+# ─── W9.1 Jarvis schedules ────────────────────────────────────────────
 
 
-class TestFrankieSchedule:
+class TestJarvisSchedule:
     def test_parse_valid_cron(self):
         t = _parse_cron("0 9 * * 1")
         nxt = _next_fire(t, datetime(2026, 1, 1, tzinfo=timezone.utc))
@@ -41,7 +41,7 @@ class TestFrankieSchedule:
     async def test_create_schedule_sets_next_run(
         self, db_session, test_family, test_parent_user
     ):
-        s = await FrankieScheduleService.create(
+        s = await JarvisScheduleService.create(
             db_session,
             family_id=test_family.id,
             created_by=test_parent_user.id,
@@ -57,7 +57,7 @@ class TestFrankieSchedule:
         self, db_session, test_family, test_parent_user
     ):
         with pytest.raises(ValidationException):
-            await FrankieScheduleService.create(
+            await JarvisScheduleService.create(
                 db_session,
                 family_id=test_family.id,
                 created_by=test_parent_user.id,
@@ -70,17 +70,17 @@ class TestFrankieSchedule:
     async def test_toggle_flips_active(
         self, db_session, test_family, test_parent_user
     ):
-        s = await FrankieScheduleService.create(
+        s = await JarvisScheduleService.create(
             db_session,
             family_id=test_family.id,
             created_by=test_parent_user.id,
             name="x", prompt="x", cron_expr="0 9 * * 1",
         )
-        toggled = await FrankieScheduleService.toggle(
+        toggled = await JarvisScheduleService.toggle(
             db_session, s.id, test_family.id
         )
         assert toggled.is_active is False
-        toggled = await FrankieScheduleService.toggle(
+        toggled = await JarvisScheduleService.toggle(
             db_session, s.id, test_family.id
         )
         assert toggled.is_active is True

--- a/docs/manual-usuario.md
+++ b/docs/manual-usuario.md
@@ -60,7 +60,7 @@ Punto central de administración. Desde aquí accedes a todas las herramientas d
 | **Consecuencias** | Registrar consecuencias para miembros |
 | **Aprobaciones** | Revisar gigs enviados para aprobación |
 | **Analytics** | Puntuación PUP y progreso familiar |
-| **Frankie** | Asistente IA para la gestión familiar |
+| **Jarvis** | Asistente IA para la gestión familiar |
 | **Kiosk** | Pantalla de visualización para TV/muro |
 | **Presupuesto** | Finanzas personales y familiares |
 | **Configuración** | Datos de familia y suscripción |
@@ -220,9 +220,9 @@ Módulo de finanzas personales y familiares. Completamente nativo en la aplicaci
 
 ---
 
-### 2.9 Frankie — Asistente IA (`/parent/frankie`)
+### 2.9 Jarvis — Asistente IA (`/parent/jarvis`)
 
-Frankie es un copiloto de inteligencia artificial para la gestión familiar. Puedes hacerle preguntas en lenguaje natural:
+Jarvis es un copiloto de inteligencia artificial para la gestión familiar. Puedes hacerle preguntas en lenguaje natural:
 
 - "¿Qué tareas están pendientes esta semana?"
 - "¿Quién ha ganado más puntos este mes?"
@@ -231,13 +231,13 @@ Frankie es un copiloto de inteligencia artificial para la gestión familiar. Pue
 
 El historial de conversación se guarda y puedes borrarlo con el botón **Limpiar historial**.
 
-#### Programar a Frankie (`/parent/frankie-schedules`)
+#### Programar a Jarvis (`/parent/jarvis-schedules`)
 
-Crea recordatorios automáticos para que Frankie te informe sin que tengas que preguntarle:
+Crea recordatorios automáticos para que Jarvis te informe sin que tengas que preguntarle:
 
-1. Escribe una **tarea o pregunta** para Frankie.
+1. Escribe una **tarea o pregunta** para Jarvis.
 2. Define la **expresión cron** (o usa los presets: diario, lunes, cada hora, etc.).
-3. Guarda. Frankie ejecutará la consulta automáticamente según el horario.
+3. Guarda. Jarvis ejecutará la consulta automáticamente según el horario.
 
 ---
 
@@ -429,11 +429,11 @@ La sección `/help` (o `/ayuda`) contiene preguntas frecuentes y guías rápidas
 | **Gig** | Tarea bonus que requiere foto de evidencia y aprobación del Parent. |
 | **Modo gig** | Regla de resolución cuando varios miembros pueden hacer el mismo gig: Reclamar (primero), Competencia, Rotación, Colaboración. |
 | **PUP Score** | Puntuación compuesta de Participación, Uso y Progreso de la familia en los últimos 30 días. |
-| **Frankie** | Asistente IA integrado para consultas y gestión familiar en lenguaje natural. |
+| **Jarvis** | Asistente IA integrado para consultas y gestión familiar en lenguaje natural. |
 | **Kiosk** | URL pública sin login para mostrar las tareas del día en una pantalla compartida. |
 | **Puntos** | Moneda interna del juego. Se ganan al completar tareas y se gastan al canjear recompensas. |
 | **Consecuencia** | Registro formal de una falta o incumplimiento, creado por el Parent. |
-| **Cron** | Expresión de tiempo para programar tareas automáticas de Frankie (ej. `0 8 * * 1` = cada lunes a las 8 am). |
+| **Cron** | Expresión de tiempo para programar tareas automáticas de Jarvis (ej. `0 8 * * 1` = cada lunes a las 8 am). |
 
 ---
 

--- a/docs/superpowers/specs/2026-06-01-gigs-refactor-design.md
+++ b/docs/superpowers/specs/2026-06-01-gigs-refactor-design.md
@@ -1,0 +1,104 @@
+# Gigs Refactor — Design Spec
+
+**Date:** 2026-06-01  
+**Status:** Approved
+
+## Problem
+
+Mandatory tasks and bonus gigs share `TaskTemplate` / `TaskAssignment` models via an `is_bonus` flag. Their lifecycles are fundamentally different:
+
+| | Mandatory | Gig |
+|---|---|---|
+| Points | 0 | Yes (= peso amount) |
+| Shuffle | Weekly | Never |
+| Availability | Assigned per week | Always open until archived |
+| Claim model | One per assigned user | Any kid independently |
+| Approval gate | None | Parent approves each claim |
+
+## Solution
+
+Clean split: new `gig_offerings` + `gig_claims` tables. Existing mandatory task flow untouched. Existing `is_bonus=True` templates migrated to new table.
+
+## Data Models
+
+### `gig_offerings`
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | UUID PK | |
+| `family_id` | FK families | |
+| `title` | str(200) | |
+| `description` | Text? | |
+| `points` | int | 1 pt = $1 MXN |
+| `difficulty` | int 1–3 | 1=Easy 2=Medium 3=Hard |
+| `category` | enum | CHORES/ERRANDS/CREATIVE/LEARNING/OUTDOOR/OTHER |
+| `allowed_roles` | JSONB | null = all roles |
+| `is_active` | bool | false = archived |
+| `created_by` | FK users | |
+| `created_at`, `updated_at` | datetime | |
+
+### `gig_claims`
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | UUID PK | |
+| `gig_id` | FK gig_offerings CASCADE | |
+| `family_id` | FK families | |
+| `claimed_by` | FK users | |
+| `status` | enum | CLAIMED→COMPLETED→APPROVED/REJECTED |
+| `proof_text` | Text? | |
+| `proof_image_url` | str? | |
+| `points_awarded` | int? | snapshot at approval |
+| `completed_at` | datetime? | |
+| `approved_by` | FK users? | |
+| `approved_at` | datetime? | |
+| `approval_notes` | Text? | |
+| `created_at` | datetime | = claimed_at |
+
+**Unique constraint**: `(gig_id, claimed_by)` where `status NOT IN ('REJECTED')` — one active claim per user per gig.
+
+### `point_transactions` change
+
+Add nullable `gig_claim_id FK gig_claims ON DELETE SET NULL`. Used when `type = GIG_APPROVED` via new gig flow.
+
+## API Routes — `/api/gigs`
+
+| Method | Path | Auth | Behavior |
+|--------|------|------|----------|
+| GET | `/offerings` | any member | list active; enriched with `my_claim` status |
+| POST | `/offerings` | parent | create |
+| PUT | `/offerings/{id}` | parent | edit |
+| DELETE | `/offerings/{id}` | parent | soft-deactivate |
+| POST | `/offerings/{id}/claim` | non-parent | create GigClaim; 409 if active claim exists |
+| POST | `/claims/{id}/complete` | claimer | submit proof; CLAIMED→COMPLETED |
+| POST | `/claims/{id}/unclaim` | claimer | delete claim record; only when CLAIMED |
+| GET | `/claims/my` | any member | my claims (all statuses) |
+| GET | `/claims/pending-approvals` | parent | COMPLETED claims awaiting review |
+| POST | `/claims/{id}/approve` | parent | `{approved, notes?}`; award points if approved |
+
+Proof image upload reuses `POST /api/task-assignments/proof-upload`.
+
+## Frontend
+
+| Page | Audience | Purpose |
+|------|----------|---------|
+| `/gigs` | kids/teens | gig board — browse + claim |
+| `/gigs/my-gigs` | kids/teens | active claims + proof submission |
+| `/parent/gigs` | parent | manage offerings + approval queue |
+
+## Mandatory Tasks Changes
+
+- Dashboard: filter to `is_bonus=False`; show `effort_level` as colored chip (Easy/Medium/Hard)
+- `/parent/tasks`: filter to `is_bonus=False`; label field "Difficulty" instead of "Effort"
+- New component: `DifficultyChip.astro`
+
+## Migration
+
+1. Create `gig_offerings` + `gig_claims` tables
+2. Add `gig_claim_id` to `point_transactions`
+3. Data: copy `is_bonus=TRUE` task_templates → `gig_offerings`
+4. Soft-delete migrated templates (`is_active=FALSE` in task_templates)
+
+## Points
+
+1 point = $1 MXN. On approval: `PointTransaction(type=GIG_APPROVED, points=gig.points, gig_claim_id=claim.id)`. Existing `TransactionType.GIG_APPROVED` enum value reused.

--- a/e2e-tests/jarvis-schedules.spec.js
+++ b/e2e-tests/jarvis-schedules.spec.js
@@ -12,18 +12,18 @@ async function login(page) {
   await page.waitForURL('**/dashboard', { timeout: 15000 });
 }
 
-test.describe('Frankie schedules', () => {
+test.describe('Jarvis schedules', () => {
   test('page loads + create form opens', async ({ page }) => {
     await login(page);
-    await page.goto(`${BASE_URL}/parent/frankie-schedules`);
-    await expect(page.locator('h1')).toContainText(/Programaciones|Frankie schedules/i);
+    await page.goto(`${BASE_URL}/parent/jarvis-schedules`);
+    await expect(page.locator('h1')).toContainText(/Programaciones|Jarvis schedules/i);
     await page.getByText(/Nueva programación|New schedule/i).first().click();
     await expect(page.locator('input[name="cron_expr"]')).toBeVisible();
   });
 
   test('preset button fills cron input', async ({ page }) => {
     await login(page);
-    await page.goto(`${BASE_URL}/parent/frankie-schedules`);
+    await page.goto(`${BASE_URL}/parent/jarvis-schedules`);
     await page.getByText(/Nueva programación|New schedule/i).first().click();
     await page.locator('.preset-btn').first().click();
     const cronValue = await page.locator('input[name="cron_expr"]').inputValue();
@@ -32,7 +32,7 @@ test.describe('Frankie schedules', () => {
 
   test('create + delete schedule', async ({ page }) => {
     await login(page);
-    await page.goto(`${BASE_URL}/parent/frankie-schedules`);
+    await page.goto(`${BASE_URL}/parent/jarvis-schedules`);
     await page.getByText(/Nueva programación|New schedule/i).first().click();
     const name = `E2E sched ${Date.now()}`;
     await page.fill('input[name="name"]', name);

--- a/e2e-tests/jarvis.spec.js
+++ b/e2e-tests/jarvis.spec.js
@@ -12,18 +12,18 @@ async function login(page) {
   await page.waitForURL('**/dashboard', { timeout: 10000 });
 }
 
-test.describe('Frankie copilot', () => {
+test.describe('Jarvis copilot', () => {
   test('parent can open chat page and see input', async ({ page }) => {
     await login(page);
-    await page.goto(`${BASE_URL}/parent/frankie`);
-    await expect(page.locator('h1')).toContainText('Frankie');
+    await page.goto(`${BASE_URL}/parent/jarvis`);
+    await expect(page.locator('h1')).toContainText('Jarvis');
     await expect(page.locator('#message-input')).toBeVisible();
   });
 
   test('sends a message and gets a response or graceful error', async ({ page }) => {
     test.skip(!process.env.E2E_FULL, 'requires LITELLM_API_KEY in backend');
     await login(page);
-    await page.goto(`${BASE_URL}/parent/frankie`);
+    await page.goto(`${BASE_URL}/parent/jarvis`);
     await page.fill('#message-input', 'What needs my attention today?');
     await page.locator('#chat-form button[type="submit"]').click();
     // Bot reply bubble appears within 30s, or alert pops with error

--- a/frontend/src/components/BottomNav.astro
+++ b/frontend/src/components/BottomNav.astro
@@ -171,7 +171,7 @@ const itemActive = "bg-brand-coral text-brand-ink border-2 border-brand-ink shad
         if (path.startsWith("/budget"))        return "budget";
         if (path.startsWith("/gigs"))          return "gigs";
         if (path.startsWith("/parent/gigs"))   return "gigs";
-        if (path.startsWith("/parent/frankie")) return "parent";
+        if (path.startsWith("/parent/jarvis")) return "parent";
         if (path.startsWith("/parent"))        return "parent";
         if (path.startsWith("/rewards"))       return "rewards";
         if (path.startsWith("/notifications")) return "notifications";

--- a/frontend/src/components/BottomNav.astro
+++ b/frontend/src/components/BottomNav.astro
@@ -2,7 +2,7 @@
 import { t } from "../lib/i18n";
 import { apiFetch } from "../lib/api";
 interface Props {
-    active?: "tasks" | "rewards" | "profile" | "parent" | "budget" | "notifications" | "pet" | "chat";
+    active?: "tasks" | "rewards" | "profile" | "parent" | "budget" | "notifications" | "pet" | "chat" | "gigs";
     role?: string;
     lang?: string;
 }
@@ -42,6 +42,16 @@ const itemActive = "bg-brand-coral text-brand-ink border-2 border-brand-ink shad
             </svg>
             <span class="text-[10px] font-extrabold font-sans tracking-wider uppercase">{t(lang, "nav_tasks")}</span>
         </a>
+
+        {role !== "parent" && (
+            <a href="/gigs" data-nav-key="gigs" class={`${itemBase} ${active === "gigs" ? itemActive : itemIdle}`}>
+                <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                        d="M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                </svg>
+                <span class="text-[10px] font-extrabold font-sans tracking-wider uppercase">Gigs</span>
+            </a>
+        )}
 
         <a href="/rewards" data-nav-key="rewards" class={`${itemBase} ${active === "rewards" ? itemActive : itemIdle}`}>
             <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -97,6 +107,16 @@ const itemActive = "bg-brand-coral text-brand-ink border-2 border-brand-ink shad
         </a>
 
         {role === "parent" && (
+            <a href="/parent/gigs" data-nav-key="gigs" class={`${itemBase} ${active === "gigs" ? itemActive : itemIdle}`}>
+                <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                        d="M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                </svg>
+                <span class="text-[10px] font-extrabold font-sans tracking-wider uppercase">Gigs</span>
+            </a>
+        )}
+
+        {role === "parent" && (
             <a href="/budget/month" data-nav-key="budget" class={`${itemBase} ${active === "budget" ? itemActive : itemIdle}`}>
                 <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
@@ -149,6 +169,8 @@ const itemActive = "bg-brand-coral text-brand-ink border-2 border-brand-ink shad
 
     function urlToKey(path: string): string {
         if (path.startsWith("/budget"))        return "budget";
+        if (path.startsWith("/gigs"))          return "gigs";
+        if (path.startsWith("/parent/gigs"))   return "gigs";
         if (path.startsWith("/parent/frankie")) return "parent";
         if (path.startsWith("/parent"))        return "parent";
         if (path.startsWith("/rewards"))       return "rewards";

--- a/frontend/src/components/DifficultyChip.astro
+++ b/frontend/src/components/DifficultyChip.astro
@@ -1,0 +1,25 @@
+---
+interface Props {
+    level: 1 | 2 | 3;
+    lang?: string;
+}
+const { level, lang = "en" } = Astro.props;
+
+const labels: Record<number, Record<string, string>> = {
+    1: { en: "Easy",   es: "Fácil"  },
+    2: { en: "Medium", es: "Medio"  },
+    3: { en: "Hard",   es: "Difícil" },
+};
+const colors: Record<number, string> = {
+    1: "bg-emerald-100 text-emerald-700",
+    2: "bg-amber-100 text-amber-700",
+    3: "bg-red-100 text-red-700",
+};
+
+const label = labels[level]?.[lang] ?? labels[1][lang];
+const color = colors[level] ?? colors[1];
+---
+
+<span class={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold ${color}`}>
+    {label}
+</span>

--- a/frontend/src/components/PointsConverter.astro
+++ b/frontend/src/components/PointsConverter.astro
@@ -62,13 +62,18 @@ if (token) {
 let maxPoints = 0;
 let maxAmount = 0;
 let completionPct = 0;
-const conversionRate = 0.10; // MXN per point
+// Derive the rate from the backend response so the preview can never drift
+// from the actual payout. Falls back to 1.0 (1 pt = $1 MXN) when not eligible.
+let conversionRate = 1.0; // MXN per point
 const isEligible = eligibility && eligibility.eligible;
 
 if (isEligible) {
     maxPoints = eligibility.max_convertible_points;
     maxAmount = eligibility.max_convertible_amount;
     completionPct = eligibility.completion_percentage;
+    if (maxPoints > 0) {
+        conversionRate = maxAmount / maxPoints;
+    }
 }
 ---
 

--- a/frontend/src/pages/api/jarvis/[...path].ts
+++ b/frontend/src/pages/api/jarvis/[...path].ts
@@ -5,7 +5,7 @@ const BACKEND_URL = process.env.API_BASE_URL || process.env.PUBLIC_API_BASE_URL 
 async function proxy({ request, params }: { request: Request; params: Record<string, string | undefined> }): Promise<Response> {
     const path = params.path ?? "";
     const url = new URL(request.url);
-    const backendUrl = `${BACKEND_URL}/api/frankie/${path}${url.search}`;
+    const backendUrl = `${BACKEND_URL}/api/jarvis/${path}${url.search}`;
 
     const forwardHeaders = new Headers();
     for (const [key, value] of request.headers.entries()) {

--- a/frontend/src/pages/budget/settings.astro
+++ b/frontend/src/pages/budget/settings.astro
@@ -29,7 +29,7 @@ const pendingDraftsCount = draftsCount?.count ?? 0;
 if (user.role !== "parent") return Astro.redirect("/dashboard");
 
 // Parallel fetch all settings data
-const [accountsRes, payeesRes, rulesRes, recurringRes, goalsRes, tagsRes, groupsRes] = await Promise.all([
+const [accountsRes, payeesRes, rulesRes, recurringRes, goalsRes, tagsRes, groupsRes, aiModelsRes, aiUsageRes] = await Promise.all([
     apiFetch<any[]>("/api/budget/accounts/", { token }),
     apiFetch<any[]>("/api/budget/payees/", { token }),
     apiFetch<any[]>("/api/budget/categorization-rules/", { token }),
@@ -37,6 +37,8 @@ const [accountsRes, payeesRes, rulesRes, recurringRes, goalsRes, tagsRes, groups
     apiFetch<any[]>("/api/budget/goals/", { token }),
     apiFetch<any[]>("/api/budget/tags/", { token }),
     apiFetch<any[]>("/api/budget/categories/groups", { token }),
+    apiFetch<any>("/api/budget/ai-settings/models", { token }),
+    apiFetch<any>("/api/budget/ai-settings/usage", { token }),
 ]);
 
 const accounts = accountsRes.data || [];
@@ -46,6 +48,8 @@ const recurring = recurringRes.data || [];
 const goals = goalsRes.data || [];
 const tags = tagsRes.data || [];
 const groups = groupsRes.data || [];
+const aiModels = aiModelsRes.data || { current_model: "gemini-2.5-flash", models: [] };
+const aiUsage = aiUsageRes.data || null;
 
 const allCategories = groups.flatMap((g: any) =>
     (g.categories || []).map((c: any) => ({ id: c.id, name: c.name, group_name: g.name }))
@@ -331,6 +335,84 @@ const frequencyLabel = (freq: string) => {
             )}
         </SettingsAccordion>
 
+        <!-- AI & SCANNER -->
+        <SettingsAccordion id="ai-scanner" title={es ? "IA y escáner" : "AI & Scanner"} icon="🤖">
+            <!-- Model selector -->
+            <div class="mb-5">
+                <label class="block text-sm font-semibold text-brand-ink mb-1.5">
+                    {es ? "Modelo de visión para recibos" : "Vision model for receipts"}
+                </label>
+                <p class="text-xs text-brand-ink-soft mb-2">
+                    {es ? "Modelo usado al escanear recibos. Se aplica a toda la familia." : "Model used when scanning receipts. Applies to the whole family."}
+                </p>
+                <div class="flex gap-2">
+                    <select id="ai-model-select" class="flex-1 py-2 px-3 border border-brand-ink/10 rounded-lg text-sm bg-brand-cream focus:ring-2 focus:ring-brand-sky-deep outline-none">
+                        {aiModels.models?.map((m: any) => (
+                            <option value={m.id} selected={m.id === aiModels.current_model}>{m.label}</option>
+                        ))}
+                    </select>
+                    <button id="ai-model-save-btn" class="px-4 py-2 bg-brand-sky-deep hover:bg-brand-ink text-white text-sm font-semibold rounded-lg transition">
+                        {es ? "Guardar" : "Save"}
+                    </button>
+                </div>
+                <p id="ai-model-current" class="text-xs text-brand-ink-soft mt-1.5">
+                    {es ? "Activo:" : "Active:"} <span class="font-mono font-semibold text-brand-ink">{aiModels.current_model}</span>
+                </p>
+            </div>
+
+            <!-- Token consumption -->
+            <div>
+                <div class="flex items-center justify-between mb-2">
+                    <p class="text-sm font-semibold text-brand-ink">{es ? "Consumo de tokens (LiteLLM)" : "Token consumption (LiteLLM)"}</p>
+                    <button id="ai-usage-refresh-btn" class="text-xs text-brand-sky-deep hover:text-brand-ink font-semibold transition">
+                        {es ? "Actualizar" : "Refresh"}
+                    </button>
+                </div>
+                <div id="ai-usage-panel" class="bg-brand-cream-deep rounded-xl p-3 text-sm">
+                    {aiUsage ? (
+                        <div class="space-y-1.5">
+                            {aiUsage.key_alias && (
+                                <div class="flex justify-between">
+                                    <span class="text-brand-ink-soft">{es ? "Clave" : "Key"}</span>
+                                    <span class="font-mono text-xs text-brand-ink">{aiUsage.key_alias}</span>
+                                </div>
+                            )}
+                            <div class="flex justify-between">
+                                <span class="text-brand-ink-soft">{es ? "Gasto" : "Spend"}</span>
+                                <span class="font-semibold text-brand-ink">${Number(aiUsage.spend ?? 0).toFixed(4)}</span>
+                            </div>
+                            {aiUsage.max_budget != null && (
+                                <div>
+                                    <div class="flex justify-between mb-1">
+                                        <span class="text-brand-ink-soft">{es ? "Presupuesto" : "Budget"}</span>
+                                        <span class="text-brand-ink">${Number(aiUsage.max_budget).toFixed(2)} / {aiUsage.budget_duration ?? "?"}</span>
+                                    </div>
+                                    <div class="w-full bg-brand-ink/10 rounded-full h-1.5">
+                                        <div class="bg-brand-sky-deep rounded-full h-1.5 transition-all"
+                                            style={`width:${Math.min(100, (Number(aiUsage.spend ?? 0) / Number(aiUsage.max_budget)) * 100).toFixed(1)}%`}></div>
+                                    </div>
+                                </div>
+                            )}
+                            {aiUsage.budget_reset_at && (
+                                <div class="flex justify-between">
+                                    <span class="text-brand-ink-soft">{es ? "Reseteo" : "Resets"}</span>
+                                    <span class="text-brand-ink text-xs">{new Date(aiUsage.budget_reset_at).toLocaleDateString()}</span>
+                                </div>
+                            )}
+                            {aiUsage.models?.length > 0 && (
+                                <div class="pt-1 border-t border-brand-ink/10">
+                                    <span class="text-xs text-brand-ink-soft">{es ? "Modelos permitidos:" : "Allowed models:"} </span>
+                                    <span class="text-xs font-mono text-brand-ink">{aiUsage.models.join(", ")}</span>
+                                </div>
+                            )}
+                        </div>
+                    ) : (
+                        <p class="text-brand-ink-soft text-xs text-center py-2">{es ? "No disponible — verifica LITELLM_API_KEY" : "Not available — check LITELLM_API_KEY"}</p>
+                    )}
+                </div>
+            </div>
+        </SettingsAccordion>
+
         <!-- BACKUPS & TOOLS -->
         <SettingsAccordion id="backups" title={es ? "Respaldos y herramientas" : "Backups & Tools"} icon="💾">
             <p class="text-sm text-brand-ink-soft mb-4">
@@ -404,7 +486,7 @@ const frequencyLabel = (freq: string) => {
 <div id="settings-toast" class="hidden fixed bottom-24 left-1/2 -translate-x-1/2 z-[70] px-4 py-2.5 rounded-xl text-white text-sm font-semibold shadow-[var(--shadow-pop)] transition-all"></div>
 </Layout>
 
-<script define:vars={{ token, accountsData: accounts, allCategoriesData: allCategories, es }}>
+<script define:vars={{ token, accountsData: accounts, allCategoriesData: allCategories, es, aiModelsData: aiModels }}>
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function showToast(msg, type = "success") {
@@ -973,5 +1055,63 @@ document.getElementById("settings-modal-overlay")?.addEventListener("click", (e)
 });
 document.getElementById("confirm-overlay")?.addEventListener("click", (e) => {
     if (e.target === document.getElementById("confirm-overlay")) closeConfirm();
+});
+
+// ─── AI & SCANNER ─────────────────────────────────────────────────────────────
+
+document.getElementById("ai-model-save-btn")?.addEventListener("click", async () => {
+    const btn = document.getElementById("ai-model-save-btn");
+    const model = document.getElementById("ai-model-select")?.value;
+    if (!model) return;
+    btn.disabled = true;
+    btn.textContent = "…";
+    try {
+        await apiCall("/api/budget/ai-settings/models", "PUT", { model });
+        const label = aiModelsData.models?.find(m => m.id === model)?.label || model;
+        const current = document.getElementById("ai-model-current");
+        if (current) current.querySelector("span").textContent = model;
+        showToast(es ? `Modelo actualizado: ${label}` : `Model updated: ${label}`);
+    } catch(e) {
+        showToast(e.message, "error");
+    } finally {
+        btn.disabled = false;
+        btn.textContent = es ? "Guardar" : "Save";
+    }
+});
+
+document.getElementById("ai-usage-refresh-btn")?.addEventListener("click", async () => {
+    const panel = document.getElementById("ai-usage-panel");
+    if (!panel) return;
+    panel.innerHTML = `<p class="text-brand-ink-soft text-xs text-center py-2">${es ? "Cargando…" : "Loading…"}</p>`;
+    try {
+        const res = await fetch("/api/budget/ai-settings/usage", {
+            headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!res.ok) throw new Error(`Error ${res.status}`);
+        const d = await res.json();
+        const pct = d.max_budget ? Math.min(100, (Number(d.spend ?? 0) / Number(d.max_budget)) * 100).toFixed(1) : null;
+        panel.innerHTML = `
+            <div class="space-y-1.5">
+                ${d.key_alias ? `<div class="flex justify-between"><span class="text-brand-ink-soft">${es ? "Clave" : "Key"}</span><span class="font-mono text-xs text-brand-ink">${d.key_alias}</span></div>` : ""}
+                <div class="flex justify-between">
+                    <span class="text-brand-ink-soft">${es ? "Gasto" : "Spend"}</span>
+                    <span class="font-semibold text-brand-ink">$${Number(d.spend ?? 0).toFixed(4)}</span>
+                </div>
+                ${d.max_budget != null ? `
+                <div>
+                    <div class="flex justify-between mb-1">
+                        <span class="text-brand-ink-soft">${es ? "Presupuesto" : "Budget"}</span>
+                        <span class="text-brand-ink">$${Number(d.max_budget).toFixed(2)} / ${d.budget_duration ?? "?"}</span>
+                    </div>
+                    <div class="w-full bg-brand-ink/10 rounded-full h-1.5">
+                        <div class="bg-brand-sky-deep rounded-full h-1.5" style="width:${pct}%"></div>
+                    </div>
+                </div>` : ""}
+                ${d.budget_reset_at ? `<div class="flex justify-between"><span class="text-brand-ink-soft">${es ? "Reseteo" : "Resets"}</span><span class="text-brand-ink text-xs">${new Date(d.budget_reset_at).toLocaleDateString()}</span></div>` : ""}
+                ${d.models?.length ? `<div class="pt-1 border-t border-brand-ink/10"><span class="text-xs text-brand-ink-soft">${es ? "Modelos:" : "Models:"} </span><span class="text-xs font-mono text-brand-ink">${d.models.join(", ")}</span></div>` : ""}
+            </div>`;
+    } catch(e) {
+        panel.innerHTML = `<p class="text-red-600 text-xs text-center py-2">${e.message}</p>`;
+    }
 });
 </script>

--- a/frontend/src/pages/dashboard.astro
+++ b/frontend/src/pages/dashboard.astro
@@ -3,6 +3,7 @@ import Layout from "../layouts/Layout.astro";
 import BottomNav from "../components/BottomNav.astro";
 import PointsConverter from "../components/PointsConverter.astro";
 import GigsIntroBanner from "../components/GigsIntroBanner.astro";
+import DifficultyChip from "../components/DifficultyChip.astro";
 import { apiFetch } from "../lib/api";
 import { t } from "../lib/i18n";
 
@@ -171,9 +172,7 @@ if (flashError) Astro.cookies.delete("flash_error", { path: "/" });
                                         {(lang === "es" && a.template_description_es ? a.template_description_es : a.template_description) || "--"}
                                     </p>
                                     <div class="flex items-center gap-2 mt-3 flex-wrap">
-                                        <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold bg-brand-cream-deep text-brand-sky-deep">
-                                            +{a.template_points} pts
-                                        </span>
+                                        <DifficultyChip level={a.template_effort_level ?? 1} lang={lang} />
                                     </div>
                                 </div>
                                 {a.can_complete && (

--- a/frontend/src/pages/dashboard.astro
+++ b/frontend/src/pages/dashboard.astro
@@ -48,6 +48,13 @@ const noTasks = requiredTotal === 0 && bonusTotal === 0;
 
 const progressPercent = requiredTotal > 0 ? Math.round((requiredCompleted / requiredTotal) * 100) : 100;
 
+// Gig trust streak — mirrors backend GIG_AUTO_APPROVE_STREAK default (3).
+// Once a kid hits the threshold, their submitted gigs auto-approve.
+const TRUST_THRESHOLD = 3;
+const isKid = user.role === "TEEN" || user.role === "CHILD";
+const trustStreak = user.gig_trust_streak ?? 0;
+const toAutoApprove = Math.max(0, TRUST_THRESHOLD - trustStreak);
+
 const flash = Astro.cookies.get("flash")?.value;
 if (flash) Astro.cookies.delete("flash", { path: "/" });
 const flashError = Astro.cookies.get("flash_error")?.value;
@@ -71,7 +78,7 @@ if (flashError) Astro.cookies.delete("flash_error", { path: "/" });
                     <p class="text-brand-cream text-xs font-semibold uppercase tracking-wider mb-1">
                         {t(lang, "dashboard_my_points")}
                     </p>
-                    <p class="text-3xl font-extrabold tracking-tight">{user.points}</p>
+                    <p data-points-badge class="text-3xl font-extrabold tracking-tight">{user.points}</p>
                 </div>
                 <div class="bg-brand-sun p-3 rounded-xl shadow-inner">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 text-brand-ink" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -79,6 +86,25 @@ if (flashError) Astro.cookies.delete("flash_error", { path: "/" });
                     </svg>
                 </div>
             </div>
+            {isKid && trustStreak > 0 && (
+                <div class="mt-3 bg-white/15 backdrop-blur-sm rounded-xl px-4 py-2.5 flex items-center gap-3 border border-white/20">
+                    <span class="text-2xl">🔥</span>
+                    <div class="flex-1">
+                        <p class="text-sm font-bold text-white">
+                            {lang === "es" ? `Racha de ${trustStreak} gigs` : `${trustStreak}-gig streak`}
+                        </p>
+                        <p class="text-xs text-brand-cream">
+                            {toAutoApprove > 0
+                                ? (lang === "es"
+                                    ? `${toAutoApprove} más para auto-aprobación`
+                                    : `${toAutoApprove} more to auto-approve`)
+                                : (lang === "es"
+                                    ? "¡Tus gigs se aprueban al instante!"
+                                    : "Your gigs auto-approve instantly!")}
+                        </p>
+                    </div>
+                </div>
+            )}
         </header>
 
         <GigsIntroBanner lang={lang} show={!user.acknowledged_gigs_intro} />
@@ -94,7 +120,7 @@ if (flashError) Astro.cookies.delete("flash_error", { path: "/" });
         )}
 
         {flash && (
-            <div class="mx-4 mt-4 p-3 bg-brand-mint/20 border border-brand-mint text-brand-mint-deep text-sm rounded-xl">
+            <div data-flash-success class="mx-4 mt-4 p-3 bg-brand-mint/20 border border-brand-mint text-brand-mint-deep text-sm rounded-xl">
                 {flash}
             </div>
         )}
@@ -445,7 +471,62 @@ if (flashError) Astro.cookies.delete("flash_error", { path: "/" });
     </dialog>
 
     <script>
+        // Lightweight, dependency-free confetti burst. Respects reduced-motion.
+        function fireConfetti() {
+            if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+            if (document.getElementById("confetti-canvas")) return;
+            const canvas = document.createElement("canvas");
+            canvas.id = "confetti-canvas";
+            canvas.style.cssText = "position:fixed;inset:0;width:100%;height:100%;pointer-events:none;z-index:9999";
+            document.body.appendChild(canvas);
+            const ctx = canvas.getContext("2d");
+            if (!ctx) { canvas.remove(); return; }
+            canvas.width = window.innerWidth;
+            canvas.height = window.innerHeight;
+            const colors = ["#4FB8E6", "#FFC857", "#6BCB77", "#FF6B6B", "#A78BFA"];
+            const N = 90;
+            const parts = Array.from({ length: N }, () => ({
+                x: canvas.width / 2,
+                y: canvas.height / 3,
+                vx: (Math.random() - 0.5) * 14,
+                vy: Math.random() * -15 - 4,
+                size: Math.random() * 7 + 4,
+                color: colors[Math.floor(Math.random() * colors.length)],
+                rot: Math.random() * Math.PI,
+                vr: (Math.random() - 0.5) * 0.3,
+            }));
+            let frame = 0;
+            const tick = () => {
+                ctx.clearRect(0, 0, canvas.width, canvas.height);
+                parts.forEach((p) => {
+                    p.vy += 0.4; // gravity
+                    p.x += p.vx; p.y += p.vy; p.rot += p.vr;
+                    ctx.save();
+                    ctx.translate(p.x, p.y); ctx.rotate(p.rot);
+                    ctx.fillStyle = p.color;
+                    ctx.fillRect(-p.size / 2, -p.size / 2, p.size, p.size);
+                    ctx.restore();
+                });
+                frame++;
+                if (frame < 110) requestAnimationFrame(tick);
+                else canvas.remove();
+            };
+            requestAnimationFrame(tick);
+        }
+
         document.addEventListener("astro:page-load", () => {
+            // Celebrate a just-completed task/gig (success flash present after redirect).
+            if (document.querySelector("[data-flash-success]")) {
+                fireConfetti();
+                const pts = document.querySelector<HTMLElement>("[data-points-badge]");
+                if (pts && !window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+                    pts.animate(
+                        [{ transform: "scale(1)" }, { transform: "scale(1.25)" }, { transform: "scale(1)" }],
+                        { duration: 600, easing: "ease-out" },
+                    );
+                }
+            }
+
             const modal = document.getElementById("gig-proof-modal") as HTMLDialogElement | null;
             if (!modal) return;
             const textarea = document.getElementById("gig-proof-text") as HTMLTextAreaElement | null;

--- a/frontend/src/pages/gigs/index.astro
+++ b/frontend/src/pages/gigs/index.astro
@@ -1,0 +1,163 @@
+---
+import Layout from "../../layouts/Layout.astro";
+import BottomNav from "../../components/BottomNav.astro";
+import DifficultyChip from "../../components/DifficultyChip.astro";
+import { apiFetch } from "../../lib/api";
+import { t } from "../../lib/i18n";
+
+const token = Astro.cookies.get("access_token")?.value;
+if (!token) return Astro.redirect("/login");
+const lang = Astro.cookies.get("lang")?.value ?? "en";
+
+const { data: user, ok: userOk } = await apiFetch<any>("/api/auth/me", { token });
+if (!userOk) {
+    Astro.cookies.delete("access_token", { path: "/" });
+    return Astro.redirect("/login");
+}
+if (user.role === "parent") return Astro.redirect("/parent/gigs");
+
+const { data: items } = await apiFetch<any[]>("/api/gigs/offerings", { token });
+const offerings: any[] = items ?? [];
+
+const flash = Astro.cookies.get("flash")?.value;
+if (flash) Astro.cookies.delete("flash", { path: "/" });
+const flashError = Astro.cookies.get("flash_error")?.value;
+if (flashError) Astro.cookies.delete("flash_error", { path: "/" });
+
+const categoryLabels: Record<string, Record<string, string>> = {
+    chores:   { en: "Chores",   es: "Quehaceres" },
+    errands:  { en: "Errands",  es: "Mandados" },
+    creative: { en: "Creative", es: "Creativo" },
+    learning: { en: "Learning", es: "Aprendizaje" },
+    outdoor:  { en: "Outdoor",  es: "Al Aire Libre" },
+    other:    { en: "Other",    es: "Otro" },
+};
+const catLabel = (cat: string) => categoryLabels[cat]?.[lang] ?? cat;
+---
+
+<Layout title={`Gigs - Family Task Manager`}>
+    <div class="w-full max-w-md md:max-w-4xl lg:max-w-6xl mx-auto bg-brand-cream-deep flex flex-col min-h-screen">
+        <header class="bg-gradient-to-br from-violet-700 to-violet-500 text-white pt-12 pb-6 px-6 rounded-b-[var(--radius-tile)] shadow-[var(--shadow-card)]">
+            <div class="flex justify-between items-center mb-4">
+                <div>
+                    <p class="text-violet-200 text-sm font-medium">{lang === "es" ? "¡Gana dinero extra!" : "Earn extra money!"}</p>
+                    <h1 class="text-2xl font-bold">{lang === "es" ? "Gigs" : "Gigs"}</h1>
+                </div>
+                <a href="/gigs/my-gigs" class="bg-white/20 backdrop-blur-sm border border-white/30 text-white text-sm font-semibold px-4 py-2 rounded-xl hover:bg-white/30 transition-colors">
+                    {lang === "es" ? "Mis Gigs" : "My Gigs"}
+                </a>
+            </div>
+            <div class="bg-white/15 backdrop-blur-sm rounded-2xl px-4 py-3 text-sm text-violet-100">
+                {lang === "es"
+                    ? "Reclama gigs, complétalas con evidencia y gana puntos que valen pesos."
+                    : "Claim gigs, complete them with proof, and earn points worth real pesos."}
+            </div>
+        </header>
+
+        <main class="flex-1 px-4 py-6">
+            {flash && (
+                <div class="mb-4 p-3 bg-brand-mint/20 border border-brand-mint text-brand-mint-deep text-sm rounded-xl">
+                    {flash}
+                </div>
+            )}
+            {flashError && (
+                <div class="mb-4 p-3 bg-red-100 border border-red-200 text-red-700 text-sm rounded-xl">
+                    {flashError}
+                </div>
+            )}
+
+            {offerings.length === 0 ? (
+                <div class="bg-brand-cream rounded-2xl p-8 text-center border border-brand-ink/10 shadow-[var(--shadow-card)]">
+                    <div class="w-16 h-16 bg-violet-100 rounded-full flex items-center justify-center mx-auto mb-4">
+                        <svg class="w-8 h-8 text-violet-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                        </svg>
+                    </div>
+                    <h3 class="font-bold text-brand-ink mb-1">{lang === "es" ? "Sin gigs disponibles" : "No gigs available"}</h3>
+                    <p class="text-brand-ink-soft text-sm">{lang === "es" ? "Tu papá/mamá publicará gigs pronto." : "Your parent will post gigs soon."}</p>
+                </div>
+            ) : (
+                <div class="space-y-4">
+                    {offerings.map((item: any) => {
+                        const o = item.offering;
+                        const claim = item.my_claim;
+                        const hasClaim = !!claim;
+                        const isApproved = claim?.status === "approved";
+                        const isCompleted = claim?.status === "completed";
+                        const isClaimed = claim?.status === "claimed";
+                        return (
+                            <div class={`bg-brand-cream rounded-2xl p-5 shadow-[var(--shadow-card)] border ${hasClaim ? "border-violet-200" : "border-brand-ink/10"} transition-all`}>
+                                <div class="flex justify-between items-start mb-3">
+                                    <div class="flex-1 pr-3">
+                                        <h3 class="font-bold text-brand-ink text-lg leading-tight">{o.title}</h3>
+                                        {o.description && (
+                                            <p class="text-brand-ink-soft text-sm mt-1 line-clamp-2">{o.description}</p>
+                                        )}
+                                    </div>
+                                    <div class="text-right flex-shrink-0">
+                                        <p class="text-2xl font-extrabold text-violet-600">{o.points}</p>
+                                        <p class="text-xs text-brand-ink-soft font-medium">pts / ${o.points} MXN</p>
+                                    </div>
+                                </div>
+                                <div class="flex items-center gap-2 flex-wrap mb-4">
+                                    <DifficultyChip level={o.difficulty ?? 1} lang={lang} />
+                                    <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-violet-100 text-violet-700">
+                                        {catLabel(o.category)}
+                                    </span>
+                                </div>
+
+                                {!hasClaim && (
+                                    <form method="POST" action="/api/gigs/claim">
+                                        <input type="hidden" name="gig_id" value={o.id} />
+                                        <button type="submit" class="w-full py-2.5 px-4 bg-violet-600 text-white font-semibold rounded-xl hover:bg-violet-700 active:scale-[.98] transition-all text-sm">
+                                            {lang === "es" ? "Reclamar" : "Claim"}
+                                        </button>
+                                    </form>
+                                )}
+                                {isClaimed && (
+                                    <a href="/gigs/my-gigs" class="block w-full py-2.5 px-4 bg-amber-100 text-amber-700 font-semibold rounded-xl text-center text-sm hover:bg-amber-200 transition-colors">
+                                        {lang === "es" ? "Reclamada — Enviar evidencia →" : "Claimed — Submit proof →"}
+                                    </a>
+                                )}
+                                {isCompleted && (
+                                    <div class="w-full py-2.5 px-4 bg-sky-100 text-sky-700 font-semibold rounded-xl text-center text-sm">
+                                        {lang === "es" ? "⏳ Pendiente de aprobación" : "⏳ Awaiting approval"}
+                                    </div>
+                                )}
+                                {isApproved && (
+                                    <div class="w-full py-2.5 px-4 bg-emerald-100 text-emerald-700 font-semibold rounded-xl text-center text-sm">
+                                        ✅ {lang === "es" ? `Aprobada · +${claim.points_awarded} pts` : `Approved · +${claim.points_awarded} pts`}
+                                    </div>
+                                )}
+                            </div>
+                        );
+                    })}
+                </div>
+            )}
+        </main>
+
+        <BottomNav active="gigs" role={user.role?.toLowerCase()} lang={lang} />
+    </div>
+</Layout>
+
+<script>
+document.querySelectorAll("form[action='/api/gigs/claim']").forEach(form => {
+    form.addEventListener("submit", async (e) => {
+        e.preventDefault();
+        const formEl = e.target as HTMLFormElement;
+        const gigId = (formEl.querySelector("[name=gig_id]") as HTMLInputElement).value;
+        const btn = formEl.querySelector("button") as HTMLButtonElement;
+        btn.disabled = true;
+        btn.textContent = "...";
+        const res = await fetch(`/api/gigs/offerings/${gigId}/claim`, { method: "POST" });
+        if (res.ok) {
+            window.location.href = "/gigs/my-gigs";
+        } else {
+            const err = await res.json().catch(() => ({ detail: "Error" }));
+            btn.disabled = false;
+            btn.textContent = btn.getAttribute("data-label") ?? "Claim";
+            alert(err.detail ?? "Error");
+        }
+    });
+});
+</script>

--- a/frontend/src/pages/gigs/my-gigs.astro
+++ b/frontend/src/pages/gigs/my-gigs.astro
@@ -76,7 +76,10 @@ const sl = (s: string) => statusLabel[s]?.[lang] ?? s;
                         }`}>
                             <div class="flex justify-between items-start mb-3">
                                 <div class="flex-1">
-                                    <span class={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold mb-2 ${
+                                    {claim.gig_title && (
+                                        <h3 class="font-bold text-brand-ink text-base leading-tight mb-1">{claim.gig_title}</h3>
+                                    )}
+                                    <span class={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold mb-1 ${
                                         claim.status === "approved" ? "bg-emerald-100 text-emerald-700" :
                                         claim.status === "rejected" ? "bg-red-100 text-red-700" :
                                         claim.status === "completed" ? "bg-sky-100 text-sky-700" :

--- a/frontend/src/pages/gigs/my-gigs.astro
+++ b/frontend/src/pages/gigs/my-gigs.astro
@@ -126,6 +126,7 @@ const sl = (s: string) => statusLabel[s]?.[lang] ?? s;
                                         <input
                                             type="file"
                                             accept="image/jpeg,image/png,image/webp"
+                                            capture="environment"
                                             name="proof_image"
                                             class="w-full text-sm text-brand-ink-soft file:mr-3 file:py-2 file:px-4 file:rounded-xl file:border-0 file:text-sm file:font-semibold file:bg-violet-100 file:text-violet-700 hover:file:bg-violet-200"
                                         />

--- a/frontend/src/pages/gigs/my-gigs.astro
+++ b/frontend/src/pages/gigs/my-gigs.astro
@@ -1,0 +1,205 @@
+---
+import Layout from "../../layouts/Layout.astro";
+import BottomNav from "../../components/BottomNav.astro";
+import { apiFetch } from "../../lib/api";
+
+const token = Astro.cookies.get("access_token")?.value;
+if (!token) return Astro.redirect("/login");
+const lang = Astro.cookies.get("lang")?.value ?? "en";
+
+const { data: user, ok: userOk } = await apiFetch<any>("/api/auth/me", { token });
+if (!userOk) {
+    Astro.cookies.delete("access_token", { path: "/" });
+    return Astro.redirect("/login");
+}
+if (user.role === "parent") return Astro.redirect("/parent/gigs");
+
+const { data: claims } = await apiFetch<any[]>("/api/gigs/claims/my", { token });
+const myClaims: any[] = claims ?? [];
+
+const flash = Astro.cookies.get("flash")?.value;
+if (flash) Astro.cookies.delete("flash", { path: "/" });
+const flashError = Astro.cookies.get("flash_error")?.value;
+if (flashError) Astro.cookies.delete("flash_error", { path: "/" });
+
+const statusLabel: Record<string, Record<string, string>> = {
+    claimed:   { en: "In progress",        es: "En progreso" },
+    completed: { en: "Awaiting approval",  es: "Esperando aprobación" },
+    approved:  { en: "Approved",           es: "Aprobada" },
+    rejected:  { en: "Rejected",           es: "Rechazada" },
+};
+const sl = (s: string) => statusLabel[s]?.[lang] ?? s;
+---
+
+<Layout title={`${lang === "es" ? "Mis Gigs" : "My Gigs"} - Family Task Manager`}>
+    <div class="w-full max-w-md md:max-w-4xl lg:max-w-6xl mx-auto bg-brand-cream-deep flex flex-col min-h-screen">
+        <header class="bg-gradient-to-br from-violet-700 to-violet-500 text-white pt-12 pb-6 px-6 rounded-b-[var(--radius-tile)] shadow-[var(--shadow-card)]">
+            <div class="flex justify-between items-center">
+                <div>
+                    <a href="/gigs" class="text-violet-200 text-sm hover:text-white transition-colors">
+                        ← {lang === "es" ? "Tablero de Gigs" : "Gig Board"}
+                    </a>
+                    <h1 class="text-2xl font-bold mt-1">{lang === "es" ? "Mis Gigs" : "My Gigs"}</h1>
+                </div>
+            </div>
+        </header>
+
+        <main class="flex-1 px-4 py-6">
+            {flash && (
+                <div class="mb-4 p-3 bg-brand-mint/20 border border-brand-mint text-brand-mint-deep text-sm rounded-xl">
+                    {flash}
+                </div>
+            )}
+            {flashError && (
+                <div class="mb-4 p-3 bg-red-100 border border-red-200 text-red-700 text-sm rounded-xl">
+                    {flashError}
+                </div>
+            )}
+
+            {myClaims.length === 0 ? (
+                <div class="bg-brand-cream rounded-2xl p-8 text-center border border-brand-ink/10 shadow-[var(--shadow-card)]">
+                    <p class="text-brand-ink-soft text-sm">
+                        {lang === "es" ? "No has reclamado ninguna gig aún." : "You haven't claimed any gigs yet."}
+                    </p>
+                    <a href="/gigs" class="inline-block mt-4 px-4 py-2 bg-violet-600 text-white text-sm font-semibold rounded-xl hover:bg-violet-700 transition-colors">
+                        {lang === "es" ? "Ver tablero de gigs" : "View gig board"}
+                    </a>
+                </div>
+            ) : (
+                <div class="space-y-4">
+                    {myClaims.map((claim: any) => (
+                        <div class={`bg-brand-cream rounded-2xl p-5 shadow-[var(--shadow-card)] border ${
+                            claim.status === "approved" ? "border-emerald-200" :
+                            claim.status === "rejected" ? "border-red-200" :
+                            claim.status === "completed" ? "border-sky-200" :
+                            "border-violet-200"
+                        }`}>
+                            <div class="flex justify-between items-start mb-3">
+                                <div class="flex-1">
+                                    <span class={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold mb-2 ${
+                                        claim.status === "approved" ? "bg-emerald-100 text-emerald-700" :
+                                        claim.status === "rejected" ? "bg-red-100 text-red-700" :
+                                        claim.status === "completed" ? "bg-sky-100 text-sky-700" :
+                                        "bg-violet-100 text-violet-700"
+                                    }`}>
+                                        {sl(claim.status)}
+                                    </span>
+                                    <p class="text-xs text-brand-ink-soft">
+                                        {lang === "es" ? "Reclamada" : "Claimed"}: {new Date(claim.created_at).toLocaleDateString(lang === "es" ? "es-MX" : "en-US")}
+                                    </p>
+                                </div>
+                                {claim.status === "approved" && (
+                                    <div class="text-right">
+                                        <p class="text-2xl font-extrabold text-emerald-600">+{claim.points_awarded}</p>
+                                        <p class="text-xs text-brand-ink-soft">pts / ${claim.points_awarded} MXN</p>
+                                    </div>
+                                )}
+                            </div>
+
+                            {claim.status === "rejected" && claim.approval_notes && (
+                                <div class="mb-3 p-3 bg-red-50 rounded-xl text-sm text-red-700">
+                                    <strong>{lang === "es" ? "Motivo:" : "Reason:"}</strong> {claim.approval_notes}
+                                </div>
+                            )}
+
+                            {/* Proof submission form — only when CLAIMED (not submitted yet) */}
+                            {claim.status === "claimed" && (
+                                <form class="space-y-3" data-complete-form data-claim-id={claim.id}>
+                                    <div>
+                                        <label class="block text-sm font-medium text-brand-ink mb-1">
+                                            {lang === "es" ? "¿Qué hiciste? (opcional)" : "What did you do? (optional)"}
+                                        </label>
+                                        <textarea
+                                            name="proof_text"
+                                            rows={3}
+                                            class="w-full rounded-xl border border-brand-ink/20 bg-brand-cream-deep px-3 py-2 text-sm text-brand-ink placeholder-brand-ink-soft focus:outline-none focus:ring-2 focus:ring-violet-400"
+                                            placeholder={lang === "es" ? "Describe lo que hiciste..." : "Describe what you did..."}
+                                        />
+                                    </div>
+                                    <div>
+                                        <label class="block text-sm font-medium text-brand-ink mb-1">
+                                            {lang === "es" ? "Foto de evidencia (opcional)" : "Photo evidence (optional)"}
+                                        </label>
+                                        <input
+                                            type="file"
+                                            accept="image/jpeg,image/png,image/webp"
+                                            name="proof_image"
+                                            class="w-full text-sm text-brand-ink-soft file:mr-3 file:py-2 file:px-4 file:rounded-xl file:border-0 file:text-sm file:font-semibold file:bg-violet-100 file:text-violet-700 hover:file:bg-violet-200"
+                                        />
+                                    </div>
+                                    <button
+                                        type="submit"
+                                        class="w-full py-2.5 px-4 bg-violet-600 text-white font-semibold rounded-xl hover:bg-violet-700 active:scale-[.98] transition-all text-sm"
+                                    >
+                                        {lang === "es" ? "Enviar para aprobación" : "Submit for approval"}
+                                    </button>
+                                </form>
+                            )}
+
+                            {claim.status === "completed" && claim.proof_text && (
+                                <div class="mt-2 p-3 bg-sky-50 rounded-xl text-sm text-sky-700">
+                                    <strong>{lang === "es" ? "Tu evidencia:" : "Your proof:"}</strong> {claim.proof_text}
+                                </div>
+                            )}
+                            {claim.status === "approved" && claim.proof_text && (
+                                <div class="mt-2 p-3 bg-emerald-50 rounded-xl text-sm text-emerald-700">
+                                    <strong>{lang === "es" ? "Evidencia enviada:" : "Submitted proof:"}</strong> {claim.proof_text}
+                                </div>
+                            )}
+                        </div>
+                    ))}
+                </div>
+            )}
+        </main>
+
+        <BottomNav active="gigs" role={user.role?.toLowerCase()} lang={lang} />
+    </div>
+</Layout>
+
+<script>
+const lang = document.cookie.split(";").find(c => c.trim().startsWith("lang="))?.split("=")[1] ?? "en";
+
+document.querySelectorAll("[data-complete-form]").forEach(form => {
+    form.addEventListener("submit", async (e) => {
+        e.preventDefault();
+        const formEl = e.target as HTMLFormElement;
+        const claimId = formEl.dataset.claimId;
+        const btn = formEl.querySelector("button[type=submit]") as HTMLButtonElement;
+        btn.disabled = true;
+        btn.textContent = "...";
+
+        const proofText = (formEl.querySelector("[name=proof_text]") as HTMLTextAreaElement)?.value || null;
+        const fileInput = formEl.querySelector("[name=proof_image]") as HTMLInputElement;
+        let proofImageUrl: string | null = null;
+
+        // Upload image if provided
+        if (fileInput?.files?.length) {
+            const uploadForm = new FormData();
+            uploadForm.append("file", fileInput.files[0]);
+            const uploadRes = await fetch("/api/task-assignments/proof-upload", {
+                method: "POST",
+                body: uploadForm,
+            });
+            if (uploadRes.ok) {
+                const uploadData = await uploadRes.json();
+                proofImageUrl = uploadData.url;
+            }
+        }
+
+        const res = await fetch(`/api/gigs/claims/${claimId}/complete`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ proof_text: proofText, proof_image_url: proofImageUrl }),
+        });
+
+        if (res.ok) {
+            window.location.reload();
+        } else {
+            const err = await res.json().catch(() => ({ detail: "Error" }));
+            btn.disabled = false;
+            btn.textContent = lang === "es" ? "Enviar para aprobación" : "Submit for approval";
+            alert(err.detail ?? "Error");
+        }
+    });
+});
+</script>

--- a/frontend/src/pages/parent/gigs.astro
+++ b/frontend/src/pages/parent/gigs.astro
@@ -145,14 +145,20 @@ if (flashError) Astro.cookies.delete("flash_error", { path: "/" });
                     {pendingClaims.map((claim: any) => (
                         <div class="bg-brand-cream rounded-2xl p-5 shadow-[var(--shadow-card)] border border-amber-200">
                             <div class="flex justify-between items-start mb-3">
-                                <div>
-                                    <p class="text-xs text-brand-ink-soft mb-1">
-                                        {lang === "es" ? "Gig completada" : "Gig completed"} · {claim.completed_at ? new Date(claim.completed_at).toLocaleDateString(lang === "es" ? "es-MX" : "en-US") : "—"}
-                                    </p>
-                                    <p class="text-xs text-brand-ink-soft">
-                                        {lang === "es" ? "Reclamante:" : "Claimer:"} <strong class="text-brand-ink">{claim.claimed_by}</strong>
+                                <div class="flex-1">
+                                    <h3 class="font-bold text-brand-ink text-base leading-tight">{claim.gig_title ?? "—"}</h3>
+                                    <p class="text-sm text-brand-ink-soft mt-0.5">
+                                        <strong class="text-brand-ink">{claim.claimer_name ?? claim.claimed_by}</strong>
+                                        {" · "}
+                                        {claim.completed_at ? new Date(claim.completed_at).toLocaleDateString(lang === "es" ? "es-MX" : "en-US") : "—"}
                                     </p>
                                 </div>
+                                {claim.gig_points && (
+                                    <div class="text-right flex-shrink-0 ml-3">
+                                        <p class="text-xl font-extrabold text-violet-600">{claim.gig_points}</p>
+                                        <p class="text-xs text-brand-ink-soft">pts / ${claim.gig_points} MXN</p>
+                                    </div>
+                                )}
                             </div>
 
                             {claim.proof_text && (

--- a/frontend/src/pages/parent/gigs.astro
+++ b/frontend/src/pages/parent/gigs.astro
@@ -1,0 +1,352 @@
+---
+import Layout from "../../layouts/Layout.astro";
+import BottomNav from "../../components/BottomNav.astro";
+import DifficultyChip from "../../components/DifficultyChip.astro";
+import { apiFetch } from "../../lib/api";
+
+const token = Astro.cookies.get("access_token")?.value;
+if (!token) return Astro.redirect("/login");
+const lang = Astro.cookies.get("lang")?.value ?? "en";
+
+const { data: user } = await apiFetch<any>("/api/auth/me", { token });
+if (!user) {
+    Astro.cookies.delete("access_token", { path: "/" });
+    return Astro.redirect("/login");
+}
+if (user.role !== "parent") return Astro.redirect("/gigs");
+
+const [offeringsRes, pendingRes] = await Promise.all([
+    apiFetch<any[]>("/api/gigs/offerings?include_inactive=false", { token }),
+    apiFetch<any[]>("/api/gigs/claims/pending-approvals", { token }),
+]);
+const offerings: any[] = offeringsRes.data ?? [];
+const pendingClaims: any[] = pendingRes.data ?? [];
+
+const activeTab = (Astro.url.searchParams.get("tab") ?? "offerings") as "offerings" | "pending";
+
+const flash = Astro.cookies.get("flash")?.value;
+if (flash) Astro.cookies.delete("flash", { path: "/" });
+const flashError = Astro.cookies.get("flash_error")?.value;
+if (flashError) Astro.cookies.delete("flash_error", { path: "/" });
+---
+
+<Layout title={`${lang === "es" ? "Gestión de Gigs" : "Gig Management"} - Family Task Manager`}>
+    <div class="w-full max-w-md md:max-w-4xl lg:max-w-6xl mx-auto bg-brand-cream-deep flex flex-col min-h-screen">
+        <header class="bg-gradient-to-br from-violet-800 to-violet-600 text-white pt-12 pb-4 px-6 rounded-b-[var(--radius-tile)] shadow-[var(--shadow-card)]">
+            <div class="flex justify-between items-start mb-4">
+                <div>
+                    <h1 class="text-2xl font-bold">{lang === "es" ? "Gigs" : "Gigs"}</h1>
+                    <p class="text-violet-200 text-sm mt-0.5">
+                        {lang === "es" ? "Publica tareas extras con recompensa en efectivo" : "Post extra tasks with cash rewards"}
+                    </p>
+                </div>
+                <button
+                    id="new-gig-btn"
+                    class="bg-white text-violet-700 font-bold text-sm px-4 py-2 rounded-xl shadow hover:bg-violet-50 transition-colors"
+                >
+                    + {lang === "es" ? "Nueva Gig" : "New Gig"}
+                </button>
+            </div>
+            <!-- Tabs -->
+            <div class="flex gap-2">
+                <a
+                    href="?tab=offerings"
+                    class={`flex-1 text-center py-2 text-sm font-semibold rounded-xl transition-colors ${activeTab === "offerings" ? "bg-white text-violet-700" : "text-violet-200 hover:text-white"}`}
+                >
+                    {lang === "es" ? "Ofertas" : "Offerings"}
+                    <span class="ml-1 text-xs">({offerings.length})</span>
+                </a>
+                <a
+                    href="?tab=pending"
+                    class={`flex-1 text-center py-2 text-sm font-semibold rounded-xl transition-colors ${activeTab === "pending" ? "bg-white text-violet-700" : "text-violet-200 hover:text-white"} ${pendingClaims.length > 0 ? "relative" : ""}`}
+                >
+                    {lang === "es" ? "Pendientes" : "Pending"}
+                    {pendingClaims.length > 0 && (
+                        <span class="ml-1 bg-red-500 text-white text-xs rounded-full px-1.5 py-0.5">{pendingClaims.length}</span>
+                    )}
+                </a>
+            </div>
+        </header>
+
+        <main class="flex-1 px-4 py-6">
+            {flash && (
+                <div class="mb-4 p-3 bg-brand-mint/20 border border-brand-mint text-brand-mint-deep text-sm rounded-xl">
+                    {flash}
+                </div>
+            )}
+            {flashError && (
+                <div class="mb-4 p-3 bg-red-100 border border-red-200 text-red-700 text-sm rounded-xl">
+                    {flashError}
+                </div>
+            )}
+
+            <!-- Offerings tab -->
+            {activeTab === "offerings" && (
+                <div class="space-y-3">
+                    {offerings.length === 0 && (
+                        <div class="bg-brand-cream rounded-2xl p-8 text-center border border-brand-ink/10 shadow-[var(--shadow-card)]">
+                            <p class="text-brand-ink-soft text-sm">
+                                {lang === "es" ? "No has publicado ninguna gig aún. ¡Crea la primera!" : "No gigs posted yet. Create the first one!"}
+                            </p>
+                        </div>
+                    )}
+                    {offerings.map((item: any) => {
+                        const o = item.offering ?? item;
+                        return (
+                            <div class="bg-brand-cream rounded-2xl p-5 shadow-[var(--shadow-card)] border border-brand-ink/10">
+                                <div class="flex justify-between items-start">
+                                    <div class="flex-1 pr-4">
+                                        <h3 class="font-bold text-brand-ink">{o.title}</h3>
+                                        {o.description && <p class="text-brand-ink-soft text-sm mt-0.5 line-clamp-2">{o.description}</p>}
+                                        <div class="flex items-center gap-2 mt-2 flex-wrap">
+                                            <DifficultyChip level={o.difficulty ?? 1} lang={lang} />
+                                        </div>
+                                    </div>
+                                    <div class="text-right flex-shrink-0">
+                                        <p class="text-xl font-extrabold text-violet-600">{o.points} pts</p>
+                                        <p class="text-xs text-brand-ink-soft">${o.points} MXN</p>
+                                    </div>
+                                </div>
+                                <div class="flex gap-2 mt-4">
+                                    <button
+                                        class="edit-gig-btn flex-1 py-2 text-sm font-semibold text-violet-700 bg-violet-100 rounded-xl hover:bg-violet-200 transition-colors"
+                                        data-id={o.id}
+                                        data-title={o.title}
+                                        data-description={o.description ?? ""}
+                                        data-points={o.points}
+                                        data-difficulty={o.difficulty ?? 1}
+                                        data-category={o.category ?? "other"}
+                                    >
+                                        {lang === "es" ? "Editar" : "Edit"}
+                                    </button>
+                                    <button
+                                        class="archive-gig-btn flex-1 py-2 text-sm font-semibold text-brand-ink-soft bg-brand-cream-deep rounded-xl hover:bg-red-100 hover:text-red-700 transition-colors"
+                                        data-id={o.id}
+                                    >
+                                        {lang === "es" ? "Archivar" : "Archive"}
+                                    </button>
+                                </div>
+                            </div>
+                        );
+                    })}
+                </div>
+            )}
+
+            <!-- Pending approvals tab -->
+            {activeTab === "pending" && (
+                <div class="space-y-4">
+                    {pendingClaims.length === 0 && (
+                        <div class="bg-brand-cream rounded-2xl p-8 text-center border border-brand-ink/10 shadow-[var(--shadow-card)]">
+                            <p class="text-brand-ink-soft text-sm">
+                                {lang === "es" ? "No hay gigs pendientes de aprobación." : "No gigs pending approval."}
+                            </p>
+                        </div>
+                    )}
+                    {pendingClaims.map((claim: any) => (
+                        <div class="bg-brand-cream rounded-2xl p-5 shadow-[var(--shadow-card)] border border-amber-200">
+                            <div class="flex justify-between items-start mb-3">
+                                <div>
+                                    <p class="text-xs text-brand-ink-soft mb-1">
+                                        {lang === "es" ? "Gig completada" : "Gig completed"} · {claim.completed_at ? new Date(claim.completed_at).toLocaleDateString(lang === "es" ? "es-MX" : "en-US") : "—"}
+                                    </p>
+                                    <p class="text-xs text-brand-ink-soft">
+                                        {lang === "es" ? "Reclamante:" : "Claimer:"} <strong class="text-brand-ink">{claim.claimed_by}</strong>
+                                    </p>
+                                </div>
+                            </div>
+
+                            {claim.proof_text && (
+                                <div class="mb-3 p-3 bg-sky-50 rounded-xl text-sm text-sky-700">
+                                    <strong>{lang === "es" ? "Evidencia:" : "Proof:"}</strong> {claim.proof_text}
+                                </div>
+                            )}
+                            {claim.proof_image_url && (
+                                <div class="mb-3">
+                                    <img src={claim.proof_image_url} alt="Proof" class="rounded-xl max-h-48 object-cover w-full" />
+                                </div>
+                            )}
+
+                            <div class="flex gap-3">
+                                <button
+                                    class="approve-btn flex-1 py-2.5 bg-emerald-500 text-white font-semibold rounded-xl hover:bg-emerald-600 active:scale-[.98] transition-all text-sm"
+                                    data-claim-id={claim.id}
+                                >
+                                    ✅ {lang === "es" ? "Aprobar" : "Approve"}
+                                </button>
+                                <button
+                                    class="reject-btn flex-1 py-2.5 bg-red-100 text-red-700 font-semibold rounded-xl hover:bg-red-200 active:scale-[.98] transition-all text-sm"
+                                    data-claim-id={claim.id}
+                                >
+                                    ✗ {lang === "es" ? "Rechazar" : "Reject"}
+                                </button>
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            )}
+        </main>
+
+        <BottomNav active="gigs" role="parent" lang={lang} />
+    </div>
+</Layout>
+
+<!-- Create/Edit Gig Modal -->
+<div id="gig-modal" class="hidden fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/50 backdrop-blur-sm px-4">
+    <div class="bg-white rounded-t-3xl sm:rounded-3xl w-full max-w-md p-6 shadow-2xl max-h-[90vh] overflow-y-auto">
+        <div class="flex justify-between items-center mb-5">
+            <h2 id="modal-title" class="text-lg font-bold text-brand-ink"></h2>
+            <button id="close-modal" class="text-brand-ink-soft hover:text-brand-ink text-2xl leading-none">&times;</button>
+        </div>
+        <form id="gig-form" class="space-y-4">
+            <input type="hidden" id="edit-gig-id" name="gig_id" value="" />
+            <div>
+                <label class="block text-sm font-medium text-brand-ink mb-1">{lang === "es" ? "Título *" : "Title *"}</label>
+                <input type="text" id="f-title" name="title" required maxlength="200"
+                    class="w-full rounded-xl border border-brand-ink/20 bg-brand-cream-deep px-3 py-2 text-sm text-brand-ink focus:outline-none focus:ring-2 focus:ring-violet-400"
+                    placeholder={lang === "es" ? "Ej: Lavar el carro" : "e.g. Wash the car"} />
+            </div>
+            <div>
+                <label class="block text-sm font-medium text-brand-ink mb-1">{lang === "es" ? "Descripción" : "Description"}</label>
+                <textarea id="f-description" name="description" rows={2}
+                    class="w-full rounded-xl border border-brand-ink/20 bg-brand-cream-deep px-3 py-2 text-sm text-brand-ink focus:outline-none focus:ring-2 focus:ring-violet-400"
+                    placeholder={lang === "es" ? "Detalles opcionales..." : "Optional details..."} />
+            </div>
+            <div class="grid grid-cols-2 gap-3">
+                <div>
+                    <label class="block text-sm font-medium text-brand-ink mb-1">{lang === "es" ? "Puntos / $MXN *" : "Points / $MXN *"}</label>
+                    <input type="number" id="f-points" name="points" required min="1"
+                        class="w-full rounded-xl border border-brand-ink/20 bg-brand-cream-deep px-3 py-2 text-sm text-brand-ink focus:outline-none focus:ring-2 focus:ring-violet-400"
+                        placeholder="50" />
+                </div>
+                <div>
+                    <label class="block text-sm font-medium text-brand-ink mb-1">{lang === "es" ? "Dificultad" : "Difficulty"}</label>
+                    <select id="f-difficulty" name="difficulty"
+                        class="w-full rounded-xl border border-brand-ink/20 bg-brand-cream-deep px-3 py-2 text-sm text-brand-ink focus:outline-none focus:ring-2 focus:ring-violet-400"
+                    >
+                        <option value="1">{lang === "es" ? "Fácil" : "Easy"}</option>
+                        <option value="2">{lang === "es" ? "Medio" : "Medium"}</option>
+                        <option value="3">{lang === "es" ? "Difícil" : "Hard"}</option>
+                    </select>
+                </div>
+            </div>
+            <div>
+                <label class="block text-sm font-medium text-brand-ink mb-1">{lang === "es" ? "Categoría" : "Category"}</label>
+                <select id="f-category" name="category"
+                    class="w-full rounded-xl border border-brand-ink/20 bg-brand-cream-deep px-3 py-2 text-sm text-brand-ink focus:outline-none focus:ring-2 focus:ring-violet-400"
+                >
+                    <option value="chores">{lang === "es" ? "Quehaceres" : "Chores"}</option>
+                    <option value="errands">{lang === "es" ? "Mandados" : "Errands"}</option>
+                    <option value="creative">{lang === "es" ? "Creativo" : "Creative"}</option>
+                    <option value="learning">{lang === "es" ? "Aprendizaje" : "Learning"}</option>
+                    <option value="outdoor">{lang === "es" ? "Al Aire Libre" : "Outdoor"}</option>
+                    <option value="other">{lang === "es" ? "Otro" : "Other"}</option>
+                </select>
+            </div>
+            <button type="submit"
+                class="w-full py-3 bg-violet-600 text-white font-bold rounded-xl hover:bg-violet-700 active:scale-[.98] transition-all"
+            >
+                {lang === "es" ? "Guardar" : "Save"}
+            </button>
+        </form>
+    </div>
+</div>
+
+<script>
+const lang = document.cookie.split(";").find(c => c.trim().startsWith("lang="))?.split("=")[1] ?? "en";
+const modal = document.getElementById("gig-modal")!;
+const modalTitle = document.getElementById("modal-title")!;
+const form = document.getElementById("gig-form") as HTMLFormElement;
+const editIdInput = document.getElementById("edit-gig-id") as HTMLInputElement;
+
+const openModal = (title: string) => {
+    modalTitle.textContent = title;
+    modal.classList.remove("hidden");
+};
+const closeModal = () => {
+    modal.classList.add("hidden");
+    form.reset();
+    editIdInput.value = "";
+};
+
+document.getElementById("new-gig-btn")!.addEventListener("click", () => {
+    openModal(lang === "es" ? "Nueva Gig" : "New Gig");
+});
+document.getElementById("close-modal")!.addEventListener("click", closeModal);
+modal.addEventListener("click", (e) => { if (e.target === modal) closeModal(); });
+
+document.querySelectorAll(".edit-gig-btn").forEach(btn => {
+    btn.addEventListener("click", () => {
+        const b = btn as HTMLElement;
+        editIdInput.value = b.dataset.id!;
+        (document.getElementById("f-title") as HTMLInputElement).value = b.dataset.title!;
+        (document.getElementById("f-description") as HTMLTextAreaElement).value = b.dataset.description!;
+        (document.getElementById("f-points") as HTMLInputElement).value = b.dataset.points!;
+        (document.getElementById("f-difficulty") as HTMLSelectElement).value = b.dataset.difficulty!;
+        (document.getElementById("f-category") as HTMLSelectElement).value = b.dataset.category!;
+        openModal(lang === "es" ? "Editar Gig" : "Edit Gig");
+    });
+});
+
+form.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    const gigId = editIdInput.value;
+    const payload = {
+        title: (document.getElementById("f-title") as HTMLInputElement).value,
+        description: (document.getElementById("f-description") as HTMLTextAreaElement).value || null,
+        points: parseInt((document.getElementById("f-points") as HTMLInputElement).value),
+        difficulty: parseInt((document.getElementById("f-difficulty") as HTMLSelectElement).value),
+        category: (document.getElementById("f-category") as HTMLSelectElement).value,
+    };
+    const btn = form.querySelector("button[type=submit]") as HTMLButtonElement;
+    btn.disabled = true;
+
+    const res = gigId
+        ? await fetch(`/api/gigs/offerings/${gigId}`, { method: "PUT", headers: {"Content-Type":"application/json"}, body: JSON.stringify(payload) })
+        : await fetch("/api/gigs/offerings", { method: "POST", headers: {"Content-Type":"application/json"}, body: JSON.stringify(payload) });
+
+    if (res.ok) {
+        closeModal();
+        window.location.reload();
+    } else {
+        const err = await res.json().catch(() => ({ detail: "Error" }));
+        btn.disabled = false;
+        alert(err.detail ?? "Error");
+    }
+});
+
+document.querySelectorAll(".archive-gig-btn").forEach(btn => {
+    btn.addEventListener("click", async () => {
+        if (!confirm(lang === "es" ? "¿Archivar esta gig?" : "Archive this gig?")) return;
+        const b = btn as HTMLElement;
+        const res = await fetch(`/api/gigs/offerings/${b.dataset.id}`, { method: "DELETE" });
+        if (res.ok) window.location.reload();
+    });
+});
+
+document.querySelectorAll(".approve-btn").forEach(btn => {
+    btn.addEventListener("click", async () => {
+        const b = btn as HTMLElement;
+        const res = await fetch(`/api/gigs/claims/${b.dataset.claimId}/approve`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ approved: true }),
+        });
+        if (res.ok) window.location.reload();
+        else alert("Error approving");
+    });
+});
+
+document.querySelectorAll(".reject-btn").forEach(btn => {
+    btn.addEventListener("click", async () => {
+        const notes = prompt(lang === "es" ? "Motivo del rechazo (opcional):" : "Rejection reason (optional):") ?? "";
+        const b = btn as HTMLElement;
+        const res = await fetch(`/api/gigs/claims/${b.dataset.claimId}/approve`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ approved: false, notes: notes || null }),
+        });
+        if (res.ok) window.location.reload();
+        else alert("Error rejecting");
+    });
+});
+</script>

--- a/frontend/src/pages/parent/index.astro
+++ b/frontend/src/pages/parent/index.astro
@@ -259,7 +259,7 @@ const pendingApprovals = Array.isArray(pending) ? pending.length : 0;
                     </div>
                 </a>
                 <a
-                    href="/parent/frankie"
+                    href="/parent/jarvis"
                     class="bg-brand-cream rounded-2xl p-5 shadow-[var(--shadow-card)] border border-brand-ink/10 hover:shadow-[var(--shadow-card)] hover:border-violet-400 transition-all flex flex-col items-center text-center gap-3"
                 >
                     <div class="w-12 h-12 rounded-xl bg-violet-100 flex items-center justify-center">

--- a/frontend/src/pages/parent/jarvis-schedules.astro
+++ b/frontend/src/pages/parent/jarvis-schedules.astro
@@ -26,7 +26,7 @@ if (Astro.request.method === "POST") {
             cron_expr: data.get("cron_expr"),
             channel: data.get("channel") || "notification",
         };
-        const { ok, error } = await apiFetch("/api/frankie/schedules/", {
+        const { ok, error } = await apiFetch("/api/jarvis/schedules/", {
             method: "POST",
             token,
             body: JSON.stringify(payload),
@@ -35,7 +35,7 @@ if (Astro.request.method === "POST") {
     } else if (action === "toggle") {
         const id = data.get("schedule_id");
         if (id) {
-            await apiFetch(`/api/frankie/schedules/${id}/toggle`, {
+            await apiFetch(`/api/jarvis/schedules/${id}/toggle`, {
                 method: "POST",
                 token,
             });
@@ -43,16 +43,16 @@ if (Astro.request.method === "POST") {
     } else if (action === "delete") {
         const id = data.get("schedule_id");
         if (id) {
-            await apiFetch(`/api/frankie/schedules/${id}`, {
+            await apiFetch(`/api/jarvis/schedules/${id}`, {
                 method: "DELETE",
                 token,
             });
         }
     }
-    return Astro.redirect("/parent/frankie-schedules");
+    return Astro.redirect("/parent/jarvis-schedules");
 }
 
-const { data: schedulesRaw } = await apiFetch<any[]>("/api/frankie/schedules/", {
+const { data: schedulesRaw } = await apiFetch<any[]>("/api/jarvis/schedules/", {
     token,
 });
 const schedules: any[] = Array.isArray(schedulesRaw) ? schedulesRaw : [];
@@ -101,7 +101,7 @@ const labels = {
 <Layout title={`${labels.title} - Family Task Manager`}>
     <div class="w-full max-w-md md:max-w-4xl mx-auto bg-brand-cream-deep flex flex-col">
         <header class="bg-gradient-to-br from-violet-600 to-fuchsia-500 text-white pt-12 pb-6 px-6 rounded-b-[var(--radius-tile)] shadow-[var(--shadow-card)]">
-            <a href="/parent/frankie" class="text-xs text-violet-200 underline">{labels.back}</a>
+            <a href="/parent/jarvis" class="text-xs text-violet-200 underline">{labels.back}</a>
             <h1 class="text-2xl font-bold mt-1">⏰ {labels.title}</h1>
             <p class="text-violet-200 text-xs">{labels.subtitle}</p>
         </header>

--- a/frontend/src/pages/parent/jarvis.astro
+++ b/frontend/src/pages/parent/jarvis.astro
@@ -18,12 +18,12 @@ if (Astro.request.method === "POST") {
     const data = await Astro.request.formData();
     const action = data.get("action");
     if (action === "clear") {
-        await apiFetch("/api/frankie/history", { method: "DELETE", token });
+        await apiFetch("/api/jarvis/history", { method: "DELETE", token });
     }
-    return Astro.redirect("/parent/frankie");
+    return Astro.redirect("/parent/jarvis");
 }
 
-const { data: historyRaw } = await apiFetch<any[]>("/api/frankie/history", {
+const { data: historyRaw } = await apiFetch<any[]>("/api/jarvis/history", {
     token,
 });
 const history: any[] = Array.isArray(historyRaw) ? historyRaw : [];
@@ -55,7 +55,7 @@ const labels = {
                     <p class="text-violet-100 text-xs mt-1">{labels.subtitle}</p>
                 </div>
                 <div class="flex gap-2 items-center">
-                    <a href="/parent/frankie-schedules" class="text-xs underline text-violet-200 hover:text-white">
+                    <a href="/parent/jarvis-schedules" class="text-xs underline text-violet-200 hover:text-white">
                         ⏰ {lang === "es" ? "Programaciones" : "Schedules"}
                     </a>
                     {history.length > 0 && (
@@ -177,7 +177,7 @@ const labels = {
 
             const liveActions: string[] = [];
             try {
-                const resp = await fetch("/api/frankie/chat-stream", {
+                const resp = await fetch("/api/jarvis/chat-stream", {
                     method: "POST",
                     headers: { "Content-Type": "application/json" },
                     body: JSON.stringify({ message, model: selectedModel }),

--- a/frontend/src/pages/parent/settings/index.astro
+++ b/frontend/src/pages/parent/settings/index.astro
@@ -130,7 +130,7 @@ const labels = {
                 </a>
 
                 <a
-                    href="/parent/frankie"
+                    href="/parent/jarvis"
                     class="bg-brand-cream rounded-2xl p-5 shadow-[var(--shadow-card)] border border-brand-ink/10 hover:shadow-[var(--shadow-card)] hover:border-violet-600 transition-all flex items-center gap-4"
                 >
                     <div class="w-12 h-12 rounded-xl bg-violet-600/15 flex items-center justify-center flex-shrink-0">

--- a/frontend/src/pages/parent/tasks.astro
+++ b/frontend/src/pages/parent/tasks.astro
@@ -2,6 +2,7 @@
 import Layout from "../../layouts/Layout.astro";
 import BottomNav from "../../components/BottomNav.astro";
 import TaskCreateModal from "../../components/TaskCreateModal.astro";
+import DifficultyChip from "../../components/DifficultyChip.astro";
 import { apiFetch } from "../../lib/api";
 import { t } from "../../lib/i18n";
 
@@ -68,7 +69,8 @@ const [{ data: templates }, { data: weekAssignments }, { data: familyMembers }] 
     apiFetch<any[]>("/api/task-assignments/week", { token }),
     apiFetch<any[]>(`/api/families/${user.family_id}/members`, { token }),
 ]);
-const templateList: any[] = Array.isArray(templates) ? templates : [];
+// Only show mandatory tasks (is_bonus=False) — gigs live in /parent/gigs
+const templateList: any[] = (Array.isArray(templates) ? templates : []).filter((t: any) => !t.is_bonus);
 const assignmentList: any[] = Array.isArray(weekAssignments) ? weekAssignments : [];
 const memberList: any[] = Array.isArray(familyMembers) ? familyMembers : [];
 
@@ -218,14 +220,9 @@ function freqLabel(interval: number): string {
                                         {tmpl.description && (
                                             <p class="text-xs text-brand-ink-soft line-clamp-1">{tmpl.description}</p>
                                         )}
-                                        <p class="text-xs text-brand-sun-deep font-semibold mt-1">
-                                            +{tmpl.effective_points ?? tmpl.points} pts
-                                            {tmpl.effort_level > 1 && (
-                                                <span class="ml-1 text-brand-ink-soft font-normal">
-                                                    ({tmpl.points} × {tmpl.effort_level === 3 ? "2" : "1.5"})
-                                                </span>
-                                            )}
-                                        </p>
+                                        <div class="mt-1">
+                                            <DifficultyChip level={tmpl.effort_level ?? 1} lang={lang} />
+                                        </div>
                                     </div>
                                     <div class="flex gap-1.5 flex-shrink-0">
                                         <!-- Toggle active -->

--- a/frontend/src/pages/rewards.astro
+++ b/frontend/src/pages/rewards.astro
@@ -158,6 +158,10 @@ if (flashError) Astro.cookies.delete("flash_error", { path: "/" });
                         {rewards.map((reward: any) => {
                             const canAfford = user.points >= reward.points_cost;
                             const canRedeem = canAfford && !isLocked;
+                            const pct = reward.points_cost > 0
+                                ? Math.min(100, Math.round((user.points / reward.points_cost) * 100))
+                                : 100;
+                            const remaining = Math.max(0, reward.points_cost - user.points);
                             return (
                                 <div
                                     class={`bg-brand-cream rounded-2xl p-5 shadow-[var(--shadow-card)] border transition-all ${canRedeem ? "border-brand-ink/10 hover:shadow-[var(--shadow-card)]" : "border-brand-ink/10 opacity-60"}`}
@@ -165,7 +169,7 @@ if (flashError) Astro.cookies.delete("flash_error", { path: "/" });
                                     <div class="flex justify-between items-start mb-3">
                                         <div class="flex-1 pr-3">
                                             <h3 class="font-bold text-brand-ink text-lg mb-1">
-                                                {reward.name}
+                                                {reward.title}
                                             </h3>
                                             {reward.description && (
                                                 <p class="text-brand-ink-soft text-sm line-clamp-2">
@@ -189,6 +193,19 @@ if (flashError) Astro.cookies.delete("flash_error", { path: "/" });
                                                 {t(lang, "rewards_pts")}
                                             </span>
                                         </div>
+                                    </div>
+                                    <div class="mb-3">
+                                        <div class="w-full bg-brand-cream-deep rounded-full h-2 overflow-hidden">
+                                            <div
+                                                class={`h-2 rounded-full transition-all duration-500 ${canAfford ? "bg-brand-mint" : "bg-brand-sun-deep"}`}
+                                                style={`width: ${pct}%`}
+                                            ></div>
+                                        </div>
+                                        <p class="text-xs mt-1 font-medium text-brand-ink-soft">
+                                            {canAfford
+                                                ? (lang === "es" ? "✓ Listo para canjear" : "✓ Ready to redeem")
+                                                : (lang === "es" ? `Te faltan ${remaining} puntos` : `${remaining} points to go`)}
+                                        </p>
                                     </div>
                                     <form method="POST">
                                         <input


### PR DESCRIPTION
## Rename Frankie → Jarvis

Renames the parent-facing AI copilot across the whole stack.

### Changes
- **Backend**: routes/services/models renamed (git-tracked renames), `/api/frankie` → `/api/jarvis`, env vars `FRANKIE_*` → `JARVIS_*`
- **DB**: new metadata-only migration `jarvis_rename_v1` (down=`gig_tables`) renaming tables `frankie_messages`→`jarvis_messages`, `frankie_schedules`→`jarvis_schedules` + their indexes/constraints (`ALTER ... RENAME`, data-preserving)
- **Frontend**: pages + nav + SSR proxy
- Migration-history files intentionally keep `frankie_v1`/`frankie_sch_v1` revision IDs (referenced by later down_revisions)

### Verified
- `alembic heads` = 1 (single linear head)
- `alembic upgrade gig_tables:jarvis_rename_v1 --sql` renders correct `ALTER ... RENAME` SQL
- `py_compile` clean; no `frankie` refs outside migration history

### ⚠️ Deploy note
Before deploy, rename `FRANKIE_MODEL` / `FRANKIE_DAILY_MESSAGE_CAP` → `JARVIS_*` in the prod VM `.env`. `/api/frankie` is a clean break (no alias) — native clients calling it 404 until updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)