### PR TITLE
fix(ops): production-readiness hardening (Track B: B1-B4, B6)

### DIFF
--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -33,7 +33,7 @@ from app.schemas.user import (
 from app.models import User
 from app.models.family import Family, generate_join_code
 from app.core.security import get_password_hash, create_access_token
-from app.core.rate_limiter import limiter, AUTH_LIMIT
+from app.core.rate_limiter import limiter, AUTH_LIMIT, EMAIL_LIMIT
 
 router = APIRouter()
 
@@ -288,7 +288,9 @@ async def update_password(
 # ---------------------------------------------------------------------------
 
 @router.post("/verify-email")
+@limiter.limit(EMAIL_LIMIT)
 async def verify_email(
+    request: Request,
     body: VerifyEmailRequest,
     db: AsyncSession = Depends(get_db),
 ):
@@ -303,7 +305,9 @@ async def verify_email(
 
 
 @router.post("/resend-verification")
+@limiter.limit(EMAIL_LIMIT)
 async def resend_verification(
+    request: Request,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -33,6 +33,7 @@ from app.schemas.user import (
 from app.models import User
 from app.models.family import Family, generate_join_code
 from app.core.security import get_password_hash, create_access_token
+from app.core.rate_limiter import limiter, AUTH_LIMIT
 
 router = APIRouter()
 
@@ -66,7 +67,9 @@ async def register(
     response_model=RegisterFamilyResponse,
     status_code=status.HTTP_201_CREATED,
 )
+@limiter.limit(AUTH_LIMIT)
 async def register_family(
+    request: Request,
     data: RegisterFamilyRequest,
     db: AsyncSession = Depends(get_db),
 ):
@@ -161,7 +164,9 @@ async def register_family(
 
 
 @router.post("/login", response_model=TokenResponse)
+@limiter.limit(AUTH_LIMIT)
 async def login(
+    request: Request,
     login_data: UserLogin,
     db: AsyncSession = Depends(get_db),
 ):
@@ -184,7 +189,9 @@ class CheckMethodsResponse(BaseModel):
 
 
 @router.post("/check-methods", response_model=CheckMethodsResponse)
+@limiter.limit(AUTH_LIMIT)
 async def check_auth_methods(
+    request: Request,
     body: CheckMethodsRequest,
     db: AsyncSession = Depends(get_db),
 ):
@@ -314,7 +321,9 @@ async def resend_verification(
 # ---------------------------------------------------------------------------
 
 @router.post("/forgot-password")
+@limiter.limit(AUTH_LIMIT)
 async def forgot_password(
+    request: Request,
     body: ForgotPasswordRequest,
     db: AsyncSession = Depends(get_db),
 ):
@@ -330,7 +339,9 @@ async def forgot_password(
 
 
 @router.post("/reset-password")
+@limiter.limit(AUTH_LIMIT)
 async def reset_password(
+    request: Request,
     body: ResetPasswordRequest,
     db: AsyncSession = Depends(get_db),
 ):

--- a/backend/app/api/routes/budget/transactions.py
+++ b/backend/app/api/routes/budget/transactions.py
@@ -4,7 +4,7 @@ Transaction routes
 CRUD endpoints for budget transactions.
 """
 
-from fastapi import APIRouter, Body, Depends, HTTPException, Response, status, Query, File, UploadFile, Form
+from fastapi import APIRouter, Body, Depends, HTTPException, Request, Response, status, Query, File, UploadFile, Form
 from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing import List, Optional, Dict
@@ -15,6 +15,7 @@ from app.core.database import get_db
 from app.core.dependencies import get_current_user, require_parent_role
 from app.core.type_utils import to_uuid_required
 from app.core.premium import require_feature
+from app.core.rate_limiter import limiter, AI_LIMIT
 from app.services.budget.transaction_service import TransactionService
 from app.services.usage_service import UsageService
 from app.services.budget.csv_import_service import CSVImportService
@@ -511,7 +512,9 @@ async def import_file_transactions_endpoint(
 
 
 @router.post("/scan-receipt", status_code=status.HTTP_200_OK)
+@limiter.limit(AI_LIMIT)
 async def scan_receipt_endpoint(
+    request: Request,
     file: UploadFile = File(..., description="Receipt photo or scanned PDF (JPEG, PNG, WebP, GIF, PDF)"),
     account_id: Optional[UUID] = Form(None, description="Target account; omit for auto-detect"),
     force: bool = Query(False, description="Bypass duplicate guard and commit the transaction"),

--- a/backend/app/api/routes/subscriptions_webhook.py
+++ b/backend/app/api/routes/subscriptions_webhook.py
@@ -27,29 +27,42 @@ logger = logging.getLogger(__name__)
 EVENT_TTL_SECONDS = 7 * 24 * 3600
 
 
-async def _dedupe_event(event_id: str) -> bool:
-    """
-    Return True if this event_id was NOT seen before (i.e. proceed),
-    False if it's a duplicate. On any Redis failure, return True so the
-    event proceeds — better to risk an idempotent reapply than to drop.
+async def _already_processed(event_id: str) -> bool:
+    """True if this event was already fully processed (skip it).
+
+    Read-only — the 'processed' mark is written only AFTER a successful state
+    change (see _mark_processed). On Redis failure, return False so the event
+    proceeds; the state transitions are idempotent.
     """
     try:
         import redis.asyncio as aioredis
 
         client = aioredis.from_url(settings.REDIS_URL, decode_responses=True)
         try:
-            result = await client.set(
-                f"paypal:event:{event_id}",
-                "1",
-                ex=EVENT_TTL_SECONDS,
-                nx=True,
-            )
-            return bool(result)
+            return (await client.get(f"paypal:event:{event_id}")) is not None
         finally:
-            await client.close()
+            await client.aclose()
     except Exception as e:
-        logger.warning("Redis dedupe failed (proceeding): %s", e)
-        return True
+        logger.warning("Redis dedupe check failed (proceeding): %s", e)
+        return False
+
+
+async def _mark_processed(event_id: str) -> None:
+    """Record that this event was successfully handled (so retries are deduped).
+
+    Called ONLY after the state change committed — never before — so a transient
+    failure leaves the event un-marked and PayPal's retry can reprocess it.
+    """
+    try:
+        import redis.asyncio as aioredis
+
+        client = aioredis.from_url(settings.REDIS_URL, decode_responses=True)
+        try:
+            await client.set(f"paypal:event:{event_id}", "1", ex=EVENT_TTL_SECONDS)
+        finally:
+            await client.aclose()
+    except Exception as e:
+        logger.warning("Redis mark-processed failed: %s", e)
 
 
 @router.post("/webhook", status_code=200)
@@ -97,12 +110,11 @@ async def receive_webhook(request: Request, db: AsyncSession = Depends(get_db)):
             detail="invalid signature",
         )
 
-    # Dedupe via Redis
-    if event_id:
-        proceed = await _dedupe_event(event_id)
-        if not proceed:
-            logger.info("Duplicate webhook event %s, skipping", event_id)
-            return {"received": True, "duplicate": True}
+    # Skip events we already fully processed (the mark is written only after a
+    # successful state change below).
+    if event_id and await _already_processed(event_id):
+        logger.info("Duplicate webhook event %s, skipping", event_id)
+        return {"received": True, "duplicate": True}
 
     if not subscription_id:
         logger.warning("Webhook event %s has no resource.id", event_id)
@@ -132,6 +144,16 @@ async def receive_webhook(request: Request, db: AsyncSession = Depends(get_db)):
         else:
             logger.info("Ignoring webhook event_type %s", event_type)
     except Exception as e:
+        # Do NOT mark processed and DO return 5xx so PayPal retries — a transient
+        # DB failure must not silently drop a subscription state change.
         logger.exception("Webhook dispatch failed for %s: %s", event_id, e)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="processing failed; will retry",
+        )
+
+    # Mark processed only after a successful (or intentionally-ignored) dispatch.
+    if event_id:
+        await _mark_processed(event_id)
 
     return {"received": True}

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -149,7 +149,13 @@ class Settings(BaseSettings):
 
     # Redis (Optional)
     REDIS_URL: str = "redis://redis:6379/0"
-    
+
+    # Storage backend for the slowapi rate limiter. Empty -> in-memory (per
+    # worker). Set to a redis:// URL in multi-worker / multi-instance deploys so
+    # the limit window is shared across workers. (Pydantic extra='ignore' means an
+    # env var must have a matching field here to take effect — hence this field.)
+    RATE_LIMIT_STORAGE_URI: str = ""
+
     # LiteLLM Proxy (for auto-translation via mistral-nemo)
     LITELLM_API_BASE: str = "http://10.1.0.99:4000"
     LITELLM_API_KEY: str = ""

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,7 +1,10 @@
 from pydantic_settings import BaseSettings, SettingsConfigDict
-from pydantic import field_validator
+from pydantic import field_validator, model_validator
 from typing import List, Union
 import os
+
+# SECRET_KEY values that must never be used in production (forgeable JWTs/cookies).
+_INSECURE_SECRET_KEYS = {"", "your-secret-key-change-this-in-production"}
 
 # Fold Vault KV secrets into os.environ before Settings() is instantiated.
 # This is a no-op if VAULT_ADDR/VAULT_TOKEN aren't set or if Vault is
@@ -188,7 +191,20 @@ class Settings(BaseSettings):
         if isinstance(v, str):
             return [i.strip() for i in v.split(',') if i.strip()]
         return v
-    
+
+    @model_validator(mode='after')
+    def _enforce_production_secrets(self):
+        """Fail fast in production (DEBUG=false) if SECRET_KEY is unset or still
+        the shipped placeholder — that would mean forgeable JWTs and session
+        cookies. Local/dev (DEBUG=true) is allowed to keep the default."""
+        if not self.DEBUG and self.SECRET_KEY in _INSECURE_SECRET_KEYS:
+            raise ValueError(
+                "SECRET_KEY is unset or still the insecure default while DEBUG is "
+                "false. Set a strong SECRET_KEY in the environment before running "
+                "in production."
+            )
+        return self
+
     model_config = SettingsConfigDict(
         env_file=".env",
         case_sensitive=True,

--- a/backend/app/core/rate_limiter.py
+++ b/backend/app/core/rate_limiter.py
@@ -1,0 +1,29 @@
+"""Application rate limiting (slowapi).
+
+Protects unauthenticated auth endpoints (brute force, credential stuffing, email
+enumeration) and expensive AI endpoints from abuse. Keyed by client IP.
+
+Storage: in-memory by default (works for single-instance + tests). For a
+multi-worker / multi-instance deploy set RATE_LIMIT_STORAGE_URI to the Redis URL
+so the window is shared across workers — otherwise each worker enforces the limit
+independently (still bounded, just N x looser).
+"""
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+from app.core.config import settings
+
+_storage_uri = getattr(settings, "RATE_LIMIT_STORAGE_URI", "") or "memory://"
+
+# headers_enabled stays False: injecting X-RateLimit-* headers on a 200 requires
+# every route to declare a `response: Response` param. The 429 response from the
+# exceeded-handler still carries Retry-After, which is what clients actually need.
+limiter = Limiter(
+    key_func=get_remote_address,
+    storage_uri=_storage_uri,
+)
+
+# Per-route limits (tweak here). Strings use the `limits` syntax.
+AUTH_LIMIT = "10/minute"      # login, register-family, check-methods, password reset
+EMAIL_LIMIT = "5/minute"     # verification / resend (extra-cheap to abuse)
+AI_LIMIT = "30/hour"         # receipt scan / document scan

--- a/backend/app/core/scheduler_lock.py
+++ b/backend/app/core/scheduler_lock.py
@@ -1,0 +1,78 @@
+"""Single-runner gate for scheduled jobs across multiple uvicorn workers.
+
+Previously APScheduler + the overdue sweep were started in every worker's
+lifespan, so with `--workers 2` every cron job fired twice (double point awards,
+double emails, double subscription sweeps). Each worker now calls
+``try_acquire_scheduler_leadership`` at startup; exactly one wins a Redis lock and
+runs the jobs. The leader renews the lock; if it dies, the TTL lets another worker
+take over.
+
+Fail-open: if Redis is unreachable we return leader=True so a single-instance
+deploy with no Redis still runs its jobs (the duplicate risk only matters when
+multiple workers share a Redis, which is exactly when Redis is up).
+"""
+import os
+import socket
+from typing import Optional, Tuple
+
+import redis.asyncio as aioredis
+
+LEADER_KEY = "ftm:scheduler:leader"
+LEADER_TTL_SECONDS = 120
+
+
+async def try_acquire_scheduler_leadership(
+    redis_url: str,
+    *,
+    key: str = LEADER_KEY,
+    ttl: int = LEADER_TTL_SECONDS,
+) -> Tuple[bool, Optional["aioredis.Redis"]]:
+    """Attempt to become the scheduler leader.
+
+    Returns ``(is_leader, client)``. When ``is_leader`` is True the caller owns
+    ``client`` and must renew/release it (the client is None in the fail-open
+    case). When False the caller must not run scheduled jobs.
+    """
+    try:
+        client = aioredis.from_url(redis_url)
+    except Exception:
+        return True, None  # fail-open: no Redis → run jobs (single instance)
+
+    try:
+        token = f"{socket.gethostname()}:{os.getpid()}"
+        acquired = await client.set(key, token, nx=True, ex=ttl)
+        if acquired:
+            return True, client
+        await client.aclose()
+        return False, None
+    except Exception:
+        try:
+            await client.aclose()
+        except Exception:
+            pass
+        return True, None  # fail-open on Redis error
+
+
+async def renew_scheduler_leadership(
+    client: "aioredis.Redis", *, key: str = LEADER_KEY, ttl: int = LEADER_TTL_SECONDS
+) -> None:
+    """Refresh the leader lock TTL so it doesn't expire while this worker lives."""
+    try:
+        await client.expire(key, ttl)
+    except Exception:
+        pass
+
+
+async def release_scheduler_leadership(
+    client: Optional["aioredis.Redis"], *, key: str = LEADER_KEY
+) -> None:
+    """Release the lock on shutdown so another worker can take over immediately."""
+    if client is None:
+        return
+    try:
+        await client.delete(key)
+    finally:
+        try:
+            await client.aclose()
+        except Exception:
+            pass

--- a/backend/app/core/scheduler_lock.py
+++ b/backend/app/core/scheduler_lock.py
@@ -1,15 +1,22 @@
 """Single-runner gate for scheduled jobs across multiple uvicorn workers.
 
 Previously APScheduler + the overdue sweep were started in every worker's
-lifespan, so with `--workers 2` every cron job fired twice (double point awards,
-double emails, double subscription sweeps). Each worker now calls
+lifespan, so with `--workers 2` every cron job fired twice. Each worker now calls
 ``try_acquire_scheduler_leadership`` at startup; exactly one wins a Redis lock and
 runs the jobs. The leader renews the lock; if it dies, the TTL lets another worker
-take over.
+take over (on its next restart — see NOTE below).
+
+Each renew/release is guarded by the leader's own token (compare-and-expire /
+compare-and-delete via a Lua script) so a worker can NEVER refresh or delete a
+lock that a different worker took over after this worker's TTL lapsed.
 
 Fail-open: if Redis is unreachable we return leader=True so a single-instance
-deploy with no Redis still runs its jobs (the duplicate risk only matters when
-multiple workers share a Redis, which is exactly when Redis is up).
+deploy with no Redis still runs its jobs.
+
+NOTE: non-leader workers do not re-poll for leadership while running; if the
+leader process dies, its lock expires after TTL and the jobs pause until a worker
+restarts (acceptable for the daily/5-min sweeps here, and a deploy restarts all
+workers). Promote to a periodic re-acquire loop if jobs become latency-critical.
 """
 import os
 import socket
@@ -20,57 +27,81 @@ import redis.asyncio as aioredis
 LEADER_KEY = "ftm:scheduler:leader"
 LEADER_TTL_SECONDS = 120
 
+# Only act if WE still hold the lock (stored value == our token).
+_RENEW_LUA = (
+    "if redis.call('get', KEYS[1]) == ARGV[1] then "
+    "return redis.call('expire', KEYS[1], ARGV[2]) else return 0 end"
+)
+_RELEASE_LUA = (
+    "if redis.call('get', KEYS[1]) == ARGV[1] then "
+    "return redis.call('del', KEYS[1]) else return 0 end"
+)
+
+
+def _worker_token() -> str:
+    return f"{socket.gethostname()}:{os.getpid()}"
+
 
 async def try_acquire_scheduler_leadership(
     redis_url: str,
     *,
     key: str = LEADER_KEY,
     ttl: int = LEADER_TTL_SECONDS,
-) -> Tuple[bool, Optional["aioredis.Redis"]]:
+) -> Tuple[bool, Optional["aioredis.Redis"], Optional[str]]:
     """Attempt to become the scheduler leader.
 
-    Returns ``(is_leader, client)``. When ``is_leader`` is True the caller owns
-    ``client`` and must renew/release it (the client is None in the fail-open
-    case). When False the caller must not run scheduled jobs.
+    Returns ``(is_leader, client, token)``. When ``is_leader`` is True the caller
+    owns ``client`` + ``token`` and must renew/release with them (both are None in
+    the fail-open case). When False the caller must not run scheduled jobs.
     """
     try:
         client = aioredis.from_url(redis_url)
     except Exception:
-        return True, None  # fail-open: no Redis → run jobs (single instance)
+        return True, None, None  # fail-open: no Redis -> run jobs (single instance)
 
     try:
-        token = f"{socket.gethostname()}:{os.getpid()}"
+        token = _worker_token()
         acquired = await client.set(key, token, nx=True, ex=ttl)
         if acquired:
-            return True, client
+            return True, client, token
         await client.aclose()
-        return False, None
+        return False, None, None
     except Exception:
         try:
             await client.aclose()
         except Exception:
             pass
-        return True, None  # fail-open on Redis error
+        return True, None, None  # fail-open on Redis error
 
 
 async def renew_scheduler_leadership(
-    client: "aioredis.Redis", *, key: str = LEADER_KEY, ttl: int = LEADER_TTL_SECONDS
+    client: Optional["aioredis.Redis"],
+    token: Optional[str],
+    *,
+    key: str = LEADER_KEY,
+    ttl: int = LEADER_TTL_SECONDS,
 ) -> None:
-    """Refresh the leader lock TTL so it doesn't expire while this worker lives."""
+    """Refresh the lock TTL, but only if we still hold it (token match)."""
+    if client is None or token is None:
+        return
     try:
-        await client.expire(key, ttl)
+        await client.eval(_RENEW_LUA, 1, key, token, ttl)
     except Exception:
         pass
 
 
 async def release_scheduler_leadership(
-    client: Optional["aioredis.Redis"], *, key: str = LEADER_KEY
+    client: Optional["aioredis.Redis"],
+    token: Optional[str],
+    *,
+    key: str = LEADER_KEY,
 ) -> None:
-    """Release the lock on shutdown so another worker can take over immediately."""
+    """Release the lock on shutdown, but only if we still hold it (token match)."""
     if client is None:
         return
     try:
-        await client.delete(key)
+        if token is not None:
+            await client.eval(_RELEASE_LUA, 1, key, token)
     finally:
         try:
             await client.aclose()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -161,6 +161,14 @@ app.add_middleware(
     max_age=1800,  # 30 minutes
 )
 
+# Rate limiting (slowapi) — protects auth + AI endpoints from abuse.
+from slowapi import _rate_limit_exceeded_handler  # noqa: E402
+from slowapi.errors import RateLimitExceeded  # noqa: E402
+from app.core.rate_limiter import limiter  # noqa: E402
+
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
 # Register exception handlers
 register_exception_handlers(app)
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -62,7 +62,7 @@ async def lifespan(app: FastAPI):
 
     # Elect a single scheduler leader so cron jobs + the overdue sweep run on
     # exactly one worker (prod runs multiple uvicorn workers).
-    is_leader, leader_client = await try_acquire_scheduler_leadership(settings.REDIS_URL)
+    is_leader, leader_client, leader_token = await try_acquire_scheduler_leadership(settings.REDIS_URL)
 
     overdue_task = None
     scheduler = None
@@ -112,7 +112,7 @@ async def lifespan(app: FastAPI):
             async def _renew_leadership_loop():
                 while True:
                     await asyncio.sleep(60)
-                    await renew_scheduler_leadership(leader_client)
+                    await renew_scheduler_leadership(leader_client, leader_token)
 
             renew_task = asyncio.create_task(_renew_leadership_loop())
 
@@ -129,7 +129,7 @@ async def lifespan(app: FastAPI):
                 await _task
             except asyncio.CancelledError:
                 pass
-    await release_scheduler_leadership(leader_client)
+    await release_scheduler_leadership(leader_client, leader_token)
     await engine.dispose()
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -48,63 +48,88 @@ async def _overdue_sweep_loop() -> None:
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Application lifespan events"""
+    from app.core.scheduler_lock import (
+        try_acquire_scheduler_leadership,
+        renew_scheduler_leadership,
+        release_scheduler_leadership,
+    )
+
     # Startup
     logger.info("Starting Family Task Manager API...")
     logger.info(
         f"Database URL: {settings.DATABASE_URL.split('@')[1] if '@' in settings.DATABASE_URL else 'Not configured'}"
     )
 
-    # Create database tables (in production, use Alembic migrations)
-    # async with engine.begin() as conn:
-    #     await conn.run_sync(Base.metadata.create_all)
+    # Elect a single scheduler leader so cron jobs + the overdue sweep run on
+    # exactly one worker (prod runs multiple uvicorn workers).
+    is_leader, leader_client = await try_acquire_scheduler_leadership(settings.REDIS_URL)
 
-    overdue_task = asyncio.create_task(_overdue_sweep_loop())
+    overdue_task = None
+    scheduler = None
+    renew_task = None
 
-    async def _pet_decay_sweep():
-        async with AsyncSessionLocal() as session:
-            try:
-                n = await PetService.sweep_decay_all(session)
-                if n:
-                    logger.info("Pet decay sweep notified %d owner(s)", n)
-            except Exception:
-                logger.exception("Pet decay sweep failed")
+    if not is_leader:
+        logger.info("Not the scheduler leader — skipping cron + overdue sweep in this worker.")
+    else:
+        logger.info("Scheduler leader — starting cron jobs + overdue sweep.")
+        overdue_task = asyncio.create_task(_overdue_sweep_loop())
 
-    async def _pup_snapshot_sweep():
-        async with AsyncSessionLocal() as session:
-            try:
-                n = await AnalyticsService.write_all_snapshots(session)
-                if n:
-                    logger.info("PUP snapshot wrote %d family rows", n)
-            except Exception:
-                logger.exception("PUP snapshot sweep failed")
+        async def _pet_decay_sweep():
+            async with AsyncSessionLocal() as session:
+                try:
+                    n = await PetService.sweep_decay_all(session)
+                    if n:
+                        logger.info("Pet decay sweep notified %d owner(s)", n)
+                except Exception:
+                    logger.exception("Pet decay sweep failed")
 
-    scheduler = AsyncIOScheduler()
-    scheduler.add_job(run_sweep, "cron", hour=3, minute=0, id="subscription_sweep")
-    scheduler.add_job(_pet_decay_sweep, "cron", hour=8, minute=0, id="pet_decay_sweep")
-    scheduler.add_job(_pup_snapshot_sweep, "cron", hour=23, minute=30, id="pup_snapshot_sweep")
+        async def _pup_snapshot_sweep():
+            async with AsyncSessionLocal() as session:
+                try:
+                    n = await AnalyticsService.write_all_snapshots(session)
+                    if n:
+                        logger.info("PUP snapshot wrote %d family rows", n)
+                except Exception:
+                    logger.exception("PUP snapshot sweep failed")
 
-    async def _jarvis_schedule_sweep():
-        async with AsyncSessionLocal() as session:
-            try:
-                n = await JarvisScheduleService.sweep_due(session)
-                if n:
-                    logger.info("Jarvis schedule sweep fired %d", n)
-            except Exception:
-                logger.exception("Jarvis schedule sweep failed")
-    scheduler.add_job(_jarvis_schedule_sweep, "cron", minute="*/5", id="jarvis_sched_sweep")
+        async def _jarvis_schedule_sweep():
+            async with AsyncSessionLocal() as session:
+                try:
+                    n = await JarvisScheduleService.sweep_due(session)
+                    if n:
+                        logger.info("Jarvis schedule sweep fired %d", n)
+                except Exception:
+                    logger.exception("Jarvis schedule sweep failed")
 
-    scheduler.start()
+        scheduler = AsyncIOScheduler()
+        scheduler.add_job(run_sweep, "cron", hour=3, minute=0, id="subscription_sweep")
+        scheduler.add_job(_pet_decay_sweep, "cron", hour=8, minute=0, id="pet_decay_sweep")
+        scheduler.add_job(_pup_snapshot_sweep, "cron", hour=23, minute=30, id="pup_snapshot_sweep")
+        scheduler.add_job(_jarvis_schedule_sweep, "cron", minute="*/5", id="jarvis_sched_sweep")
+        scheduler.start()
+
+        if leader_client is not None:
+            async def _renew_leadership_loop():
+                while True:
+                    await asyncio.sleep(60)
+                    await renew_scheduler_leadership(leader_client)
+
+            renew_task = asyncio.create_task(_renew_leadership_loop())
 
     yield
 
     # Shutdown
     logger.info("Shutting down API...")
-    scheduler.shutdown(wait=True)
-    overdue_task.cancel()
-    try:
-        await overdue_task
-    except asyncio.CancelledError:
-        pass
+    if scheduler is not None:
+        scheduler.shutdown(wait=True)
+    for _task in (overdue_task, renew_task):
+        if _task is not None:
+            _task.cancel()
+            try:
+                await _task
+            except asyncio.CancelledError:
+                pass
+    await release_scheduler_leadership(leader_client)
     await engine.dispose()
 
 
@@ -201,8 +226,49 @@ async def root():
 
 @app.get("/health")
 async def health_check():
-    """Health check endpoint"""
-    return {"status": "healthy", "database": "connected", "version": "1.0.0"}
+    """Liveness probe: the process is up. Cheap; does NOT touch dependencies."""
+    return {"status": "healthy", "version": settings.VERSION}
+
+
+@app.get("/ready")
+async def readiness_check():
+    """Readiness probe: can we actually serve — DB and Redis reachable?
+
+    Returns 503 (degraded) if any dependency check fails, so orchestrators and
+    uptime monitors see the truth instead of a static 'connected'.
+    """
+    from fastapi.responses import JSONResponse
+    from sqlalchemy import text
+
+    checks = {"database": "error", "redis": "error"}
+    healthy = True
+
+    try:
+        async with AsyncSessionLocal() as session:
+            await session.execute(text("SELECT 1"))
+        checks["database"] = "connected"
+    except Exception:
+        logger.exception("Readiness: database check failed")
+        healthy = False
+
+    try:
+        import redis.asyncio as aioredis
+
+        r = aioredis.from_url(settings.REDIS_URL)
+        try:
+            await r.ping()
+            checks["redis"] = "connected"
+        finally:
+            await r.aclose()
+    except Exception:
+        logger.exception("Readiness: redis check failed")
+        healthy = False
+
+    return JSONResponse(
+        status_code=200 if healthy else 503,
+        content={"status": "ready" if healthy else "degraded", **checks,
+                 "version": settings.VERSION},
+    )
 
 
 if __name__ == "__main__":

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -86,3 +86,6 @@ fastapi-cors==0.0.6
 # has roles/storage.objectAdmin on the bucket; no JSON key files needed
 # (ADC via metadata server). See gcs_receipt_service.py.
 google-cloud-storage>=2.18
+
+# Rate limiting (B1) — auth + AI endpoint abuse protection
+slowapi==0.1.9

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -290,6 +290,19 @@ async def auth_headers(client: AsyncClient, test_parent_user) -> dict:
     return {"Authorization": f"Bearer {token}"}
 
 
+@pytest.fixture(autouse=True)
+def _disable_rate_limiter():
+    """Disable the global rate limiter by default so its in-memory counters don't
+    bleed across tests. The dedicated rate-limit test re-enables it explicitly."""
+    try:
+        from app.core.rate_limiter import limiter
+        limiter.reset()
+        limiter.enabled = False
+    except Exception:
+        pass
+    yield
+
+
 @pytest_asyncio.fixture
 async def db(db_session: AsyncSession) -> AsyncSession:
     """Alias for db_session, used in budget tests."""

--- a/backend/tests/test_config_validation.py
+++ b/backend/tests/test_config_validation.py
@@ -1,0 +1,33 @@
+"""B4: production config must fail fast on insecure default secrets.
+
+A placeholder/empty SECRET_KEY means forgeable JWTs and session cookies. The app
+must refuse to boot with one when DEBUG is false, while local/dev (DEBUG=true)
+keeps working with the shipped default.
+"""
+import pytest
+from pydantic import ValidationError
+
+from app.core.config import Settings
+
+DEFAULT_KEY = "your-secret-key-change-this-in-production"
+
+
+def test_production_rejects_default_secret_key():
+    with pytest.raises(ValidationError):
+        Settings(DEBUG=False, SECRET_KEY=DEFAULT_KEY, _env_file=None)
+
+
+def test_production_rejects_empty_secret_key():
+    with pytest.raises(ValidationError):
+        Settings(DEBUG=False, SECRET_KEY="", _env_file=None)
+
+
+def test_production_allows_real_secret_key():
+    s = Settings(DEBUG=False, SECRET_KEY="x" * 40, _env_file=None)
+    assert s.SECRET_KEY == "x" * 40
+
+
+def test_debug_allows_default_secret_key():
+    # local/dev must keep working with the placeholder
+    s = Settings(DEBUG=True, SECRET_KEY=DEFAULT_KEY, _env_file=None)
+    assert s.DEBUG is True

--- a/backend/tests/test_health_readiness.py
+++ b/backend/tests/test_health_readiness.py
@@ -1,0 +1,45 @@
+"""B3: /health must not falsely claim DB connectivity; /ready does the real check.
+
+Before: GET /health returned {"database": "connected"} from a static dict without
+ever touching the database. Now /health is a cheap liveness probe (no dependency
+claims) and /ready actually pings the DB (+ Redis), returning 503 when degraded.
+"""
+import pytest
+from httpx import AsyncClient
+
+
+class TestHealthReadiness:
+    @pytest.mark.asyncio
+    async def test_health_is_liveness_only(self, client: AsyncClient):
+        r = await client.get("/health")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["status"] == "healthy"
+        # It must no longer falsely assert DB status without checking.
+        assert "database" not in body
+
+    @pytest.mark.asyncio
+    async def test_ready_actually_checks_database(self, client: AsyncClient):
+        r = await client.get("/ready")
+        # DB + Redis are up in the test environment → ready.
+        assert r.status_code == 200
+        body = r.json()
+        assert body["status"] == "ready"
+        assert body["database"] == "connected"
+
+    @pytest.mark.asyncio
+    async def test_ready_returns_503_when_db_down(self, client: AsyncClient, monkeypatch):
+        """If the DB check raises, readiness must report 503 (not a cheerful 200)."""
+        import app.main as main_mod
+
+        class _BoomSession:
+            async def __aenter__(self):
+                raise RuntimeError("db down")
+
+            async def __aexit__(self, *a):
+                return False
+
+        monkeypatch.setattr(main_mod, "AsyncSessionLocal", lambda: _BoomSession())
+        r = await client.get("/ready")
+        assert r.status_code == 503
+        assert r.json()["database"] == "error"

--- a/backend/tests/test_paypal_webhook_resilience.py
+++ b/backend/tests/test_paypal_webhook_resilience.py
@@ -1,0 +1,71 @@
+"""B6: a PayPal webhook whose state change fails must be retriable.
+
+Before: the event was marked processed in Redis BEFORE the state change, and a
+dispatch exception was swallowed into a 200. So a transient DB failure both (a)
+told PayPal "ok" (no retry) and (b) deduped any retry — the event was lost.
+Now: mark processed only AFTER a successful dispatch, and return 5xx on failure.
+"""
+import uuid
+
+import pytest
+from unittest.mock import patch
+
+from app.core.config import settings
+
+WEBHOOK_URL = "/api/subscriptions/webhook"
+VERIFY = "app.services.paypal_service.PayPalService.verify_webhook_signature"
+
+
+def _event(event_type: str, event_id: str, sub_id: str = "sub-x") -> dict:
+    return {"id": event_id, "event_type": event_type, "resource": {"id": sub_id}}
+
+
+async def _redis():
+    import redis.asyncio as aioredis
+
+    return aioredis.from_url(settings.REDIS_URL, decode_responses=True)
+
+
+class TestWebhookResilience:
+    @pytest.mark.asyncio
+    async def test_failed_apply_returns_5xx_and_is_not_marked_processed(
+        self, client, monkeypatch
+    ):
+        monkeypatch.setattr(settings, "PAYPAL_WEBHOOK_ID", "test-wh")
+        event_id = "evt-b6fail-" + uuid.uuid4().hex
+        rc = await _redis()
+        await rc.delete(f"paypal:event:{event_id}")
+
+        with patch(VERIFY, return_value=True), patch(
+            "app.api.routes.subscriptions_webhook.apply_activated",
+            side_effect=RuntimeError("transient db failure"),
+        ):
+            r = await client.post(
+                WEBHOOK_URL, json=_event("BILLING.SUBSCRIPTION.ACTIVATED", event_id)
+            )
+
+        assert r.status_code >= 500, r.text
+        marked = await rc.get(f"paypal:event:{event_id}")
+        await rc.aclose()
+        assert marked is None, "failed event must NOT be marked processed — PayPal must retry"
+
+    @pytest.mark.asyncio
+    async def test_successful_event_is_marked_and_then_deduped(self, client, monkeypatch):
+        monkeypatch.setattr(settings, "PAYPAL_WEBHOOK_ID", "test-wh")
+        event_id = "evt-b6ok-" + uuid.uuid4().hex
+        rc = await _redis()
+        await rc.delete(f"paypal:event:{event_id}")
+
+        with patch(VERIFY, return_value=True):
+            r = await client.post(
+                WEBHOOK_URL, json=_event("BILLING.SUBSCRIPTION.SUSPENDED", event_id)
+            )
+        assert r.status_code == 200, r.text
+        assert (await rc.get(f"paypal:event:{event_id}")) == "1"
+
+        with patch(VERIFY, return_value=True):
+            r2 = await client.post(
+                WEBHOOK_URL, json=_event("BILLING.SUBSCRIPTION.SUSPENDED", event_id)
+            )
+        await rc.aclose()
+        assert r2.json().get("duplicate") is True

--- a/backend/tests/test_rate_limiting.py
+++ b/backend/tests/test_rate_limiting.py
@@ -1,0 +1,41 @@
+"""B1: auth endpoints must be rate limited (brute-force / enumeration defense).
+
+Before: no endpoint had any rate limit. A burst of login attempts from one client
+must start returning 429 once the per-window limit is exceeded.
+"""
+import pytest
+
+from app.core.rate_limiter import limiter
+
+
+@pytest.fixture(autouse=True)
+def _enable_rate_limiter():
+    """This module needs the limiter ON (conftest disables it elsewhere)."""
+    limiter.reset()
+    limiter.enabled = True
+    yield
+    limiter.enabled = False
+    limiter.reset()
+
+
+class TestRateLimiting:
+    @pytest.mark.asyncio
+    async def test_login_burst_is_rate_limited(self, client):
+        statuses = []
+        for _ in range(13):
+            r = await client.post(
+                "/api/auth/login",
+                json={"email": "nobody@test.com", "password": "wrong"},
+            )
+            statuses.append(r.status_code)
+        assert 429 in statuses, f"expected a 429 once the limit is hit; got {statuses}"
+
+    @pytest.mark.asyncio
+    async def test_forgot_password_burst_is_rate_limited(self, client):
+        statuses = []
+        for _ in range(13):
+            r = await client.post(
+                "/api/auth/forgot-password", json={"email": "nobody@test.com"}
+            )
+            statuses.append(r.status_code)
+        assert 429 in statuses, f"expected a 429 once the limit is hit; got {statuses}"

--- a/backend/tests/test_scheduler_lock.py
+++ b/backend/tests/test_scheduler_lock.py
@@ -1,0 +1,51 @@
+"""B2: scheduled jobs must run on exactly ONE worker, not every uvicorn worker.
+
+The leader-election primitive backs that guarantee: the first caller acquires the
+Redis lock (becomes the scheduler leader); concurrent callers do not.
+"""
+from uuid import uuid4
+
+import pytest
+
+from app.core.config import settings
+from app.core.scheduler_lock import try_acquire_scheduler_leadership
+
+
+class TestSchedulerLeaderElection:
+    @pytest.mark.asyncio
+    async def test_only_one_worker_becomes_leader(self):
+        key = "ftm:test:leader:" + uuid4().hex
+        a_leader, a_client = await try_acquire_scheduler_leadership(
+            settings.REDIS_URL, key=key, ttl=30
+        )
+        b_leader, b_client = await try_acquire_scheduler_leadership(
+            settings.REDIS_URL, key=key, ttl=30
+        )
+        try:
+            assert a_leader is True, "first caller must win leadership"
+            assert b_leader is False, "second caller must NOT also become leader"
+        finally:
+            if a_client is not None:
+                await a_client.delete(key)
+                await a_client.aclose()
+            if b_client is not None:
+                await b_client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_leadership_frees_after_release(self):
+        key = "ftm:test:leader:" + uuid4().hex
+        first, client = await try_acquire_scheduler_leadership(
+            settings.REDIS_URL, key=key, ttl=30
+        )
+        assert first is True
+        # release
+        await client.delete(key)
+        await client.aclose()
+        # a new caller can now take leadership
+        second, client2 = await try_acquire_scheduler_leadership(
+            settings.REDIS_URL, key=key, ttl=30
+        )
+        assert second is True
+        if client2 is not None:
+            await client2.delete(key)
+            await client2.aclose()

--- a/backend/tests/test_scheduler_lock.py
+++ b/backend/tests/test_scheduler_lock.py
@@ -1,24 +1,28 @@
 """B2: scheduled jobs must run on exactly ONE worker, not every uvicorn worker.
 
 The leader-election primitive backs that guarantee: the first caller acquires the
-Redis lock (becomes the scheduler leader); concurrent callers do not.
+Redis lock (becomes the scheduler leader); concurrent callers do not. Renew/release
+are token-guarded so a worker can't refresh or delete another worker's lock.
 """
 from uuid import uuid4
 
 import pytest
 
 from app.core.config import settings
-from app.core.scheduler_lock import try_acquire_scheduler_leadership
+from app.core.scheduler_lock import (
+    try_acquire_scheduler_leadership,
+    release_scheduler_leadership,
+)
 
 
 class TestSchedulerLeaderElection:
     @pytest.mark.asyncio
     async def test_only_one_worker_becomes_leader(self):
         key = "ftm:test:leader:" + uuid4().hex
-        a_leader, a_client = await try_acquire_scheduler_leadership(
+        a_leader, a_client, a_token = await try_acquire_scheduler_leadership(
             settings.REDIS_URL, key=key, ttl=30
         )
-        b_leader, b_client = await try_acquire_scheduler_leadership(
+        b_leader, b_client, b_token = await try_acquire_scheduler_leadership(
             settings.REDIS_URL, key=key, ttl=30
         )
         try:
@@ -34,18 +38,39 @@ class TestSchedulerLeaderElection:
     @pytest.mark.asyncio
     async def test_leadership_frees_after_release(self):
         key = "ftm:test:leader:" + uuid4().hex
-        first, client = await try_acquire_scheduler_leadership(
+        first, client, token = await try_acquire_scheduler_leadership(
             settings.REDIS_URL, key=key, ttl=30
         )
         assert first is True
-        # release
-        await client.delete(key)
-        await client.aclose()
+        await release_scheduler_leadership(client, token, key=key)
         # a new caller can now take leadership
-        second, client2 = await try_acquire_scheduler_leadership(
+        second, client2, token2 = await try_acquire_scheduler_leadership(
             settings.REDIS_URL, key=key, ttl=30
         )
         assert second is True
         if client2 is not None:
             await client2.delete(key)
             await client2.aclose()
+
+    @pytest.mark.asyncio
+    async def test_release_with_wrong_token_does_not_delete_lock(self):
+        """A worker that no longer holds the lock must not be able to delete it."""
+        import redis.asyncio as aioredis
+
+        key = "ftm:test:leader:" + uuid4().hex
+        leader, client, token = await try_acquire_scheduler_leadership(
+            settings.REDIS_URL, key=key, ttl=30
+        )
+        assert leader is True
+
+        # An impostor with the wrong token must NOT delete our lock.
+        impostor = aioredis.from_url(settings.REDIS_URL)
+        await release_scheduler_leadership(impostor, "impostor:999", key=key)
+        assert (await client.get(key)) is not None, "wrong-token release deleted the lock"
+
+        # Our own (correct-token) release clears it.
+        await release_scheduler_leadership(client, token, key=key)
+        check = aioredis.from_url(settings.REDIS_URL)
+        leftover = await check.get(key)
+        await check.aclose()
+        assert leftover is None

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,7 +101,10 @@ services:
       TEST_DATABASE_URL: postgresql+asyncpg://familyapp_test:familyapp_test123@test_db:5432/familyapp_test
       REDIS_URL: redis://redis:6379/0
       ALLOWED_ORIGINS: http://localhost:3003,http://localhost:8000,https://family.agent-ia.mx
-      DEBUG: ${DEBUG:-false}
+      # Local dev defaults to DEBUG=true so a fresh `compose up` (no .env) boots
+      # without tripping the production SECRET_KEY validator. Prod uses
+      # docker-compose.gcp.yml which sets DEBUG=false explicitly + a real key.
+      DEBUG: ${DEBUG:-true}
     ports:
        # Host port is configurable so a deployment can avoid collisions with
        # other services on the same host. Defaults to 8003 to match local-dev

--- a/docs/audit/2026-06-04/08-trackB-specs.md
+++ b/docs/audit/2026-06-04/08-trackB-specs.md
@@ -1,0 +1,528 @@
+# Track B — scoped specs (workflow wefc76sbx)
+
+## B1: Rate Limiting on Auth & AI Endpoints
+
+**Current:** No rate limiting exists on any endpoint. Auth endpoints (login, register-family, check-methods, forgot-password, reset-password, verify-email, resend-verification) at backend/app/api/routes/auth.py:40-352 and AI scan endpoints (scan-receipt at backend/app/api/routes/budget/transactions.py:513-597, scan-document at backend/app/api/routes/calendar.py:189-230, jarvis chat at backend/app/api/routes/jarvis.py:46-87) are all unauthenticated or require_parent_role but have no rate limiting. OAuth endpoints at backend/app/api/routes/oauth.py:28-77 are also unprotected. Middleware setup in backend/app/main.py:121-140 has CORS + SessionMiddleware but no rate limiting. Redis is already configured (backend/app/core/config.py:148) and used for webhook deduping and model settings.
+
+**Fix:** Implement Redis-backed rate limiting via slowapi (FastAPI-native rate limiting library backed by Redis). Recommended approach: 
+1. Install slowapi (pip dependency)
+2. Create backend/app/core/rate_limiter.py with:
+   - RedisLimiter instance using settings.REDIS_URL
+   - Factory function to build limiter keys by IP + endpoint path
+   - Configurable per-endpoint limits (e.g., 5 reqs/min for auth, 10 reqs/min for AI)
+3. Wire limiter into backend/app/main.py:120 via app.state.limiter = limiter + register Limiter.get_response as error handler (429 status)
+4. Apply @limiter.limit decorators to auth routes (login, register, register-family, check-methods, forgot-password, reset-password, verify-email, resend-verification), OAuth routes (google, google/verify), and AI scan routes (scan-receipt, scan-document, /jarvis/chat, /jarvis/chat-stream)
+5. For per-user rate limiting on authenticated endpoints, override the key_func to use family_id from JWT instead of IP address
+
+Alternative (if slowapi + Redis has issues): use starlette-rate-limit with aioredis directly for finer control.
+
+Limits recommended:
+- Public auth (login, register-family, check-methods, forgot-password, reset-password): 10 requests/5 minutes per IP
+- Email verification (verify-email, resend-verification): 5 requests/5 minutes per IP
+- OAuth (google, google/verify): 10 requests/5 minutes per IP
+- AI endpoints (scan-receipt, scan-document): 30 requests/hour per family_id (authenticated)
+- Jarvis chat endpoints (chat, chat-stream): 100 requests/day per family_id (per config JARVIS_DAILY_MESSAGE_CAP already exists; add per-minute throttle of 10 msgs/min to prevent rapid spam)
+
+Handler: Return 429 Too Soon with JSON response {"detail": "Rate limit exceeded. Please try again in X seconds.", "retry_after": X}
+
+**Files:** /Volumes/shared/AgentIA/family-task-manager/backend/requirements.txt, /Volumes/shared/AgentIA/family-task-manager/backend/app/main.py, /Volumes/shared/AgentIA/family-task-manager/backend/app/core/config.py, /Volumes/shared/AgentIA/family-task-manager/backend/app/core/rate_limiter.py (NEW), /Volumes/shared/AgentIA/family-task-manager/backend/app/api/routes/auth.py, /Volumes/shared/AgentIA/family-task-manager/backend/app/api/routes/oauth.py, /Volumes/shared/AgentIA/family-task-manager/backend/app/api/routes/budget/transactions.py, /Volumes/shared/AgentIA/family-task-manager/backend/app/api/routes/calendar.py, /Volumes/shared/AgentIA/family-task-manager/backend/app/api/routes/jarvis.py, /Volumes/shared/AgentIA/family-task-manager/backend/tests/test_rate_limiting.py (NEW)
+
+**New deps:** slowapi==0.1.9
+
+**Test plan:** RED (fails without rate limiting):
+1. test_auth_login_rate_limit: POST /api/auth/login 11x in 5 min; expect 1-10 to succeed (200), 11+ to fail (429)
+2. test_register_family_rate_limit: POST /api/auth/register-family 11x in 5 min from same IP; expect 11th+ to fail (429)
+3. test_scan_receipt_rate_limit: POST /api/budget/transactions/scan-receipt 31x in 1 hour under same family_id; expect 1-30 to succeed (201/200), 31+ to fail (429)
+4. test_jarvis_chat_per_minute_limit: POST /api/jarvis/chat 11x in 1 minute; expect 11+ to fail (429)
+5. test_jarvis_daily_cap: POST /api/jarvis/chat 101x over a day (interleaved with sleep); expect 1-100 to succeed, 101 to fail (429 or existing daily cap logic)
+
+GREEN (passes with rate limiting):
+1. Same tests verify 429 responses include retry_after header and detail JSON
+2. test_rate_limit_key_by_ip: Two IPs calling login simultaneously should each get their own quota
+3. test_rate_limit_key_by_family: Two families calling scan-receipt simultaneously should each get their own quota
+4. test_rate_limit_window_reset: After 5 min window passes, login quota resets (can make 10 more reqs)
+
+Hard to test: Redis unavailability fallback (would need to mock Redis failure). Recommended: log warning but allow request to proceed (fail open) to avoid outage.
+
+**Risk:** SHARED FILES with other items:
+- backend/app/main.py: also touched by B2 (CSRF), B3 (HSTS), B4 (HTTPS redirect). Middleware order matters: add rate limiter BEFORE CORS/session so all paths are protected. Risk: if rate limiter is added after session, it won't rate limit session-free requests (OAuth, public auth).
+- backend/app/core/config.py: already has REDIS_URL setting, no conflict.
+
+PRODUCTION RISKS:
+1. Redis unavailability: if Redis is down, slowapi will error on key increment. Mitigation: wrap limiter in try-catch that logs and allows request (fail open). Document this trade-off.
+2. Distributed deployments: if multiple API instances run, each will check Redis independently (correct behavior), but IP-based rate limiting may be inaccurate if behind a load balancer without X-Forwarded-For header. Mitigation: trust_proxy config or override key_func to extract real IP from X-Forwarded-For.
+3. User enumeration on forgot-password: rate limiting per IP helps, but still allows basic enumeration across IPs. Current design already returns same response regardless of email existence (backend/app/api/routes/auth.py:321-329), so rate limiting just adds latency, not privacy.
+4. JARVIS_DAILY_MESSAGE_CAP already exists in config: new per-minute rate limiter is additional layer, not conflicting.
+
+DEPENDENCIES:
+- slowapi package (PyPI: slowapi 0.1.9+) supports redis:// URLs directly. No incompatibilities with FastAPI 0.109.0 or SQLAlchemy 2.0.25.
+- Redis must be accessible at settings.REDIS_URL (already required for other features). No extra infrastructure needed.
+
+**Config/env:** No new env vars needed. Existing REDIS_URL in backend/app/core/config.py:148 is reused. Optional config additions to settings:
+- RATE_LIMIT_ENABLED: bool = True (default) — kill switch for rate limiting
+- RATE_LIMIT_AUTH_PER_MINUTE: int = 10 (for "10 per 5 min" convert to per-minute: ~2)
+- RATE_LIMIT_AI_PER_HOUR: int = 30
+- RATE_LIMIT_JARVIS_PER_MINUTE: int = 10
+
+Alternatively, hardcode limits in backend/app/core/rate_limiter.py as module constants with comments for easy tweaking.
+
+If Redis is unavailable (local dev without Redis), slowapi can fall back to in-memory storage (memory://) but this won't work across multiple processes. Recommend: in dev, set REDIS_URL="" to use memory storage; tests mock Redis via conftest.py.
+
+
+---
+
+## B2: APScheduler jobs + overdue-sweep run in EVERY uvicorn worker
+
+**Current:** backend/app/main.py lines 81-96: AsyncIOScheduler initialized in lifespan startup, which runs in every uvicorn worker process. Four jobs scheduled: subscription_sweep (3:00 UTC daily), pet_decay_sweep (8:00 UTC daily), pup_snapshot_sweep (23:30 UTC daily), jarvis_sched_sweep (every 5 mins). Additionally, _overdue_sweep_loop() (lines 31-45) fires every 60 minutes via asyncio.create_task(). docker-compose.gcp.yml line 102 specifies --workers 2, so all 4 jobs + overdue_sweep execute 2x simultaneously. Subscription_sweep is a separate async function (backend/app/jobs/subscription_sweep.py) that downgrades expired subs, but Jarvis/pet/PUP snapshots are inline lambdas. No distributed locking present; Redis is available (config.py line 148 REDIS_URL) and used for FX caching (fx_service.py) but not leveraged for job coordination.
+
+**Fix:** Implement single-runner gate using Redis SETNX-based distributed lock to ensure scheduler and overdue_sweep run only once per cluster. Create app/core/scheduler_lock.py with RedisLeaderLock class using redis.asyncio. Modify lifespan() in main.py to: (1) Acquire leader lock on startup with TTL=120s and periodic renewal; (2) Initialize scheduler/overdue_sweep only if lock acquired; (3) Release lock on shutdown. Lock key: "ftm:scheduler:leader" (settable via env). Non-leader workers log that they skipped job init. Add SCHEDULER_LOCK_ENABLED env var (default True) to allow opt-out. For overdue_sweep specifically, wrap the loop check in the same lock context. Alternative: split scheduler into dedicated sidecar process (set env flag SKIP_SCHEDULER=True for worker processes).
+
+**Files:** backend/app/core/scheduler_lock.py, backend/app/main.py, backend/app/core/config.py, docker-compose.gcp.yml, .env.gcp.example
+
+**New deps:** 
+
+**Test plan:** RED (unit): Mock Redis client, verify SETNX succeeds only for one concurrent lock attempt; verify TTL set; verify non-leader path skips scheduler init. GREEN: Acquire lock, confirm scheduler/overdue_sweep started; release lock, confirm tasks cleaned up. Concurrency: Simulate 2+ uvicorn workers starting simultaneously—only one should acquire lock, others log skip. TTL renewal: Mock time passage, verify lock renewed before TTL expiry. Integration (manual): docker-compose up with --workers 3, inspect logs for "[LEADER]" vs "[FOLLOWER]" messages; verify cron jobs fire once per interval not 3x. Hard parts: timing the TTL renewal test without blocking; ensuring Redis connection reuse (use fx_service.py pattern).
+
+**Risk:** CONFLICTS: B1 (startup routines) and B7 (Redis connection) both touch config.py + require working Redis. If Redis is down on startup, lock acquisition fails and scheduler doesn't run—need graceful fallback (log warning, continue without scheduler, or raise only if SCHEDULER_LOCK_ENABLED=True). APScheduler holds references to jobs in memory—if lock holder dies abruptly, jobs orphan until TTL expires (120s is reasonable). Existing code paths that call TaskAssignmentService.mark_overdue_all() directly (e.g. /api/task-assignments/check-overdue endpoint) are unaffected; distributed lock only gates the periodic background sweep. No other code besides main.py touches scheduler, so risk of unintended side-effects is low. Prod: confirm REDIS_URL + Redis health on startup; test lock failure scenarios (Redis down, network partition).
+
+**Config/env:** SCHEDULER_LOCK_ENABLED=True (default) — set False to disable lock and run scheduler in every worker (unsafe but useful for single-worker dev). SCHEDULER_LOCK_KEY="ftm:scheduler:leader" — Redis key name. SCHEDULER_LOCK_TTL=120 — lock hold time in seconds; renewal happens every TTL/2. Falls back to no-lock behavior if Redis unavailable and SCHEDULER_LOCK_ENABLED=False.
+
+
+---
+
+## B3: Health check endpoints (/health + /ready) with actual DB/Redis pings
+
+**Current:** backend/app/main.py:202-205 — the /health endpoint returns a static dict without touching any infrastructure:
+```python
+@app.get("/health")
+async def health_check():
+    """Health check endpoint"""
+    return {"status": "healthy", "database": "connected", "version": "1.0.0"}
+```
+
+This hardcoded response violates liveness vs readiness semantics:
+- Kubernetes expects /health (liveness probe) to fail only if the process should be restarted (DB unreachable is NOT a restart reason)
+- Kubernetes expects /ready (readiness probe) to fail if the service cannot handle requests (DB unreachable = unready)
+- Currently both return "healthy" regardless of actual DB/Redis connectivity
+
+**Fix:** Create two endpoints in backend/app/main.py:
+
+1. **GET /health** (liveness) — fast, returns 200 if process is running. Logs only startup/fatal errors. DB/Redis unavailable does NOT cause 503.
+   ```python
+   @app.get("/health")
+   async def health_check():
+       """Liveness probe: returns 200 if process is alive."""
+       return {"status": "alive", "version": "1.0.0"}
+   ```
+
+2. **GET /ready** (readiness) — actually pings DB + Redis, returns 503 if either fails. This is the health check the app depends on for traffic/scheduling decisions.
+   ```python
+   @app.get("/ready")
+   async def readiness_check():
+       """Readiness probe: returns 200 only if all critical services are responding."""
+       checks = {}
+       status_code = 200
+       
+       # Ping database with SELECT 1
+       try:
+           async with AsyncSessionLocal() as session:
+               await session.execute(text("SELECT 1"))
+               checks["database"] = "connected"
+       except Exception as e:
+           checks["database"] = f"error: {type(e).__name__}"
+           status_code = 503
+       
+       # Ping Redis (requires singleton in app.core.redis)
+       try:
+           redis = await get_redis_client()
+           await redis.ping()
+           checks["redis"] = "connected"
+       except Exception as e:
+           checks["redis"] = f"error: {type(e).__name__}"
+           status_code = 503
+       
+       response_dict = {"status": "ready" if status_code == 200 else "degraded", "checks": checks, "version": "1.0.0"}
+       
+       if status_code != 200:
+           raise HTTPException(status_code=status_code, detail=response_dict)
+       return response_dict
+   ```
+
+Support code needed:
+- **backend/app/core/redis.py** (new file): Redis client singleton + get_redis_client() factory matching fx_service.py pattern (handles event loop rebinding for tests)
+- **backend/app/main.py imports**: Add `from sqlalchemy import text` and `from fastapi import HTTPException`
+- Update existing /health if called by external monitoring (fallback to /ready-style logic with timeout=2s on DB ping)
+
+**Files:** /Volumes/shared/AgentIA/family-task-manager/backend/app/main.py, /Volumes/shared/AgentIA/family-task-manager/backend/app/core/redis.py
+
+**New deps:** 
+
+**Test plan:** **RED test** (test_health_endpoints.py):
+1. `/health` always returns 200 + "alive" status
+2. `/ready` returns 200 + "connected" when DB/Redis are up
+3. `/ready` returns 503 when DB query fails (mock engine.execute to raise)
+4. `/ready` returns 503 when Redis.ping() fails (mock redis client to raise)
+5. `/ready` returns degraded checks dict with error messages
+6. Response times: /health <10ms (no I/O), /ready <200ms (with DB ping)
+
+**Implementation note**: Use `unittest.mock.AsyncMock` + `@pytest.mark.asyncio` + fixtures from conftest.py (client: AsyncClient). Mock SQLAlchemy's `execute()` at the service layer, not the connection pool.
+
+**Hard to test**: Redis singleton's event-loop rebinding requires pytest's function-scoped loop — test in isolation (fx_service.py already has a parallel pattern to verify against).
+
+**Integration test** (optional): Start Docker containers for postgres + redis, hit /ready, verify both connected; kill postgres, hit /ready, verify 503 + error msg.
+
+**Risk:** **Production risk**: 
+- If /ready endpoint is slow (DB timeout), load balancers may take 30s to mark unhealthy. Add configurable timeout (default 5s) via settings.HEALTH_CHECK_TIMEOUT.
+- Redis optional per config comment (REDIS_URL may point nowhere in dev) — /ready should only require Redis if explicitly configured (or gracefully degrade if Redis is optional).
+- Breaking change for external monitoring: if GCP/k8s health checks currently call /health, they must be updated to /ready. Recommend keeping /health as-is for backward compatibility, add /ready as new.
+
+**Shared files conflict**: backend/app/main.py touched by B1 (root endpoint), B3 (health), and possibly B5 (metrics). Coordinate with other B-items using same file. frontend/app/main.py is NOT touched (this is backend only).
+
+**Dependencies**: Requires `sqlalchemy.text` (already in engine module), `redis.asyncio` (already imported in fx_service, subscriptions_webhook). No new pip packages.
+
+**Config/env:** Optional settings in backend/app/core/config.py:
+```python
+HEALTH_CHECK_DB_TIMEOUT: float = 5.0  # seconds for SELECT 1 query
+HEALTH_CHECK_REDIS_TIMEOUT: float = 2.0  # seconds for PING
+REDIS_OPTIONAL: bool = False  # if True, /ready doesn't fail on Redis error
+```
+
+Production .env should set HEALTH_CHECK_DB_TIMEOUT=5 (k8s probes timeout at 10s, needs margin for retry).
+
+
+---
+
+## B4: No startup validation of critical secrets — app boots with default/placeholder SECRET_KEY (forgeable JWTs)
+
+**Current:** backend/app/core/config.py:28 defines SECRET_KEY with a placeholder default: `SECRET_KEY: str = "your-secret-key-change-this-in-production"`. No validators exist; the Settings object instantiates (line 200) without checking if SECRET_KEY is still the default or if critical env vars (DATABASE_URL, PAYPAL_CLIENT_ID, etc.) are empty/missing in production. The app starts normally and uses this forgeable key in JWT token signing (backend/app/core/security.py:41, line 49) and session middleware (backend/app/main.py:135). Currently, only DEBUG mode is defined (config.py:19, defaults to True); there is no ENVIRONMENT or PROD flag to trigger strict validation.
+
+**Fix:** Add a model_validator to Settings (pydantic v2 pattern) that detects production mode (via a new ENV or ENVIRONMENT variable, or by checking DEBUG=False) and raises a clear validation error if SECRET_KEY is the placeholder, DATABASE_URL is default/missing, or other critical secrets (PAYPAL_CLIENT_ID, ANTHROPIC_API_KEY, LITELLM_API_KEY where applicable) are empty. The validator should run at model instantiation (before settings = Settings() on line 200 completes) so the app fails immediately on boot with a helpful message listing which secrets are misconfigured. Pattern: use @model_validator(mode='after') to inspect self.DEBUG or os.environ.get('ENVIRONMENT') == 'production' and raise ValueError with a detailed message.
+
+**Files:** /Volumes/shared/AgentIA/family-task-manager/backend/app/core/config.py
+
+**New deps:** 
+
+**Test plan:** RED test: instantiate Settings with ENVIRONMENT=production and SECRET_KEY at its default, expect ValidationError with message naming 'SECRET_KEY'. Verify DATABASE_URL='' (empty) also triggers the error in prod. GREEN test: instantiate Settings with ENVIRONMENT=production, SECRET_KEY='custom-prod-key-...', DATABASE_URL='postgresql://...', expect success. Verify dev (ENVIRONMENT=development or DEBUG=True) does NOT validate (allows placeholder). This is unit-testable by creating settings with monkeypatched os.environ; reference backend/tests/test_vault_bootstrap.py (line 114-142) as a pattern for env mocking.
+
+**Risk:** config.py is shared with B1 (rate limiting), B3 (health check), B5 (logging/Sentry), B6 (PayPal webhook), B7 (httpx async) — these items may add ENV/DEBUG/mode detection or validators. **Conflict mitigation:** (1) use a distinct ENVIRONMENT env var (not DEBUG, which may be touched by others) so validators don't interfere; (2) keep the validator focused on ONLY secret-checking (don't validate other settings like ALLOWED_ORIGINS/GOOGLE_CLIENT_IDS which have existing validators); (3) document the validator's purpose in a comment so sibling changes don't accidentally remove/weaken it. Startup will be slightly slower (~microseconds for one model_validator call) but only once at boot.
+
+**Config/env:** Add ENVIRONMENT env var (default='development'). In production, set ENVIRONMENT=production. Alternatively, can infer from DEBUG=False, but using explicit ENVIRONMENT is clearer. No new .env entries needed — existing .env in dev has all defaults; prod will provide real SECRET_KEY, DATABASE_URL, etc. before boot.
+
+
+---
+
+## B5: No error tracking (Sentry) and no structured/JSON logging
+
+**Current:** backend/app/main.py (lines 24-28): uses standard `logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")` — produces plain-text logs only. backend/app/core/config.py (line 174): declares `LOG_LEVEL: str = "INFO"` but main.py hardcodes `logging.INFO` with no reference to `settings.LOG_LEVEL`. backend/app/core/exception_handlers.py (lines 102-110): registers handlers for only 7 domain exceptions; no catch-all `@app.exception_handler(Exception)` exists, so unhandled errors return bare Starlette 500 with no context capture. backend/requirements.txt: no sentry-sdk, structlog, or python-json-logger. .env.gcp.example (line 12): sets LOG_LEVEL=INFO as a placeholder with no enforcement. No request-id / access-log middleware. No Sentry DSN configuration or initialization.
+
+**Fix:** 1. **Add dependencies to backend/requirements.txt**: Add `sentry-sdk[fastapi]==2.22.0` and `python-json-logger==3.2.0` (or structlog==24.4.0 if structlog preferred; python-json-logger is simpler for drop-in replacement).
+
+2. **Create backend/app/core/logging.py** — new logging configuration module:
+   - Function `setup_logging(level: str, is_json: bool) -> None` that reconfigures Python's root logger
+   - When `is_json=True`, attach a JSON formatter (`pythonjsonlogger.jsonlogger.JsonFormatter`) that emits `{"timestamp", "level", "logger", "message", "exc_info", ...}`
+   - When `is_json=False`, use plain-text (default)
+   - Respects `settings.LOG_LEVEL` (from env or config.py default)
+   - Initialize root logger + FastAPI logger (name="uvicorn.*")
+
+3. **Modify backend/app/main.py**:
+   - Replace lines 24-28 logging.basicConfig with: `from app.core.logging import setup_logging; setup_logging(settings.LOG_LEVEL, is_json=settings.JSON_LOGGING_ENABLED)` (call after settings imported, before app creation)
+   - Add Sentry initialization after logging setup (if `settings.SENTRY_DSN`):
+     ```python
+     import sentry_sdk
+     from sentry_sdk.integrations.fastapi import FastApiIntegration
+     from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
+     
+     if settings.SENTRY_DSN:
+         sentry_sdk.init(
+             dsn=settings.SENTRY_DSN,
+             integrations=[
+                 FastApiIntegration(),
+                 SqlalchemyIntegration(),
+             ],
+             environment=settings.ENVIRONMENT,
+             debug=settings.DEBUG,
+             traces_sample_rate=0.1 if not settings.DEBUG else 1.0,
+         )
+         logger.info("Sentry initialized with DSN %s", settings.SENTRY_DSN[:20] + "...")
+     ```
+   - Add catch-all exception handler at end (before `if __name__ == "__main__"`):
+     ```python
+     @app.exception_handler(Exception)
+     async def global_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+         logger.exception("Unhandled exception in %s %s", request.method, request.url.path)
+         return JSONResponse(
+             status_code=500,
+             content={"error": "internal_server_error", "message": "An unexpected error occurred"}
+         )
+     ```
+
+4. **Add config.py settings** (backend/app/core/config.py):
+   - `SENTRY_DSN: str = ""` (optional, no-op if empty)
+   - `ENVIRONMENT: str = "development"` (for Sentry environment tag; also used in sentry_sdk.init)
+   - `JSON_LOGGING_ENABLED: bool = False` (opt-in, default off for local dev; set via env `JSON_LOGGING_ENABLED=true` in prod)
+
+5. **Update .env.gcp.example**:
+   - Add lines after `LOG_LEVEL=INFO`:
+     ```
+     JSON_LOGGING_ENABLED=true
+     SENTRY_DSN=https://your-sentry-key@sentry.io/your-project-id
+     ENVIRONMENT=production
+     ```
+   - Update ENVIRONMENT placeholder to match current deploy env
+
+6. **Light test**: backend/tests/test_logging.py or conftest.py addition:
+   - Assert `settings.SENTRY_DSN` can be set/unset without crashing app startup
+   - Assert logger is configured (check `logging.root.handlers` has a handler)
+   - Assert JSON output when enabled: `JSON_LOGGING_ENABLED=true` → logger emits valid JSON lines
+   - Optional: mock Sentry and assert `sentry_sdk.init` is called when DSN is set
+
+**Files:** backend/app/main.py, backend/app/core/config.py, backend/app/core/logging.py, backend/requirements.txt, .env.gcp.example
+
+**New deps:** 
+
+**Test plan:** 
+**RED tests (before implementation):**
+1. `test_sentry_init_guarded_on_dsn`: Run app startup with and without SENTRY_DSN env set; verify no error either way
+2. `test_json_logging_enabled`: Set JSON_LOGGING_ENABLED=true, capture logger output, assert it's valid JSON with keys: timestamp, level, message, logger
+3. `test_plaintext_logging_default`: Run app with JSON_LOGGING_ENABLED unset (default false), capture logger output, assert it's plain-text format (not JSON)
+4. `test_log_level_respected`: Set LOG_LEVEL=DEBUG via env, assert logger.getEffectiveLevel() == logging.DEBUG (not hardcoded INFO)
+5. `test_unhandled_exception_caught`: Mock a route that raises uncaught Exception, assert (a) status_code=500, (b) response JSON has keys "error" and "message", (c) exception is logged with logger.exception()
+
+**GREEN proofs (after implementation):**
+- All 5 tests pass
+- Manual: `SENTRY_DSN="" python -m pytest ...` → app boots, no errors
+- Manual: `JSON_LOGGING_ENABLED=true python -m pytest ...` → logs contain `{"timestamp": "...", "level": "INFO", "message": ...}`
+- Manual: Unhandled route error (e.g., `1/0`) returns 500 with `{"error": "internal_server_error", ...}` and is captured in sentry.log if DSN set
+- Manual: config.py Settings() can be instantiated with `SENTRY_DSN=""` (no-op), `SENTRY_DSN="https://..."` (valid DSN), and any LOG_LEVEL (DEBUG, INFO, WARNING, ERROR)
+
+**Testing difficulty**: Sentry mocking is straightforward (mock `sentry_sdk.init`). JSON logger validation requires capturing stderr/stdout or monkeypatching handlers. Logger level checking is simple (read logging.root.getEffectiveLevel()). Overall: Easy to medium.
+
+
+**Risk:** 
+**Prod risk**: LOW. Both Sentry and JSON logging are completely opt-in via environment variables (SENTRY_DSN empty by default, JSON_LOGGING_ENABLED=false by default). Local dev unaffected. No breaking changes to existing exception handlers (new catch-all is a supplement). JSON formatter is a pure logging-layer change, doesn't affect API contracts or database. Sentry library integrations (FastApiIntegration, SqlalchemyIntegration) are passive observers, zero side effects.
+
+**File conflicts with sibling items**:
+- **backend/app/main.py** (lines 1-30): Item B5 modifies logging setup. No other items in Track B touch main.py lines 1-30 per the audit. Item A1 (security fix) also touches main.py but at line 147 (StaticFiles mount) and context is separate.
+- **backend/app/core/config.py**: Item B5 adds 3 new settings (SENTRY_DSN, ENVIRONMENT, JSON_LOGGING_ENABLED). Item B6 (hardcoded SECRET_KEY validation) also touches config.py. Item B7 (LOG_LEVEL env not used) also touches config.py. No overlaps if B6/B7 handle their own settings additions without duplicating these 3.
+- **backend/requirements.txt**: Item B5 adds 2 packages (sentry-sdk[fastapi], python-json-logger). Item B1 (remove aioredis) also touches requirements. Item B2 (split requirements-dev.txt) also touches requirements. No conflicts if each item adds/removes its own lines without duplicating.
+
+**Integration notes**: If B6 adds validation for SECRET_KEY, B5's ENVIRONMENT setting will coexist naturally (both simple string fields). If B7 fixes LOG_LEVEL usage, B5's `setup_logging(settings.LOG_LEVEL, ...)` call will work correctly. If B2 creates requirements-dev.txt, sentry-sdk + python-json-logger stay in prod requirements.txt (both are runtime deps, not dev-only).
+</risk>
+<parameter name="config_or_env">
+**New environment variables** (add to .env.gcp.example and prod Vault):
+- `SENTRY_DSN=""` (empty by default, opt-in via Vault / deploy .env)
+- `ENVIRONMENT="development"` (local) or `"production"` (GCP). Sent as Sentry context tag. Replaces any hardcoded env strings.
+- `JSON_LOGGING_ENABLED=false` (default) or `true` (GCP). When true, all logs emit as JSON lines for GCP Cloud Logging to parse and index.
+
+**Config.py changes** (add to Settings class, lines ~173-176):
+```python
+SENTRY_DSN: str = ""  # optional; no-op if empty
+ENVIRONMENT: str = "development"  # "production" in GCP
+JSON_LOGGING_ENABLED: bool = False  # opt-in per env
+```
+
+**Impact on .env.gcp.example**:
+- Add post-LOG_LEVEL block (after line 12):
+  ```
+  JSON_LOGGING_ENABLED=true
+  SENTRY_DSN=https://your-sentry-key@sentry.io/your-project-id
+  ENVIRONMENT=production
+  ```
+  - Deployer must fill in real SENTRY_DSN from Sentry.io project setup (or leave empty if not using Sentry yet)
+
+**No changes to existing local .env** (logging defaults to plaintext + no Sentry, development mode). Backward-compatible.
+</config_or_env>
+<parameter name="new_deps">
+["sentry-sdk[fastapi]==2.22.0", "python-json-logger==3.2.0"]
+
+
+**Config/env:** 
+
+
+---
+
+## B6: PayPal webhook drops subscription state-change events permanently on transient DB failure
+
+**Current:** backend/app/api/routes/subscriptions_webhook.py:receive_webhook() marks event as processed in Redis BEFORE the subscription state change commits to the database:
+
+1. Line 102: `proceed = await _dedupe_event(event_id)` — Redis SET with NX flag succeeds, event marked processed
+2. Lines 112-131: `apply_activated/cancelled/payment_failed(db, ...)` called
+3. Each apply_* function in backend/app/services/subscription_state.py (lines 50, 67, 84) calls `await db.commit()` within their own session
+4. If any exception occurs during apply_* (network timeout, DB constraint violation, connection pool exhaustion), the exception is caught at line 134-135
+5. Handler returns 200 anyway (line 137), triggering get_db() finally block which executes rollback()
+6. Result: Redis key exists (event marked processed), but subscription state change was rolled back — event lost forever because PayPal won't retry (thinks it's processed) and DB never committed the change
+
+**Fix:** Reorder the dedupe and state-change commit to ensure atomicity and returnability:
+
+CHANGE: Move dedupe check AFTER successful state change, and return 5xx on any apply_* failure so PayPal retries:
+
+In backend/app/api/routes/subscriptions_webhook.py:receive_webhook():
+  1. Keep signature verification (lines 84-98)
+  2. REMOVE early _dedupe_event call (currently lines 101-105)
+  3. Try apply_activated/cancelled/payment_failed (lines 112-131)
+  4. On SUCCESS: THEN mark event in Redis (dedupe after commit)
+  5. On FAILURE: Return 500 (not 200) so PayPal retries — do NOT catch exception or return 200
+
+LOGIC:
+  - Try apply_* function which internally calls db.commit()
+  - If commit succeeds, ONLY THEN check/mark Redis dedupe
+  - If anything fails (apply_*, or Redis dedupe after successful DB commit), return 5xx
+  - PayPal's retry logic handles transient failures by re-sending
+  - apply_* functions already implement idempotency (check state before mutating)
+
+CODE STRUCTURE:
+```python
+# Verify signature (keep as-is, lines 84-98)
+
+# REMOVE lines 101-105 (early dedupe check)
+
+# Dispatch event handler
+try:
+    if event_type == "BILLING.SUBSCRIPTION.ACTIVATED":
+        # ... extract period_end (lines 113-120)
+        await apply_activated(...)
+    elif event_type == "BILLING.SUBSCRIPTION.CANCELLED":
+        await apply_cancelled(...)
+    elif event_type == "BILLING.SUBSCRIPTION.PAYMENT.FAILED":
+        await apply_payment_failed(...)
+    else:
+        logger.info("Ignoring webhook event_type %s", event_type)
+        return {"received": True}
+    
+    # State change committed. NOW mark event processed.
+    if event_id:
+        try:
+            await _mark_event_processed(event_id)  # Mark AFTER state commit
+        except Exception as e:
+            logger.error("Failed to mark event processed (will retry): %s", e)
+            # Still return 5xx so PayPal retries; idempotent apply_* already happened
+            raise
+    
+    return {"received": True}
+    
+except Exception as e:
+    logger.exception("Webhook dispatch failed for %s: %s", event_id, e)
+    # Return 500 to trigger PayPal retry — event not marked processed
+    raise HTTPException(status_code=500, detail="Event processing failed")
+```
+
+Introduce new helper:
+```python
+async def _mark_event_processed(event_id: str) -> None:
+    """Mark event as processed in Redis. Raises on failure (caller decides 5xx response)."""
+    import redis.asyncio as aioredis
+    
+    client = aioredis.from_url(settings.REDIS_URL, decode_responses=True)
+    try:
+        result = await client.set(
+            f"paypal:event:{event_id}",
+            "1",
+            ex=EVENT_TTL_SECONDS,
+            nx=True,
+        )
+        if not result:
+            # Duplicate event (already processed)
+            logger.info("Event %s already processed", event_id)
+    finally:
+        await client.close()
+```
+
+Delete _dedupe_event helper entirely (no longer used).
+
+**Files:** backend/app/api/routes/subscriptions_webhook.py
+
+**New deps:** 
+
+**Test plan:** TDD Red-Green approach:
+
+RED TEST 1: Simulate DB failure during apply_* (e.g., connection pool exhaustion, constraint violation)
+  - Mock apply_cancelled to raise IntegrityError mid-handler
+  - POST webhook event
+  - Assert: HTTP 500 returned (not 200)
+  - Assert: Event NOT marked in Redis (dedupe check returns False on next attempt)
+  - Assert: Subscription state unchanged in DB (rolled back)
+  - Assertion: Event is retriable — next POST with same event_id will attempt again
+
+RED TEST 2: Simulate Redis failure AFTER successful DB commit
+  - Mock apply_activated to succeed
+  - Mock _mark_event_processed to raise ConnectionError
+  - POST webhook event
+  - Assert: HTTP 500 returned
+  - Assert: Subscription state IS changed in DB (commit happened before Redis call)
+  - Assert: Event NOT in Redis (mark failed)
+  - Assertion: On retry, apply_activated is called again but idempotent (sees status already "active", returns early)
+  - Assertion: Redis mark succeeds on second retry
+
+RED TEST 3: Normal success path
+  - Mock apply_cancelled to succeed
+  - POST webhook event  
+  - Assert: HTTP 200 returned
+  - Assert: Subscription state changed (cancel_at_period_end=True)
+  - Assert: Event marked in Redis
+
+RED TEST 4: Duplicate event (already processed)
+  - POST webhook event and get 200 (event marked in Redis)
+  - POST same webhook event again
+  - Assert: apply_* is NOT called second time (early return after Redis check shows already processed)
+  - Assert: HTTP 200 returned (idempotent client perspective)
+  - Assert: Subscription state reflects only one application
+
+Testing approach:
+  - Use pytest with async fixtures
+  - Mock Redis client with aioredis.from_url patch
+  - Mock PayPalService.verify_webhook_signature = True
+  - Mock apply_* functions or wrap them with side-effect injection
+  - Use db_session.refresh(subscription) to check DB state
+  - Check Redis state via mock or real Redis test instance
+
+Hardest part: Simulating mid-transaction failures without actually breaking the transaction. Solution: Create wrapper apply_* that injects failure at specific points (after finding subscription, after updating state, before commit).
+
+Unit test file: backend/tests/test_paypal_webhook.py (already exists, add new test cases)
+
+**Risk:** CONFLICTS WITH TRACK B SIBLINGS:
+  - B1 (Firebase Cloud Tasks integration): May modify webhook exception handling or routing — ensure exception handler change doesn't conflict with Task Queue retry semantics
+  - B2 (Family config multi-tenant scoping): May add family_id lookup in subscription routes — ensure apply_* functions still work with correct scoping
+  - B3 (Payment method tokenization): May modify subscription state transitions — ensure apply_* idempotency assumptions hold with new fields
+  - B4-B5: Don't directly conflict but share webhook/subscription codebase
+
+PROD RISK:
+  - Returning 500 on transient DB failures will trigger PayPal retry for 24h — acceptable because apply_* functions are idempotent
+  - Short window where Redis mark fails but DB committed: acceptable, next retry marks event
+  - If Redis dedupe never succeeds (Redis down permanently), events reprocess: acceptable (idempotent), but watch logs for Redis failures
+  - Event may be processed 2x if: (1) DB commits, (2) Redis mark fails, (3) get_db() rollback is somehow partial — very unlikely with async transactions
+  
+TESTING RISK:
+  - Hard to simulate true transactional failure without actually breaking DB
+  - Solution: Mock apply_* with side-effect injection or use pytest-mock to raise exception at specific call count
+  - Redis tests may need real Redis instance or solid mock — use fakeredis or mock aioredis.from_url
+  
+DATA INTEGRITY:
+  - Idempotency assumptions: Each apply_* (activated, cancelled, payment_failed) must be idempotent
+    - apply_activated: checks `if sub.status == "active": return sub` (line 40) ✓
+    - apply_cancelled: checks `if sub.cancel_at_period_end: return sub` (line 62) ✓
+    - apply_payment_failed: checks `if sub.status == "payment_failed": return sub` (line 79) ✓
+  - All three are safe to reapply — no risk of data corruption on duplicate
+
+**Config/env:** 
+
+
+---
+
+## ITEM B7: PayPal API calls use blocking 'requests' inside async route handlers
+
+**Current:** backend/app/services/paypal_service.py lines 52-97: _PayPalV2HTTP class uses synchronous requests.post() at line 52 for OAuth token, requests.get() at line 66 for subscription fetch, requests.post() at line 80 for API operations (all with 15s timeouts). Called from async routes: /api/subscriptions/checkout (subscriptions.py:158 calls create_subscription), /api/subscriptions/activate (subscriptions.py:253 calls execute_subscription), /api/subscriptions/cancel (subscriptions.py:315 calls cancel_subscription), /api/subscriptions/webhook (subscriptions_webhook.py:84 calls verify_webhook_signature). Event loop blocks during PayPal latency.
+
+**Fix:** Convert _PayPalV2HTTP to async: (1) Replace 'import requests' with 'import httpx', (2) Create module-level AsyncClient instance with timeout=15s, (3) Convert _auth() to async _auth_async() using 'await client.post(...)' for OAuth token, (4) Convert get() to async get_async() using 'await client.get(...)', (5) Convert post() to async post_async() using 'await client.post(...)'. Update method signatures: create_subscription, execute_subscription, get_subscription, cancel_subscription, verify_webhook_signature all become async. Add 'await' at 4 caller sites: subscriptions.py lines 158, 253, 315 and subscriptions_webhook.py line 84.
+
+**Files:** /Volumes/shared/AgentIA/family-task-manager/backend/app/services/paypal_service.py, /Volumes/shared/AgentIA/family-task-manager/backend/app/api/routes/subscriptions.py, /Volumes/shared/AgentIA/family-task-manager/backend/app/api/routes/subscriptions_webhook.py, /Volumes/shared/AgentIA/family-task-manager/backend/tests/test_paypal_service_extras.py, /Volumes/shared/AgentIA/family-task-manager/backend/tests/test_paypal_webhook.py
+
+**New deps:** 
+
+**Test plan:** RED test: Call /api/subscriptions/checkout endpoint and verify requests library is not on call stack (event loop not blocked). GREEN tests: (1) Mock httpx.AsyncClient using unittest.mock.AsyncMock, (2) Test _PayPalV2HTTP.get_async() with mocked response returns correct subscription data, (3) Test _PayPalV2HTTP.post_async() with mocked response returns correct result, (4) Test PayPalService.create_subscription() awaits and returns approval_url, (5) Test PayPalService.execute_subscription() awaits and returns status, (6) Test PayPalService.cancel_subscription() awaits and returns cancelled status, (7) Test PayPalService.verify_webhook_signature() awaits and returns True/False. (8) Test /checkout route completes without blocking, (9) Test /activate route completes without blocking, (10) Test /cancel route completes without blocking, (11) Test /webhook route deduplicates and processes events without blocking. Update existing mocks in test_paypal_service_extras.py:22-53 and test_paypal_webhook.py:30-40 from patch(return_value=...) to AsyncMock(return_value=...) pattern. Verify existing JSON fixtures still load.
+
+**Risk:** Token caching race condition if AsyncClient is not properly managed - mitigate with single module-level instance or asyncio.Lock. httpx 0.26.0 already in requirements.txt, no new deps. No config/env changes needed. Conflicts with B4 (Redis async refactoring) minimal - B7 only touches PayPal service, no shared files. Test compatibility risk: existing mocks use unittest.mock.patch with return_value, must convert to AsyncMock (similar pattern as A3 receipt fix). Prod benefit: eliminates event loop blocking on 4 high-traffic routes, improves concurrent user handling during PayPal checkout/activation. Webhook verification stays consistent. Timeout values (15s) preserved.
+
+**Config/env:** 
+
+
+---

--- a/docs/audit/2026-06-04/09-trackB-progress.md
+++ b/docs/audit/2026-06-04/09-trackB-progress.md
@@ -1,0 +1,36 @@
+# Track B — prod-ops: execution progress
+
+Branch `fix/prod-ops` (stacked on `fix/security-criticals`). Commits e707841, d78e0d1.
+TDD in the `family_app_backend` container against test_db.
+
+## DONE ✓ (5 of 7)
+- **B4 — startup secret validation.** Settings fails fast in prod (DEBUG=false) on an
+  unset/placeholder SECRET_KEY. `config.py` model_validator. Tests: test_config_validation.py (4).
+- **B3 — real readiness probe.** `/health` is now liveness-only (no false "database:connected");
+  new `/ready` pings DB + Redis, returns 503 when degraded. Tests: test_health_readiness.py (3).
+- **B2 — single scheduler leader.** Redis leader lock (`app/core/scheduler_lock.py`) gates
+  APScheduler + overdue sweep to one worker (was firing once per uvicorn worker). TTL renewal,
+  release on shutdown, fail-open without Redis. Tests: test_scheduler_lock.py (2).
+- **B6 — PayPal webhook retriability.** Was marking events processed before the state change +
+  swallowing failures into 200 → lost events. Now marks only after a successful apply, returns
+  503 on failure so PayPal retries. Tests: test_paypal_webhook_resilience.py (2).
+- **B1 — auth rate limiting.** slowapi 10/min per-IP on login / register-family / check-methods /
+  forgot-password / reset-password. In-memory default (RATE_LIMIT_STORAGE_URI → Redis for
+  multi-worker). Tests: test_rate_limiting.py (2). Autouse conftest fixture disables the limiter
+  for other tests.
+
+58 passed across combined Track A+B suites; no regressions.
+
+## DEFERRED (specced in 08-trackB-specs.md) — lowest value / highest churn
+- **B5 — observability (Sentry + JSON logging).** Opt-in via SENTRY_DSN env + a logging module;
+  mostly config, low testability. New deps: sentry-sdk[fastapi], python-json-logger.
+- **B7 — PayPal async (requests → httpx).** Blocking `requests` in async handlers; calls are
+  infrequent (subscribe/cancel/webhook-verify). Refactor needs the existing paypal test mocks
+  rewritten from requests to httpx. Pattern mirrors the A3 receipt fix (timeout + offload).
+
+## Deploy notes
+- New dep slowapi==0.1.9 added to requirements.txt (rebuild image).
+- For multi-worker prod, set RATE_LIMIT_STORAGE_URI to the Redis URL so the limit window is
+  shared across workers (else each worker enforces independently — still bounded).
+- B2 leader lock uses REDIS_URL; if Redis is down, jobs fail-open (run everywhere) — acceptable
+  for single-instance, revisit if scaling out without Redis.


### PR DESCRIPTION
## Track B — prod-ops hardening

From the 2026-06-04 audit. **Stacked on #32** (base `fix/security-criticals`); retarget after it merges.

| | Issue | Fix |
|---|---|---|
| **B4** | App boots with placeholder `SECRET_KEY` → forgeable JWTs | `Settings` fails fast in prod (`DEBUG=false`) on unset/default key |
| **B3** | `/health` reported `database: connected` without touching the DB | `/health` = liveness only; new `/ready` pings DB+Redis, 503 when degraded |
| **B2** | APScheduler + overdue sweep fired in **every** uvicorn worker | Redis leader lock gates jobs to one worker (TTL renew, fail-open w/o Redis) |
| **B6** | PayPal webhook marked events processed *before* the state change + swallowed failures → lost events | mark only after successful apply; 503 on failure so PayPal retries |
| **B1** | No rate limiting anywhere | slowapi 10/min per-IP on the unauthenticated auth surface |

### Tests (TDD)
test_config_validation (4), test_health_readiness (3), test_scheduler_lock (2), test_paypal_webhook_resilience (2), test_rate_limiting (2). **58 passed** across combined Track A+B suites; no regressions.

### Deferred (lowest value / highest churn — specced in `docs/audit/2026-06-04/08-trackB-specs.md`)
- **B5** observability (Sentry + JSON logging) — opt-in config
- **B7** PayPal async (requests → httpx) — infrequent calls; needs paypal test-mock rewrite

### Deploy
- New dep `slowapi==0.1.9` (rebuild image).
- Multi-worker: set `RATE_LIMIT_STORAGE_URI` to Redis for a shared limit window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)