### PR TITLE
feat(auth): JWT access + refresh tokens (audit Bucket 1 #4)

### DIFF
--- a/.env.gcp.example
+++ b/.env.gcp.example
@@ -27,7 +27,8 @@ JWT_SECRET_KEY=CHANGE_ME_openssl_rand_hex_32
 # Distinct signing key for session cookies (do NOT reuse SECRET_KEY).
 SESSION_SECRET_KEY=
 ALGORITHM=HS256
-ACCESS_TOKEN_EXPIRE_MINUTES=10080   # 7 days — mobile UX, no silent re-auth
+ACCESS_TOKEN_EXPIRE_MINUTES=60      # 1 hour — short-lived access; refresh token (7d) auto-renews
+REFRESH_TOKEN_EXPIRE_DAYS=7
 
 # ── Public URLs (Cloudflare Tunnel — staging subdomain) ───────────────────
 # Cutover to family.agent-ia.mx + api.family.agent-ia.mx once GCP is green.

--- a/.env.gcp.example
+++ b/.env.gcp.example
@@ -25,7 +25,8 @@ POSTGRES_DB=familyapp
 SECRET_KEY=CHANGE_ME_openssl_rand_hex_32
 JWT_SECRET_KEY=CHANGE_ME_openssl_rand_hex_32
 # Distinct signing key for session cookies (do NOT reuse SECRET_KEY).
-SESSION_SECRET_KEY=
+# Must be set — a blank value silently falls back to SECRET_KEY, defeating the split.
+SESSION_SECRET_KEY=CHANGE_ME_openssl_rand_hex_32
 ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=60      # 1 hour — short-lived access; refresh token (7d) auto-renews
 REFRESH_TOKEN_EXPIRE_DAYS=7

--- a/.env.gcp.example
+++ b/.env.gcp.example
@@ -24,6 +24,8 @@ POSTGRES_DB=familyapp
 # Generate: openssl rand -hex 32
 SECRET_KEY=CHANGE_ME_openssl_rand_hex_32
 JWT_SECRET_KEY=CHANGE_ME_openssl_rand_hex_32
+# Distinct signing key for session cookies (do NOT reuse SECRET_KEY).
+SESSION_SECRET_KEY=
 ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=10080   # 7 days — mobile UX, no silent re-auth
 

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -183,9 +183,10 @@ async def login(
     db: AsyncSession = Depends(get_db),
 ):
     """Login and get access token"""
-    user, access_token = await AuthService.authenticate_user(db, login_data)
+    user, access_token, refresh_token = await AuthService.authenticate_user(db, login_data)
     return TokenResponse(
         access_token=access_token,
+        refresh_token=refresh_token,
         token_type="bearer",
         user=UserResponse.model_validate(user),
     )

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -32,7 +32,13 @@ from app.schemas.user import (
 )
 from app.models import User
 from app.models.family import Family, generate_join_code
-from app.core.security import get_password_hash, create_access_token
+from app.core.security import (
+    get_password_hash,
+    create_access_token,
+    create_refresh_token,
+    decode_token,
+    oauth2_scheme,
+)
 from app.core.rate_limiter import limiter, AUTH_LIMIT, EMAIL_LIMIT
 
 router = APIRouter()
@@ -184,6 +190,35 @@ async def login(
 ):
     """Login and get access token"""
     user, access_token, refresh_token = await AuthService.authenticate_user(db, login_data)
+    return TokenResponse(
+        access_token=access_token,
+        refresh_token=refresh_token,
+        token_type="bearer",
+        user=UserResponse.model_validate(user),
+    )
+
+
+@router.post("/refresh", response_model=TokenResponse)
+async def refresh_tokens(
+    token: str = Depends(oauth2_scheme),
+    db: AsyncSession = Depends(get_db),
+):
+    """Exchange a valid refresh token for a fresh access + refresh pair."""
+    payload = decode_token(token, expected_type="refresh")
+    user_id = payload.get("sub")
+    ver = payload.get("ver")
+    result = await db.execute(select(User).where(User.id == user_id))
+    user = result.scalar_one_or_none()
+    if user is None or ver != user.token_version:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Refresh token is no longer valid",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    access_token = create_access_token(
+        {"sub": str(user.id), "role": user.role.value, "family_id": str(user.family_id)}
+    )
+    refresh_token = create_refresh_token(str(user.id), version=user.token_version)
     return TokenResponse(
         access_token=access_token,
         refresh_token=refresh_token,

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -268,11 +268,14 @@ async def check_auth_methods(
 
 
 @router.post("/logout")
-async def logout(current_user: User = Depends(get_current_user)):
-    """Logout (invalidate token)"""
-    return {
-        "message": "Logged out successfully. Please delete the token on client side."
-    }
+async def logout(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Log out everywhere: bump token_version so all refresh tokens die."""
+    current_user.token_version += 1
+    await db.commit()
+    return {"message": "Logged out successfully."}
 
 
 @router.get("/me", response_model=UserResponse)
@@ -411,5 +414,7 @@ async def reset_password(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Could not reset password.",
         )
+    user.token_version += 1
+    await db.commit()
     return {"message": "Password reset successfully. You can now log in."}
 

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -170,12 +170,14 @@ async def register_family(
     except Exception:
         pass  # Don't block registration on email failure
 
-    # Issue access token
+    # Issue access + refresh tokens
     access_token = create_access_token(
         data={"sub": str(user.id), "family_id": str(user.family_id), "role": user.role.value}
     )
+    refresh_token = create_refresh_token(str(user.id), version=user.token_version)
     return RegisterFamilyResponse(
         access_token=access_token,
+        refresh_token=refresh_token,
         token_type="bearer",
         user=UserResponse.model_validate(user),
     )

--- a/backend/app/api/routes/invitations.py
+++ b/backend/app/api/routes/invitations.py
@@ -12,7 +12,7 @@ from app.core.database import get_db
 from app.core.dependencies import get_current_user, require_parent_role, verify_family_id
 from app.core.config import settings
 from app.core.type_utils import to_uuid_required
-from app.core.security import create_access_token
+from app.core.security import create_access_token, create_refresh_token
 from app.core.premium import require_feature
 from app.services.invitation_service import InvitationService
 from app.services.email_service import EmailService
@@ -147,7 +147,7 @@ async def accept_invitation(
                 detail="Only parents or adults (18+) can accept family invitations. Please contact a family administrator."
             )
         
-        # Create access token
+        # Create access + refresh tokens
         access_token = create_access_token(
             data={
                 "sub": str(user.id),
@@ -155,7 +155,8 @@ async def accept_invitation(
                 "role": user.role.value,
             }
         )
-        
+        refresh_token = create_refresh_token(str(user.id), version=user.token_version)
+
         await db.commit()
         
         # Send welcome email via the idempotent helper — it resolves
@@ -176,6 +177,7 @@ async def accept_invitation(
         return AcceptInvitationResponse(
             success=True,
             access_token=access_token,
+            refresh_token=refresh_token,
             token_type="bearer",
             message=f"Welcome to the family!"
         )

--- a/backend/app/api/routes/oauth.py
+++ b/backend/app/api/routes/oauth.py
@@ -45,14 +45,15 @@ async def google_oauth_login(
     logger.info(f"Google OAuth login attempt: email={google_user_info.get('email')}, join_code={request.join_code}")
     
     # Authenticate or create user
-    user, access_token, is_new_user = await GoogleOAuthService.authenticate_or_create_user(
+    user, access_token, refresh_token, is_new_user = await GoogleOAuthService.authenticate_or_create_user(
         db, google_user_info, request.family_id, request.join_code
     )
-    
+
     logger.info(f"Google OAuth successful: user_id={user.id}, email={user.email}, family_id={user.family_id}, is_new={is_new_user}")
-    
+
     return TokenResponse(
         access_token=access_token,
+        refresh_token=refresh_token,
         token_type="bearer",
         user=UserResponse.model_validate(user),
     )

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -30,7 +30,12 @@ class Settings(BaseSettings):
     # Security
     SECRET_KEY: str = "your-secret-key-change-this-in-production"
     ALGORITHM: str = "HS256"
-    ACCESS_TOKEN_EXPIRE_MINUTES: int = 10080  # 7 days
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = 60  # 1 hour (was 10080 / 7 days)
+    REFRESH_TOKEN_EXPIRE_DAYS: int = 7
+    # Separate signing key for Starlette SessionMiddleware cookies so it does
+    # not share the JWT signing key. Defaults to SECRET_KEY when unset so dev
+    # and existing envs keep working; production .env sets a distinct value.
+    SESSION_SECRET_KEY: str = ""
 
     # Trust-score auto-approval: once a user has this many consecutive
     # approved gigs, subsequent gig completions auto-approve and credit

--- a/backend/app/core/dependencies.py
+++ b/backend/app/core/dependencies.py
@@ -22,7 +22,7 @@ async def get_current_user(
     )
 
     # Decode token
-    payload = decode_token(token)
+    payload = decode_token(token, expected_type="access")
     user_id: str = payload.get("sub")
 
     if user_id is None:

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 from jose import JWTError, jwt
@@ -29,28 +30,46 @@ get_password_hash = hash_password
 
 
 def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
-    """Create JWT access token"""
+    """Create a short-lived access JWT."""
     to_encode = data.copy()
-    
     if expires_delta:
         expire = datetime.now(timezone.utc) + expires_delta
     else:
         expire = datetime.now(timezone.utc) + timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
-    
-    to_encode.update({"exp": expire})
-    encoded_jwt = jwt.encode(to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
-    
-    return encoded_jwt
+    to_encode.update({"exp": expire, "type": "access"})
+    return jwt.encode(to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
 
 
-def decode_token(token: str) -> dict:
-    """Decode JWT token"""
+def create_refresh_token(sub: str, version: int) -> str:
+    """Create a long-lived refresh JWT carrying the user's token_version."""
+    expire = datetime.now(timezone.utc) + timedelta(days=settings.REFRESH_TOKEN_EXPIRE_DAYS)
+    to_encode = {
+        "sub": sub,
+        "ver": version,
+        "type": "refresh",
+        "jti": uuid.uuid4().hex,
+        "exp": expire,
+    }
+    return jwt.encode(to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
+
+
+def decode_token(token: str, expected_type: Optional[str] = None) -> dict:
+    """Decode a JWT. When expected_type is set, enforce the `type` claim,
+    treating a missing type as 'access' (legacy 7-day tokens)."""
     try:
         payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM])
-        return payload
     except JWTError:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Could not validate credentials",
             headers={"WWW-Authenticate": "Bearer"},
         )
+    if expected_type is not None:
+        token_type = payload.get("type", "access")
+        if token_type != expected_type:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid token type",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+    return payload

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -176,7 +176,7 @@ app.add_middleware(
 # Session Middleware (required for OAuth)
 app.add_middleware(
     SessionMiddleware,
-    secret_key=settings.SECRET_KEY,
+    secret_key=settings.SESSION_SECRET_KEY or settings.SECRET_KEY,
     max_age=1800,  # 30 minutes
 )
 

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -26,6 +26,7 @@ class User(Base):
     role = Column(SQLEnum(UserRole), nullable=False, default=UserRole.CHILD)
     family_id = Column(UUID(as_uuid=True), ForeignKey("families.id"), nullable=False, index=True)
     points = Column(Integer, default=0, nullable=False)
+    token_version = Column(Integer, nullable=False, default=0, server_default="0")
     is_active = Column(Boolean, default=True, nullable=False)
     preferred_lang = Column(String(5), default="en", nullable=False, server_default="en")
     

--- a/backend/app/schemas/invitation.py
+++ b/backend/app/schemas/invitation.py
@@ -46,6 +46,7 @@ class AcceptInvitationResponse(BaseModel):
     """Response after accepting invitation"""
     success: bool
     access_token: str
+    refresh_token: Optional[str] = None
     token_type: str
     message: str
 

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -83,6 +83,7 @@ class TokenResponse(BaseModel):
     """Schema for authentication token response"""
 
     access_token: str
+    refresh_token: Optional[str] = None
     token_type: str = "bearer"
     user: UserResponse
 

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -121,5 +121,6 @@ class RegisterFamilyRequest(BaseModel):
 class RegisterFamilyResponse(BaseModel):
     """Response after creating a family + user"""
     access_token: str
+    refresh_token: Optional[str] = None
     token_type: str = "bearer"
     user: UserResponse

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -12,7 +12,7 @@ from uuid import UUID
 from app.models import User, Family
 from app.models.user import UserRole
 from app.schemas.user import UserCreate, UserLogin
-from app.core.security import verify_password, get_password_hash, create_access_token
+from app.core.security import verify_password, get_password_hash, create_access_token, create_refresh_token
 from app.core.config import settings
 from app.core.exceptions import (
     NotFoundException,
@@ -66,30 +66,31 @@ class AuthService:
     async def authenticate_user(
         db: AsyncSession,
         login_data: UserLogin,
-    ) -> tuple[User, str]:
-        """Authenticate user and return user + access token"""
+    ) -> tuple[User, str, str]:
+        """Authenticate user and return (user, access_token, refresh_token)."""
         # Find user by email
         user = (await db.execute(
             select(User).where(User.email == login_data.email)
         )).scalar_one_or_none()
-        
+
         if not user:
             raise UnauthorizedException("Invalid email or password")
-        
+
         # Verify password
         if not verify_password(login_data.password, user.password_hash):
             raise UnauthorizedException("Invalid email or password")
-        
+
         # Check if user is active
         if not user.is_active:
             raise UnauthorizedException("Account is deactivated")
-        
-        # Create access token
+
+        # Create access + refresh tokens
         access_token = create_access_token(
             data={"sub": str(user.id), "family_id": str(user.family_id), "role": user.role.value}
         )
-        
-        return user, access_token
+        refresh_token = create_refresh_token(str(user.id), version=user.token_version)
+
+        return user, access_token, refresh_token
 
     @staticmethod
     async def get_user_by_id(db: AsyncSession, user_id: UUID) -> User:

--- a/backend/app/services/google_oauth_service.py
+++ b/backend/app/services/google_oauth_service.py
@@ -13,7 +13,7 @@ from uuid import uuid4
 from app.models import User, Family
 from app.models.user import UserRole
 from app.core.config import settings
-from app.core.security import create_access_token
+from app.core.security import create_access_token, create_refresh_token
 from app.core.exceptions import (
     ValidationException,
     UnauthorizedException,
@@ -91,18 +91,18 @@ class GoogleOAuthService:
         google_user_info: Dict[str, Any],
         family_id: Optional[str] = None,
         join_code: Optional[str] = None,
-    ) -> tuple[User, str, bool]:
+    ) -> tuple[User, str, str, bool]:
         """
         Authenticate existing user or create new user from Google OAuth
-        
+
         Args:
             db: Database session
             google_user_info: User info from Google
             family_id: Optional family ID for new user registration
             join_code: Optional family join code to join an existing family
-            
+
         Returns:
-            Tuple of (User, access_token, is_new_user)
+            Tuple of (User, access_token, refresh_token, is_new_user)
         """
         google_id = google_user_info['google_id']
         email = google_user_info['email']
@@ -139,7 +139,8 @@ class GoogleOAuthService:
                     "role": user.role.value
                 }
             )
-            return user, access_token, False
+            refresh_token = create_refresh_token(str(user.id), version=user.token_version)
+            return user, access_token, refresh_token, False
         
         # New user - determine which family to join
         target_family_id = None
@@ -198,7 +199,7 @@ class GoogleOAuthService:
         await db.commit()
         await db.refresh(user)
 
-        # Create access token
+        # Create access + refresh tokens
         access_token = create_access_token(
             data={
                 "sub": str(user.id),
@@ -206,6 +207,7 @@ class GoogleOAuthService:
                 "role": user.role.value
             }
         )
+        refresh_token = create_refresh_token(str(user.id), version=user.token_version)
 
         # Fire welcome email for this brand-new Google user. Google has
         # already vouched for email ownership (email_verified=true in
@@ -225,4 +227,4 @@ class GoogleOAuthService:
                 exc_info=True,
             )
 
-        return user, access_token, True
+        return user, access_token, refresh_token, True

--- a/backend/app/services/invitation_service.py
+++ b/backend/app/services/invitation_service.py
@@ -11,7 +11,7 @@ from sqlalchemy import select
 
 from app.models.invitation import FamilyInvitation, InvitationStatus
 from app.models.user import User, UserRole
-from app.core.security import get_password_hash, create_access_token
+from app.core.security import get_password_hash
 from app.core.exceptions import ValidationException, NotFoundException
 from app.services.email_service import EmailService
 

--- a/backend/migrations/versions/2026_06_15_1324-02b4ae6958cc_add_user_token_version.py
+++ b/backend/migrations/versions/2026_06_15_1324-02b4ae6958cc_add_user_token_version.py
@@ -1,0 +1,27 @@
+"""add user token_version
+
+Revision ID: 02b4ae6958cc
+Revises: 7a3b284cde5a
+Create Date: 2026-06-15 13:24:03.241225
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '02b4ae6958cc'
+down_revision = '7a3b284cde5a'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("token_version", sa.Integer(), nullable=False, server_default="0"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "token_version")

--- a/backend/tests/test_auth_service.py
+++ b/backend/tests/test_auth_service.py
@@ -130,7 +130,7 @@ class TestUserAuthentication:
             password="password123",
         )
 
-        user, access_token = await AuthService.authenticate_user(db_session, login_data)
+        user, access_token, refresh_token = await AuthService.authenticate_user(db_session, login_data)
 
         assert user is not None
         assert user.id == test_parent_user.id
@@ -138,6 +138,9 @@ class TestUserAuthentication:
         assert access_token is not None
         assert isinstance(access_token, str)
         assert len(access_token) > 0
+        assert refresh_token is not None
+        assert isinstance(refresh_token, str)
+        assert len(refresh_token) > 0
 
 
 @pytest.mark.asyncio
@@ -207,10 +210,11 @@ class TestPasswordUpdate:
             password=new_password,
         )
         
-        user, token = await AuthService.authenticate_user(db_session, login_data)
-        
+        user, token, refresh_token = await AuthService.authenticate_user(db_session, login_data)
+
         assert user is not None
         assert token is not None
+        assert refresh_token is not None
 
 
 @pytest.mark.asyncio
@@ -280,3 +284,19 @@ class TestGetUserById:
             await AuthService.get_user_by_id(db_session, uuid4())
 
         assert "user not found" in str(exc_info.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_authenticate_user_returns_access_and_refresh(db_session, test_parent_user):
+    from app.services.auth_service import AuthService
+    from app.schemas.user import UserLogin
+    from app.core.security import decode_token
+
+    user, access, refresh = await AuthService.authenticate_user(
+        db_session, UserLogin(email="parent@test.com", password="password123")
+    )
+    assert user.id == test_parent_user.id
+    assert decode_token(access).get("type") == "access"
+    refresh_claims = decode_token(refresh)
+    assert refresh_claims.get("type") == "refresh"
+    assert refresh_claims.get("ver") == test_parent_user.token_version

--- a/backend/tests/test_refresh_endpoint.py
+++ b/backend/tests/test_refresh_endpoint.py
@@ -34,3 +34,16 @@ async def test_refresh_rejects_stale_version(client: AsyncClient, db_session, te
     await db_session.commit()
     resp = await client.post("/api/auth/refresh", headers=_bearer(stale))
     assert resp.status_code == 401, resp.text
+
+
+@pytest.mark.asyncio
+async def test_logout_invalidates_refresh(client: AsyncClient, db_session, test_parent_user):
+    refresh = create_refresh_token(str(test_parent_user.id), version=test_parent_user.token_version)
+    # Authenticate logout with a valid access token.
+    from app.core.security import create_access_token
+    access = create_access_token({"sub": str(test_parent_user.id)})
+    out = await client.post("/api/auth/logout", headers=_bearer(access))
+    assert out.status_code == 200, out.text
+    # The pre-logout refresh token must now be rejected.
+    resp = await client.post("/api/auth/refresh", headers=_bearer(refresh))
+    assert resp.status_code == 401, resp.text

--- a/backend/tests/test_refresh_endpoint.py
+++ b/backend/tests/test_refresh_endpoint.py
@@ -1,0 +1,36 @@
+"""POST /api/auth/refresh — exchange a valid refresh token for a new pair."""
+import pytest
+from httpx import AsyncClient
+
+from app.core.security import create_refresh_token, decode_token
+
+
+def _bearer(tok):
+    return {"Authorization": f"Bearer {tok}"}
+
+
+@pytest.mark.asyncio
+async def test_refresh_happy_path(client: AsyncClient, test_parent_user):
+    refresh = create_refresh_token(str(test_parent_user.id), version=test_parent_user.token_version)
+    resp = await client.post("/api/auth/refresh", headers=_bearer(refresh))
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert decode_token(body["access_token"]).get("type") == "access"
+    assert decode_token(body["refresh_token"]).get("type") == "refresh"
+
+
+@pytest.mark.asyncio
+async def test_refresh_rejects_access_token(client: AsyncClient, test_parent_user):
+    from app.core.security import create_access_token
+    access = create_access_token({"sub": str(test_parent_user.id)})
+    resp = await client.post("/api/auth/refresh", headers=_bearer(access))
+    assert resp.status_code == 401, resp.text
+
+
+@pytest.mark.asyncio
+async def test_refresh_rejects_stale_version(client: AsyncClient, db_session, test_parent_user):
+    stale = create_refresh_token(str(test_parent_user.id), version=test_parent_user.token_version)
+    test_parent_user.token_version += 1
+    await db_session.commit()
+    resp = await client.post("/api/auth/refresh", headers=_bearer(stale))
+    assert resp.status_code == 401, resp.text

--- a/backend/tests/test_token_types.py
+++ b/backend/tests/test_token_types.py
@@ -41,3 +41,12 @@ def test_decode_token_treats_missing_type_as_access():
     legacy = jwt.encode({"sub": "u1"}, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
     payload = decode_token(legacy, expected_type="access")
     assert payload["sub"] == "u1"
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_rejects_refresh_token(db_session, test_parent_user):
+    from app.core.dependencies import get_current_user
+    refresh = create_refresh_token(str(test_parent_user.id), version=0)
+    with pytest.raises(HTTPException) as exc:
+        await get_current_user(token=refresh, db=db_session)
+    assert exc.value.status_code == 401

--- a/backend/tests/test_token_types.py
+++ b/backend/tests/test_token_types.py
@@ -1,0 +1,43 @@
+"""Access vs refresh token claims + typed decoding."""
+import pytest
+from jose import jwt
+
+from app.core.config import settings
+from app.core.security import (
+    create_access_token,
+    create_refresh_token,
+    decode_token,
+)
+from fastapi import HTTPException
+
+
+def _decode_raw(token):
+    return jwt.decode(token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM])
+
+
+def test_access_token_is_typed_access():
+    tok = create_access_token({"sub": "u1"})
+    assert _decode_raw(tok)["type"] == "access"
+
+
+def test_refresh_token_carries_type_and_version():
+    tok = create_refresh_token("u1", version=3)
+    claims = _decode_raw(tok)
+    assert claims["type"] == "refresh"
+    assert claims["ver"] == 3
+    assert claims["sub"] == "u1"
+    assert "jti" in claims
+
+
+def test_decode_token_rejects_wrong_type():
+    refresh = create_refresh_token("u1", version=0)
+    with pytest.raises(HTTPException) as exc:
+        decode_token(refresh, expected_type="access")
+    assert exc.value.status_code == 401
+
+
+def test_decode_token_treats_missing_type_as_access():
+    # A legacy token minted without a `type` claim must still decode as access.
+    legacy = jwt.encode({"sub": "u1"}, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
+    payload = decode_token(legacy, expected_type="access")
+    assert payload["sub"] == "u1"

--- a/backend/tests/test_token_version.py
+++ b/backend/tests/test_token_version.py
@@ -1,0 +1,8 @@
+"""User.token_version backs refresh-token revocation."""
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_user_token_version_defaults_to_zero(db_session, test_parent_user):
+    await db_session.refresh(test_parent_user)
+    assert test_parent_user.token_version == 0

--- a/docs/superpowers/plans/2026-06-15-jwt-access-refresh.md
+++ b/docs/superpowers/plans/2026-06-15-jwt-access-refresh.md
@@ -1,0 +1,1101 @@
+# JWT Access + Refresh Tokens Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the single 7-day JWT with a short-lived access token (1h) + rotating refresh token (7d), revocable via a per-user `token_version`, with transparent refresh at the Astro BFF layer.
+
+**Architecture:** Backend mints access+refresh JWTs; `token_version` on `User` enables logout-everywhere. The Astro frontend is a BFF — it owns two httpOnly cookies and transparently refreshes the access token (in `middleware.ts`, which runs before every route) using the refresh cookie. The backend keeps reading the JWT from the `Authorization` header.
+
+**Tech Stack:** FastAPI, python-jose, SQLAlchemy/Alembic, asyncpg, Astro 5 SSR (@astrojs/node), Playwright.
+
+**Spec:** `docs/superpowers/specs/2026-06-15-jwt-access-refresh-design.md`
+
+**Spec correction (found in planning):** The refresh cookie is `Path=/` (not `Path=/api/auth`). Cookies are only sent to paths matching their `Path`; the middleware and proxy routes that perform transparent refresh run on non-auth paths (`/api/budget/*`, page routes), so a `/api/auth`-scoped refresh cookie would never reach them. It remains httpOnly and BFF-only, so the security delta is nil.
+
+**Test commands:**
+- Backend: `podman exec -e PYTHONPATH=/app family_app_backend pytest <path> -q --no-cov`
+- E2E: `cd e2e-tests && npm run test -- <file>`
+
+---
+
+## File Structure
+
+**Backend (create):**
+- `backend/migrations/versions/<rev>_add_user_token_version.py` — migration for `User.token_version`.
+
+**Backend (modify):**
+- `backend/app/core/config.py` — token TTLs + `SESSION_SECRET_KEY`.
+- `backend/app/core/security.py` — token type stamping, `create_refresh_token`, typed decode.
+- `backend/app/core/dependencies.py` — `get_current_user` rejects non-access tokens.
+- `backend/app/models/user.py` — `token_version` column.
+- `backend/app/services/auth_service.py` — return access+refresh.
+- `backend/app/services/google_oauth_service.py`, `invitation_service.py` — return refresh.
+- `backend/app/api/routes/auth.py` — `/refresh` endpoint, logout + reset bump version, login returns refresh.
+- `backend/app/schemas/user.py` — `TokenResponse.refresh_token`.
+- `backend/app/main.py` — `SessionMiddleware` uses `SESSION_SECRET_KEY`.
+- `backend/.env.gcp.example` — document `SESSION_SECRET_KEY`.
+
+**Frontend (create):**
+- `frontend/src/lib/auth-cookies.ts` — single cookie-pair builder.
+- `frontend/src/lib/server/refresh.ts` — server-side refresh helper (calls backend).
+- `frontend/src/pages/api/auth/refresh.ts` — refresh route.
+
+**Frontend (modify):**
+- `frontend/src/middleware.ts` — refresh-on-expiry before validation.
+- `frontend/src/pages/api/auth/login.ts`, `register.ts`, `oauth/google.ts`, `invitations/accept.ts` — set both cookies via the shared helper.
+- `frontend/src/pages/api/auth/logout.ts` — call backend logout + clear both cookies.
+- `frontend/src/pages/api/*/[...path].ts` (proxy routes) — refresh-once-on-401 retry.
+
+**E2E (create):**
+- `e2e-tests/tests/auth-refresh.spec.ts`.
+
+---
+
+## Phase A — Backend
+
+### Task A1: Token TTLs + SESSION_SECRET_KEY config
+
+**Files:**
+- Modify: `backend/app/core/config.py`
+
+- [ ] **Step 1: Edit config**
+
+In `backend/app/core/config.py`, change the access TTL and add the new settings (place near the existing `ACCESS_TOKEN_EXPIRE_MINUTES` / `SECRET_KEY` lines):
+
+```python
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = 60  # 1 hour (was 10080 / 7 days)
+    REFRESH_TOKEN_EXPIRE_DAYS: int = 7
+    # Separate signing key for Starlette SessionMiddleware cookies so it does
+    # not share the JWT signing key. Defaults to SECRET_KEY when unset so dev
+    # and existing envs keep working; production .env sets a distinct value.
+    SESSION_SECRET_KEY: str = ""
+```
+
+- [ ] **Step 2: Verify import still loads**
+
+Run: `podman exec -e PYTHONPATH=/app family_app_backend python -c "from app.core.config import settings; print(settings.ACCESS_TOKEN_EXPIRE_MINUTES, settings.REFRESH_TOKEN_EXPIRE_DAYS)"`
+Expected: `60 7`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/app/core/config.py
+git commit -m "feat(auth): 1h access TTL, refresh TTL, SESSION_SECRET_KEY setting"
+```
+
+---
+
+### Task A2: `token_version` column + migration
+
+**Files:**
+- Modify: `backend/app/models/user.py`
+- Create: `backend/migrations/versions/<rev>_add_user_token_version.py`
+- Test: `backend/tests/test_token_version.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/test_token_version.py`:
+
+```python
+"""User.token_version backs refresh-token revocation."""
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_user_token_version_defaults_to_zero(db_session, test_parent_user):
+    await db_session.refresh(test_parent_user)
+    assert test_parent_user.token_version == 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `podman exec -e PYTHONPATH=/app family_app_backend pytest tests/test_token_version.py -q --no-cov`
+Expected: FAIL — `AttributeError: ... 'User' ... has no attribute 'token_version'`
+
+- [ ] **Step 3: Add the column**
+
+In `backend/app/models/user.py`, add to the `User` model (near the other `Integer` columns like `points`):
+
+```python
+    token_version = Column(Integer, nullable=False, default=0, server_default="0")
+```
+
+(Ensure `Integer` is imported — it already is in this model.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `podman exec -e PYTHONPATH=/app family_app_backend pytest tests/test_token_version.py -q --no-cov`
+Expected: PASS (test DB is built from `create_all`, so the column exists immediately).
+
+- [ ] **Step 5: Generate the migration**
+
+Run: `podman exec -e PYTHONPATH=/app family_app_backend alembic revision -m "add user token_version"`
+Then edit the new file in `backend/migrations/versions/` so `upgrade()`/`downgrade()` are exactly:
+
+```python
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("token_version", sa.Integer(), nullable=False, server_default="0"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "token_version")
+```
+
+Confirm `down_revision` points at the current head (run `alembic heads` first; set it to that revision id).
+
+- [ ] **Step 6: Apply migration to the dev DB**
+
+Run: `podman exec -e PYTHONPATH=/app family_app_backend alembic upgrade head`
+Expected: applies cleanly; `alembic current` shows the new revision as head.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/models/user.py backend/migrations/versions/ backend/tests/test_token_version.py
+git commit -m "feat(auth): add User.token_version for refresh revocation"
+```
+
+---
+
+### Task A3: Token creation + typed decode in security.py
+
+**Files:**
+- Modify: `backend/app/core/security.py`
+- Test: `backend/tests/test_token_types.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/test_token_types.py`:
+
+```python
+"""Access vs refresh token claims + typed decoding."""
+import pytest
+from jose import jwt
+
+from app.core.config import settings
+from app.core.security import (
+    create_access_token,
+    create_refresh_token,
+    decode_token,
+)
+from fastapi import HTTPException
+
+
+def _decode_raw(token):
+    return jwt.decode(token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM])
+
+
+def test_access_token_is_typed_access():
+    tok = create_access_token({"sub": "u1"})
+    assert _decode_raw(tok)["type"] == "access"
+
+
+def test_refresh_token_carries_type_and_version():
+    tok = create_refresh_token("u1", version=3)
+    claims = _decode_raw(tok)
+    assert claims["type"] == "refresh"
+    assert claims["ver"] == 3
+    assert claims["sub"] == "u1"
+    assert "jti" in claims
+
+
+def test_decode_token_rejects_wrong_type():
+    refresh = create_refresh_token("u1", version=0)
+    with pytest.raises(HTTPException) as exc:
+        decode_token(refresh, expected_type="access")
+    assert exc.value.status_code == 401
+
+
+def test_decode_token_treats_missing_type_as_access():
+    # A legacy token minted without a `type` claim must still decode as access.
+    legacy = jwt.encode({"sub": "u1"}, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
+    payload = decode_token(legacy, expected_type="access")
+    assert payload["sub"] == "u1"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `podman exec -e PYTHONPATH=/app family_app_backend pytest tests/test_token_types.py -q --no-cov`
+Expected: FAIL — `ImportError: cannot import name 'create_refresh_token'` (and `decode_token` has no `expected_type`).
+
+- [ ] **Step 3: Implement**
+
+In `backend/app/core/security.py`:
+
+Add `import uuid` and `timedelta` is already imported. Update `create_access_token` to stamp the type, add `create_refresh_token`, and extend `decode_token`:
+
+```python
+def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
+    """Create a short-lived access JWT."""
+    to_encode = data.copy()
+    if expires_delta:
+        expire = datetime.now(timezone.utc) + expires_delta
+    else:
+        expire = datetime.now(timezone.utc) + timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+    to_encode.update({"exp": expire, "type": "access"})
+    return jwt.encode(to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
+
+
+def create_refresh_token(sub: str, version: int) -> str:
+    """Create a long-lived refresh JWT carrying the user's token_version."""
+    expire = datetime.now(timezone.utc) + timedelta(days=settings.REFRESH_TOKEN_EXPIRE_DAYS)
+    to_encode = {
+        "sub": sub,
+        "ver": version,
+        "type": "refresh",
+        "jti": uuid.uuid4().hex,
+        "exp": expire,
+    }
+    return jwt.encode(to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
+
+
+def decode_token(token: str, expected_type: Optional[str] = None) -> dict:
+    """Decode a JWT. When expected_type is set, enforce the `type` claim,
+    treating a missing type as 'access' (legacy 7-day tokens)."""
+    try:
+        payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM])
+    except JWTError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Could not validate credentials",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    if expected_type is not None:
+        token_type = payload.get("type", "access")
+        if token_type != expected_type:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid token type",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+    return payload
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `podman exec -e PYTHONPATH=/app family_app_backend pytest tests/test_token_types.py -q --no-cov`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/core/security.py backend/tests/test_token_types.py
+git commit -m "feat(auth): type-stamp access tokens, add create_refresh_token + typed decode"
+```
+
+---
+
+### Task A4: `get_current_user` rejects refresh tokens
+
+**Files:**
+- Modify: `backend/app/core/dependencies.py`
+- Test: `backend/tests/test_token_types.py` (extend)
+
+- [ ] **Step 1: Add the failing test**
+
+Append to `backend/tests/test_token_types.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_get_current_user_rejects_refresh_token(db_session, test_parent_user):
+    from app.core.dependencies import get_current_user
+    refresh = create_refresh_token(str(test_parent_user.id), version=0)
+    with pytest.raises(HTTPException) as exc:
+        await get_current_user(token=refresh, db=db_session)
+    assert exc.value.status_code == 401
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `podman exec -e PYTHONPATH=/app family_app_backend pytest tests/test_token_types.py::test_get_current_user_rejects_refresh_token -q --no-cov`
+Expected: FAIL — a refresh token currently decodes fine and returns the user.
+
+- [ ] **Step 3: Implement**
+
+In `backend/app/core/dependencies.py::get_current_user`, change the decode call:
+
+```python
+    payload = decode_token(token, expected_type="access")
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `podman exec -e PYTHONPATH=/app family_app_backend pytest tests/test_token_types.py -q --no-cov`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/core/dependencies.py backend/tests/test_token_types.py
+git commit -m "feat(auth): get_current_user only accepts access (or legacy) tokens"
+```
+
+---
+
+### Task A5: `authenticate_user` returns access + refresh
+
+**Files:**
+- Modify: `backend/app/services/auth_service.py`
+- Test: `backend/tests/test_auth_service.py` (extend)
+
+- [ ] **Step 1: Add the failing test**
+
+Append to `backend/tests/test_auth_service.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_authenticate_user_returns_access_and_refresh(db_session, test_parent_user):
+    from app.services.auth_service import AuthService
+    from app.schemas.user import UserLogin
+    from app.core.security import decode_token
+
+    user, access, refresh = await AuthService.authenticate_user(
+        db_session, UserLogin(email="parent@test.com", password="password123")
+    )
+    assert user.id == test_parent_user.id
+    assert decode_token(access).get("type") == "access"
+    refresh_claims = decode_token(refresh)
+    assert refresh_claims.get("type") == "refresh"
+    assert refresh_claims.get("ver") == test_parent_user.token_version
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `podman exec -e PYTHONPATH=/app family_app_backend pytest tests/test_auth_service.py::test_authenticate_user_returns_access_and_refresh -q --no-cov`
+Expected: FAIL — `authenticate_user` returns a 2-tuple `(user, access)`.
+
+- [ ] **Step 3: Implement**
+
+In `backend/app/services/auth_service.py`, update the import and `authenticate_user`:
+
+Change the import line:
+```python
+from app.core.security import verify_password, get_password_hash, create_access_token, create_refresh_token
+```
+
+Update the signature + return (the body already builds `access_token` via `create_access_token({"sub": ...})`; add the refresh and return all three):
+```python
+    async def authenticate_user(
+        db: AsyncSession,
+        login_data: UserLogin,
+    ) -> tuple[User, str, str]:
+        """Authenticate user and return (user, access_token, refresh_token)."""
+        # ... existing lookup + password verification unchanged ...
+        access_token = create_access_token(
+            {"sub": str(user.id), "role": user.role.value, "family_id": str(user.family_id)}
+        )
+        refresh_token = create_refresh_token(str(user.id), version=user.token_version)
+        return user, access_token, refresh_token
+```
+
+(Keep the existing claim shape used today; only add `create_refresh_token` and widen the return tuple. Match the existing `create_access_token({...})` payload already in the function.)
+
+- [ ] **Step 4: Update the login route caller**
+
+In `backend/app/api/routes/auth.py::login`, unpack three values:
+```python
+    user, access_token, refresh_token = await AuthService.authenticate_user(db, login_data)
+    return TokenResponse(
+        access_token=access_token,
+        refresh_token=refresh_token,
+        token_type="bearer",
+        user=UserResponse.model_validate(user),
+    )
+```
+
+- [ ] **Step 5: Run to verify it passes (test added in Step 1; TokenResponse field added in Task A8 — if running before A8, expect a schema error, do A8 first then re-run)**
+
+Run: `podman exec -e PYTHONPATH=/app family_app_backend pytest tests/test_auth_service.py::test_authenticate_user_returns_access_and_refresh -q --no-cov`
+Expected: PASS.
+
+> NOTE: Do Task A8 (schema) before re-running the login route, since `TokenResponse(refresh_token=...)` needs the new field. The service-level test in Step 1 does not touch `TokenResponse` and passes independently.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/services/auth_service.py backend/app/api/routes/auth.py backend/tests/test_auth_service.py
+git commit -m "feat(auth): authenticate_user issues access + refresh tokens"
+```
+
+---
+
+### Task A8: `TokenResponse.refresh_token` schema
+
+> (Ordered before A6/A7 because they construct token responses.)
+
+**Files:**
+- Modify: `backend/app/schemas/user.py`
+
+- [ ] **Step 1: Add the field**
+
+In `backend/app/schemas/user.py`, add to `TokenResponse`:
+```python
+    refresh_token: Optional[str] = None
+```
+(`Optional` is already imported in this module; if not, add `from typing import Optional`.)
+
+- [ ] **Step 2: Verify import loads**
+
+Run: `podman exec -e PYTHONPATH=/app family_app_backend python -c "from app.schemas.user import TokenResponse; print('ok')"`
+Expected: `ok`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/app/schemas/user.py
+git commit -m "feat(auth): add refresh_token to TokenResponse"
+```
+
+---
+
+### Task A6: `POST /api/auth/refresh` endpoint
+
+**Files:**
+- Modify: `backend/app/api/routes/auth.py`
+- Test: `backend/tests/test_refresh_endpoint.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/test_refresh_endpoint.py`:
+
+```python
+"""POST /api/auth/refresh — exchange a valid refresh token for a new pair."""
+import pytest
+from httpx import AsyncClient
+
+from app.core.security import create_refresh_token, decode_token
+
+
+def _bearer(tok):
+    return {"Authorization": f"Bearer {tok}"}
+
+
+@pytest.mark.asyncio
+async def test_refresh_happy_path(client: AsyncClient, test_parent_user):
+    refresh = create_refresh_token(str(test_parent_user.id), version=test_parent_user.token_version)
+    resp = await client.post("/api/auth/refresh", headers=_bearer(refresh))
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert decode_token(body["access_token"]).get("type") == "access"
+    assert decode_token(body["refresh_token"]).get("type") == "refresh"
+
+
+@pytest.mark.asyncio
+async def test_refresh_rejects_access_token(client: AsyncClient, test_parent_user):
+    from app.core.security import create_access_token
+    access = create_access_token({"sub": str(test_parent_user.id)})
+    resp = await client.post("/api/auth/refresh", headers=_bearer(access))
+    assert resp.status_code == 401, resp.text
+
+
+@pytest.mark.asyncio
+async def test_refresh_rejects_stale_version(client: AsyncClient, db_session, test_parent_user):
+    stale = create_refresh_token(str(test_parent_user.id), version=test_parent_user.token_version)
+    test_parent_user.token_version += 1
+    await db_session.commit()
+    resp = await client.post("/api/auth/refresh", headers=_bearer(stale))
+    assert resp.status_code == 401, resp.text
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `podman exec -e PYTHONPATH=/app family_app_backend pytest tests/test_refresh_endpoint.py -q --no-cov`
+Expected: FAIL — 404/405 (route does not exist).
+
+- [ ] **Step 3: Implement the endpoint**
+
+In `backend/app/api/routes/auth.py`, add (use the existing `oauth2_scheme` dependency to read the Bearer token, and `select`/`User` already imported in this module):
+
+```python
+from app.core.security import create_access_token, create_refresh_token, decode_token
+from app.core.security import oauth2_scheme
+
+
+@router.post("/refresh", response_model=TokenResponse)
+async def refresh_tokens(
+    token: str = Depends(oauth2_scheme),
+    db: AsyncSession = Depends(get_db),
+):
+    """Exchange a valid refresh token for a fresh access + refresh pair."""
+    payload = decode_token(token, expected_type="refresh")
+    user_id = payload.get("sub")
+    ver = payload.get("ver")
+    result = await db.execute(select(User).where(User.id == user_id))
+    user = result.scalar_one_or_none()
+    if user is None or ver != user.token_version:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Refresh token is no longer valid",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    access_token = create_access_token(
+        {"sub": str(user.id), "role": user.role.value, "family_id": str(user.family_id)}
+    )
+    refresh_token = create_refresh_token(str(user.id), version=user.token_version)
+    return TokenResponse(
+        access_token=access_token,
+        refresh_token=refresh_token,
+        token_type="bearer",
+        user=UserResponse.model_validate(user),
+    )
+```
+
+Add `/api/auth/refresh` to the middleware `publicRoutes` list in Task B4 (so the BFF can call it even when the access token is dead). The backend route itself stays unauthenticated-by-access (it authenticates via the refresh token).
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `podman exec -e PYTHONPATH=/app family_app_backend pytest tests/test_refresh_endpoint.py -q --no-cov`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/api/routes/auth.py backend/tests/test_refresh_endpoint.py
+git commit -m "feat(auth): POST /api/auth/refresh (typed + token_version checked)"
+```
+
+---
+
+### Task A7: logout + reset-password bump `token_version`
+
+**Files:**
+- Modify: `backend/app/api/routes/auth.py`
+- Test: `backend/tests/test_refresh_endpoint.py` (extend)
+
+- [ ] **Step 1: Add the failing test**
+
+Append to `backend/tests/test_refresh_endpoint.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_logout_invalidates_refresh(client: AsyncClient, db_session, test_parent_user):
+    refresh = create_refresh_token(str(test_parent_user.id), version=test_parent_user.token_version)
+    # Authenticate logout with a valid access token.
+    from app.core.security import create_access_token
+    access = create_access_token({"sub": str(test_parent_user.id)})
+    out = await client.post("/api/auth/logout", headers=_bearer(access))
+    assert out.status_code == 200, out.text
+    # The pre-logout refresh token must now be rejected.
+    resp = await client.post("/api/auth/refresh", headers=_bearer(refresh))
+    assert resp.status_code == 401, resp.text
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `podman exec -e PYTHONPATH=/app family_app_backend pytest tests/test_refresh_endpoint.py::test_logout_invalidates_refresh -q --no-cov`
+Expected: FAIL — logout is a no-op; the old refresh still works.
+
+- [ ] **Step 3: Implement**
+
+Replace the existing `logout` in `backend/app/api/routes/auth.py`:
+
+```python
+@router.post("/logout")
+async def logout(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Log out everywhere: bump token_version so all refresh tokens die."""
+    current_user.token_version += 1
+    await db.commit()
+    return {"message": "Logged out successfully."}
+```
+
+In `reset_password`, after a successful reset, bump the version on the affected user (the `EmailService.reset_password` returns the user):
+```python
+    user = await EmailService.reset_password(db, token, new_hash)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Could not reset password.")
+    user.token_version += 1
+    await db.commit()
+    return {"message": "Password reset successfully. You can now log in."}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `podman exec -e PYTHONPATH=/app family_app_backend pytest tests/test_refresh_endpoint.py -q --no-cov`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/api/routes/auth.py backend/tests/test_refresh_endpoint.py
+git commit -m "feat(auth): logout + password-reset bump token_version (logout-everywhere)"
+```
+
+---
+
+### Task A9: OAuth + invitation return refresh; SessionMiddleware key; env example
+
+**Files:**
+- Modify: `backend/app/services/google_oauth_service.py`, `backend/app/services/invitation_service.py`, `backend/app/main.py`, `backend/.env.gcp.example`
+- Test: `backend/tests/test_google_oauth_audiences.py` (verify existing still passes)
+
+- [ ] **Step 1: Return refresh from OAuth + invitations**
+
+In `google_oauth_service.py` and `invitation_service.py`, wherever `create_access_token(...)` is called and a token is returned to the route, also create a refresh token and include it. Import `create_refresh_token`. Each call site that currently returns `(user, access_token)` (or sets `access_token` on a response) becomes `(user, access_token, create_refresh_token(str(user.id), version=user.token_version))`, and the corresponding route in `auth.py`/`oauth.py`/`invitations.py` puts it in `TokenResponse.refresh_token`.
+
+(Exact line numbers: `google_oauth_service.py:135` and `:202`; `invitation_service.py` — its `create_access_token` call. Update each return + its caller.)
+
+- [ ] **Step 2: SessionMiddleware uses SESSION_SECRET_KEY**
+
+In `backend/app/main.py` (the `SessionMiddleware` registration):
+```python
+app.add_middleware(
+    SessionMiddleware,
+    secret_key=settings.SESSION_SECRET_KEY or settings.SECRET_KEY,
+    ...
+)
+```
+
+- [ ] **Step 3: Document the env var**
+
+In `backend/.env.gcp.example`, add:
+```
+# Distinct signing key for session cookies (do NOT reuse SECRET_KEY).
+SESSION_SECRET_KEY=
+```
+
+- [ ] **Step 4: Run OAuth + auth suites**
+
+Run: `podman exec -e PYTHONPATH=/app family_app_backend pytest tests/test_google_oauth_audiences.py tests/test_auth.py tests/test_email_auth.py -q --no-cov`
+Expected: PASS (no regressions; update any test that asserts the old 2-tuple).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/google_oauth_service.py backend/app/services/invitation_service.py backend/app/main.py backend/.env.gcp.example backend/tests/
+git commit -m "feat(auth): OAuth/invitation issue refresh; split SessionMiddleware key"
+```
+
+---
+
+### Task A10: Backend full-suite regression
+
+- [ ] **Step 1: Run the whole suite**
+
+Run: `podman exec -e PYTHONPATH=/app family_app_backend pytest tests/ -q --no-cov -p no:cacheprovider`
+Expected: all green except the known 10 xfail / 1 xpass baseline. Fix any test that hard-codes the old 7-day TTL or the 2-tuple `authenticate_user` return.
+
+- [ ] **Step 2: Commit any test fixups**
+
+```bash
+git add backend/tests/
+git commit -m "test(auth): update fixtures for access+refresh return shape"
+```
+
+---
+
+## Phase B — Frontend (BFF)
+
+### Task B1: Shared cookie-pair helper
+
+**Files:**
+- Create: `frontend/src/lib/auth-cookies.ts`
+
+- [ ] **Step 1: Create the helper**
+
+`frontend/src/lib/auth-cookies.ts`:
+
+```ts
+const ACCESS_MAX_AGE = 60 * 60;            // 1 hour
+const REFRESH_MAX_AGE = 60 * 60 * 24 * 7;  // 7 days
+
+function buildCookie(
+    name: string,
+    value: string,
+    opts: { maxAge: number; httpOnly?: boolean; secure: boolean }
+): string {
+    let c = `${name}=${encodeURIComponent(value)}`;
+    c += "; Path=/";
+    if (opts.httpOnly) c += "; HttpOnly";
+    if (opts.secure) c += "; Secure";
+    c += "; SameSite=Lax";
+    c += `; Max-Age=${opts.maxAge}`;
+    return c;
+}
+
+/** Set-Cookie header values for the access+refresh pair. Both httpOnly,
+ *  Path=/ so the middleware/proxies (which run on every route) can read the
+ *  refresh cookie to mint a fresh access token. */
+export function authCookies(accessToken: string, refreshToken: string, secure: boolean): string[] {
+    return [
+        buildCookie("access_token", accessToken, { maxAge: ACCESS_MAX_AGE, httpOnly: true, secure }),
+        buildCookie("refresh_token", refreshToken, { maxAge: REFRESH_MAX_AGE, httpOnly: true, secure }),
+    ];
+}
+
+/** Set-Cookie header values that clear both auth cookies (HTTP + HTTPS). */
+export function clearAuthCookies(): string[] {
+    return [
+        "access_token=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0",
+        "access_token=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0; Secure",
+        "refresh_token=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0",
+        "refresh_token=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0; Secure",
+    ];
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `cd frontend && npx astro check 2>&1 | tail -5`
+Expected: no new errors from this file.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/lib/auth-cookies.ts
+git commit -m "feat(auth): shared access+refresh cookie helper"
+```
+
+---
+
+### Task B2: Set both cookies on login/register/oauth/invitation
+
+**Files:**
+- Modify: `frontend/src/pages/api/auth/login.ts`, `register.ts`, `oauth/google.ts`, `invitations/accept.ts`
+
+- [ ] **Step 1: login.ts**
+
+In `frontend/src/pages/api/auth/login.ts`, import the helper and replace the single `tokenCookie` build with the pair. After `const result: LoginResponse = await response.json();`:
+
+```ts
+import { authCookies } from "../../../lib/auth-cookies";
+// ...
+const cookies = authCookies(result.access_token, result.refresh_token, !import.meta.env.DEV);
+```
+
+Then everywhere a `Set-Cookie` was appended with `tokenCookie`, append each entry of `cookies` instead:
+```ts
+for (const c of cookies) headers.append("Set-Cookie", c);
+if (uiRoleCookie) headers.append("Set-Cookie", uiRoleCookie);
+```
+(Keep the `ui_role` logic. `LoginResponse` type gains `refresh_token` — see Step 5.)
+
+- [ ] **Step 2: register.ts** — same change (replace its `buildCookie("access_token", ...)` with `authCookies(result.access_token, result.refresh_token, !import.meta.env.DEV)`; append both).
+
+- [ ] **Step 3: oauth/google.ts** — same change.
+
+- [ ] **Step 4: invitations/accept.ts** — same change.
+
+- [ ] **Step 5: Add refresh_token to the LoginResponse type**
+
+In `frontend/src/types/api.ts`, add `refresh_token: string;` (or `?: string`) to `LoginResponse`.
+
+- [ ] **Step 6: Type-check + manual login smoke**
+
+Run: `cd frontend && npx astro check 2>&1 | tail -5`
+Expected: no new errors. (Functional login verified in Phase C / verify skill.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/pages/api/auth/login.ts frontend/src/pages/api/auth/register.ts frontend/src/pages/api/oauth/google.ts frontend/src/pages/api/invitations/accept.ts frontend/src/types/api.ts
+git commit -m "feat(auth): set access+refresh cookies on all auth entry points"
+```
+
+---
+
+### Task B3: Server-side refresh helper + `/api/auth/refresh` route
+
+**Files:**
+- Create: `frontend/src/lib/server/refresh.ts`, `frontend/src/pages/api/auth/refresh.ts`
+
+- [ ] **Step 1: Refresh helper**
+
+`frontend/src/lib/server/refresh.ts`:
+
+```ts
+import { authCookies } from "../auth-cookies";
+
+const API = () => process.env.API_BASE_URL || process.env.PUBLIC_API_BASE_URL || "http://localhost:8002";
+
+export interface RefreshResult {
+    ok: boolean;
+    accessToken?: string;
+    setCookies?: string[];
+}
+
+/** Exchange a refresh token for a new pair by calling the backend.
+ *  Returns the new access token + Set-Cookie header values on success. */
+export async function refreshAccessToken(refreshToken: string): Promise<RefreshResult> {
+    if (!refreshToken) return { ok: false };
+    const resp = await fetch(`${API()}/api/auth/refresh`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${refreshToken}` },
+    });
+    if (!resp.ok) return { ok: false };
+    const body = await resp.json();
+    return {
+        ok: true,
+        accessToken: body.access_token,
+        setCookies: authCookies(body.access_token, body.refresh_token, !import.meta.env.DEV),
+    };
+}
+
+/** Read a cookie value from a raw Cookie header. */
+export function readCookie(cookieHeader: string, name: string): string | undefined {
+    const m = cookieHeader.match(new RegExp(`(?:^|;\\s*)${name}=([^;]+)`));
+    return m ? decodeURIComponent(m[1]) : undefined;
+}
+```
+
+- [ ] **Step 2: Refresh route**
+
+`frontend/src/pages/api/auth/refresh.ts`:
+
+```ts
+import type { APIRoute } from "astro";
+import { refreshAccessToken } from "../../../lib/server/refresh";
+
+export const POST: APIRoute = async ({ cookies }) => {
+    const refreshToken = cookies.get("refresh_token")?.value ?? "";
+    const result = await refreshAccessToken(refreshToken);
+    if (!result.ok) {
+        return new Response(JSON.stringify({ ok: false }), {
+            status: 401,
+            headers: { "Content-Type": "application/json" },
+        });
+    }
+    const headers = new Headers({ "Content-Type": "application/json" });
+    for (const c of result.setCookies!) headers.append("Set-Cookie", c);
+    return new Response(JSON.stringify({ ok: true }), { status: 200, headers });
+};
+```
+
+- [ ] **Step 3: Type-check**
+
+Run: `cd frontend && npx astro check 2>&1 | tail -5`
+Expected: no new errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/lib/server/refresh.ts frontend/src/pages/api/auth/refresh.ts
+git commit -m "feat(auth): BFF refresh helper + /api/auth/refresh route"
+```
+
+---
+
+### Task B4: Middleware refresh-on-expiry
+
+**Files:**
+- Modify: `frontend/src/middleware.ts`
+
+- [ ] **Step 1: Add a local exp check + refresh before the auth guard**
+
+In `frontend/src/middleware.ts`:
+
+(a) Add `/api/auth/refresh` to `publicRoutes`.
+
+(b) Add a helper near the top of the module:
+```ts
+function isExpired(jwt: string | undefined): boolean {
+    if (!jwt) return true;
+    const parts = jwt.split(".");
+    if (parts.length !== 3) return true;
+    try {
+        const payload = JSON.parse(atob(parts[1].replace(/-/g, "+").replace(/_/g, "/")));
+        if (!payload.exp) return true;
+        // Refresh 30s early to avoid edge races.
+        return Date.now() / 1000 >= payload.exp - 30;
+    } catch {
+        return true;
+    }
+}
+```
+
+(c) Right after the existing `const token = cookies.get("access_token")?.value;` (the protected-route block) and BEFORE the "if (!token) redirect" logic, attempt a refresh when the access token is missing/expired but a refresh cookie exists:
+```ts
+let accessToken = cookies.get("access_token")?.value;
+const refreshToken = cookies.get("refresh_token")?.value;
+let refreshedSetCookies: string[] | undefined;
+
+if (isExpired(accessToken) && refreshToken) {
+    const { refreshAccessToken } = await import("./lib/server/refresh");
+    const r = await refreshAccessToken(refreshToken);
+    if (r.ok) {
+        accessToken = r.accessToken;
+        refreshedSetCookies = r.setCookies;
+        // Make the fresh token visible to this same request's downstream logic.
+        cookies.set("access_token", r.accessToken!, { path: "/", httpOnly: true, sameSite: "lax", secure: !import.meta.env.DEV, maxAge: 3600 });
+    }
+}
+```
+Then use `accessToken` in place of `token` for the remaining missing-token / `/api/auth/me` validation logic. If `accessToken` is still missing/invalid → existing redirect/401 path, but also clear the refresh cookie there (append `clearAuthCookies()` to the response, import it).
+
+(d) Ensure the final `const response = await next();` path appends `refreshedSetCookies` (if set) so the browser stores the rotated cookies:
+```ts
+const response = await next();
+if (refreshedSetCookies) for (const c of refreshedSetCookies) response.headers.append("Set-Cookie", c);
+return response;
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `cd frontend && npx astro check 2>&1 | tail -5`
+Expected: no new errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/middleware.ts
+git commit -m "feat(auth): middleware transparently refreshes expired access tokens"
+```
+
+---
+
+### Task B5: Proxy routes refresh-once-on-401
+
+**Files:**
+- Modify: each `frontend/src/pages/api/*/[...path].ts`
+
+- [ ] **Step 1: Add a shared retry wrapper**
+
+In `frontend/src/lib/server/refresh.ts`, add:
+```ts
+/** If a backend response is 401 and a refresh token is present, refresh once
+ *  and let the caller retry with the new access token. Returns the new token
+ *  + Set-Cookie list, or null if refresh isn't possible. */
+export async function tryRefreshFor401(
+    status: number,
+    cookieHeader: string
+): Promise<{ accessToken: string; setCookies: string[] } | null> {
+    if (status !== 401) return null;
+    const refreshToken = readCookie(cookieHeader, "refresh_token");
+    if (!refreshToken) return null;
+    const r = await refreshAccessToken(refreshToken);
+    if (!r.ok) return null;
+    return { accessToken: r.accessToken!, setCookies: r.setCookies! };
+}
+```
+
+- [ ] **Step 2: Wire one proxy route, then replicate**
+
+In `frontend/src/pages/api/budget/[...path].ts` (the canonical proxy), after the first backend fetch, if the response is 401, call `tryRefreshFor401`, and on success re-issue the backend fetch with the new `Authorization: Bearer <accessToken>`, then append `setCookies` to the returned response. Replicate the identical block in every other `*/[...path].ts` proxy (`gigs`, `calendar`, `chat`, `dm`, `jarvis`, `meals`, `kiosk`, `task-templates`, `subscriptions`, `analytics`). Since these files are near-identical, the cleanest path is to extract the proxy body into a shared `frontend/src/lib/server/proxy.ts` and have each route call it — do that if the files already share a copy-pasted shape.
+
+- [ ] **Step 3: Type-check**
+
+Run: `cd frontend && npx astro check 2>&1 | tail -5`
+Expected: no new errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/lib/server/refresh.ts frontend/src/pages/api/
+git commit -m "feat(auth): proxy routes refresh once on backend 401 and retry"
+```
+
+---
+
+### Task B6: Logout calls backend + clears both cookies
+
+**Files:**
+- Modify: `frontend/src/pages/api/auth/logout.ts`
+
+- [ ] **Step 1: Implement**
+
+```ts
+import type { APIRoute } from "astro";
+import { clearAuthCookies } from "../../../lib/auth-cookies";
+
+export const POST: APIRoute = async ({ cookies }) => {
+    // Bump token_version server-side (logout-everywhere) before clearing cookies.
+    const access = cookies.get("access_token")?.value;
+    if (access) {
+        const api = process.env.API_BASE_URL || process.env.PUBLIC_API_BASE_URL || "http://localhost:8002";
+        try {
+            await fetch(`${api}/api/auth/logout`, { method: "POST", headers: { Authorization: `Bearer ${access}` } });
+        } catch { /* best-effort; still clear cookies below */ }
+    }
+    const headers = new Headers({ Location: "/login" });
+    for (const c of clearAuthCookies()) headers.append("Set-Cookie", c);
+    headers.append("Set-Cookie", "ui_role=; Path=/; SameSite=Lax; Max-Age=0");
+    headers.append("Set-Cookie", "ui_role=; Path=/; SameSite=Lax; Max-Age=0; Secure");
+    return new Response(null, { status: 302, headers });
+};
+```
+
+- [ ] **Step 2: Type-check + commit**
+
+Run: `cd frontend && npx astro check 2>&1 | tail -5`
+```bash
+git add frontend/src/pages/api/auth/logout.ts
+git commit -m "feat(auth): logout bumps server token_version + clears both cookies"
+```
+
+---
+
+## Phase C — E2E + verification
+
+### Task C1: E2E — transparent refresh + logout revocation
+
+**Files:**
+- Create: `e2e-tests/tests/auth-refresh.spec.ts`
+
+- [ ] **Step 1: Write the E2E test**
+
+`e2e-tests/tests/auth-refresh.spec.ts` (follow the existing suite's login helper + base URL conventions):
+
+```ts
+import { test, expect } from "@playwright/test";
+import { login } from "./helpers"; // use the suite's existing login helper
+
+test("expired access token is transparently refreshed", async ({ page, context }) => {
+    await login(page); // lands authenticated on /dashboard
+    // Force the access token to look expired by deleting only it; refresh cookie remains.
+    const cookies = await context.cookies();
+    const others = cookies.filter((c) => c.name !== "access_token");
+    await context.clearCookies();
+    await context.addCookies(others);
+    // Navigate to a protected page — middleware should refresh, not bounce to /login.
+    await page.goto("/dashboard");
+    await expect(page).toHaveURL(/\/dashboard/);
+    const after = await context.cookies();
+    expect(after.find((c) => c.name === "access_token")).toBeTruthy();
+});
+
+test("logout invalidates the refresh token", async ({ page, context }) => {
+    await login(page);
+    const before = await context.cookies();
+    const refresh = before.find((c) => c.name === "refresh_token")!.value;
+    await page.request.post("/api/auth/logout");
+    // Re-plant the old refresh cookie and try to refresh — backend must 401.
+    await context.addCookies([{ name: "refresh_token", value: refresh, url: page.url() }]);
+    const resp = await page.request.post("/api/auth/refresh");
+    expect(resp.status()).toBe(401);
+});
+```
+
+- [ ] **Step 2: Run E2E (requires the dev stack up + frontend rebuilt)**
+
+Run: `cd e2e-tests && npm run test -- auth-refresh.spec.ts`
+Expected: 2 passed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e-tests/tests/auth-refresh.spec.ts
+git commit -m "test(e2e): transparent refresh + logout revocation"
+```
+
+---
+
+### Task C2: Manual verification via the `verify` skill
+
+- [ ] **Step 1:** Rebuild the frontend image + bring the stack up; log in through the browser; confirm normal navigation works, then wait past 1h (or temporarily set `ACCESS_TOKEN_EXPIRE_MINUTES=1` in a scratch env) and confirm a protected page still loads without a login bounce, and that logout from one session blocks refresh.
+
+- [ ] **Step 2:** Confirm a legacy 7-day `access_token` cookie (mint one with the old TTL + no `type`) still authenticates (backward-compat grace).
+
+---
+
+## Self-Review
+
+**Spec coverage:** access(1h)+refresh(7d) → A1/A3/A5; token_version revocation → A2/A6/A7; /auth/refresh → A6; rotation → A6 (issues new pair); backward-compat grace → A3/A4 (missing type = access); SESSION_SECRET_KEY split → A1/A9; BFF two-cookie + refresh + proxy retry + logout → B1–B6; tests → A2/A3/A4/A5/A6/A7 + C1. All spec sections covered.
+
+**Placeholder scan:** Proxy-route replication (B5) names the exact routes and recommends extracting `proxy.ts`; OAuth/invitation edits (A9) cite the call-site line numbers. No "TBD"/"handle edge cases".
+
+**Type consistency:** `authenticate_user` → 3-tuple (A5) consumed in login (A5) and asserted (A5 test); `create_refresh_token(sub, version)` signature used identically in A3/A5/A6; `TokenResponse.refresh_token` (A8) used by A5/A6/A9; `authCookies(access, refresh, secure)` / `clearAuthCookies()` used consistently in B1/B2/B3/B6; `refreshAccessToken`/`readCookie`/`tryRefreshFor401` defined in B3/B5 and used in B4/B5.

--- a/docs/superpowers/specs/2026-06-15-jwt-access-refresh-design.md
+++ b/docs/superpowers/specs/2026-06-15-jwt-access-refresh-design.md
@@ -1,0 +1,196 @@
+# JWT Access + Refresh Tokens — Design
+
+**Date:** 2026-06-15
+**Status:** Approved (design); pending implementation
+**Audit item:** Bucket 1, #4 (HIGH) — from `docs/audit/2026-06-04/05-verified-prioritized.md`
+
+## Problem
+
+Today the app issues a single JWT (`access_token`) with a **7-day** lifetime
+(`ACCESS_TOKEN_EXPIRE_MINUTES = 10080`, `backend/app/core/config.py:33`) and **no
+revocation** — `POST /api/auth/logout` (`backend/app/api/routes/auth.py:234`) is a
+no-op that returns a message; the token stays valid for the full 7 days after
+"logout". Separately, `SessionMiddleware` reuses `settings.SECRET_KEY`
+(`backend/app/main.py:165`) for cookie signing — the same key that signs JWTs (crypto
+hygiene: one key, two purposes).
+
+A leaked 7-day token is usable for a week with no kill switch.
+
+## Goal
+
+- Short-lived **access** token (1h) + longer **refresh** token (7d, rotating).
+- Real revocation on logout and password reset (logout-everywhere).
+- Separate signing key for `SessionMiddleware`.
+- No forced mass logout on deploy; no new infra dependency (no Redis-for-auth).
+
+## Architecture context (why this is small)
+
+The frontend is a **Backend-For-Frontend (BFF)**. The browser never holds the JWT:
+
+- Astro server routes (`frontend/src/pages/api/auth/*.ts`) set an **httpOnly**
+  `access_token` cookie. The 4 setters duplicate a `buildCookie()` helper
+  (`login.ts`, `register.ts`, `oauth/google.ts`, `invitations/accept.ts`).
+- All browser → backend API calls funnel through Astro proxy routes
+  (`frontend/src/pages/api/*/[...path].ts`) which read the httpOnly cookie
+  server-side and inject `Authorization: Bearer <token>`. SSR pages read
+  `Astro.cookies.get("access_token")` and pass it to `lib/api.ts::apiFetch`.
+- `middleware.ts` guards protected routes: for `/api/*` it validates the token by
+  calling backend `/api/auth/me`; on 401/403 it deletes the cookie; on 5xx it
+  returns 503 without deleting.
+- Backend `get_current_user` (`backend/app/core/dependencies.py:14`) reads the token
+  from the `Authorization` header via `oauth2_scheme`, decodes it, uses `sub` as the
+  user id. The backend never reads a cookie for the JWT.
+
+Because the refresh token is httpOnly and only ever travels between the Astro
+server and the backend (never to browser JS), XSS cannot exfiltrate it. Refresh
+logic centralizes at the BFF layer (middleware + proxy routes).
+
+## Design
+
+### Token model
+
+| Token   | TTL | Claims |
+|---------|-----|--------|
+| access  | 60 min | `{sub, role, family_id, type:"access", exp}` |
+| refresh | 7 days | `{sub, ver, type:"refresh", jti, exp}` |
+
+- `jti` (uuid4) is for log correlation only — **not** stored.
+- `ver` is the user's `token_version` at issue time.
+
+### Revocation: `token_version` column
+
+- New column `User.token_version: int` (NOT NULL, default 0). One Alembic migration.
+- The refresh token embeds `ver = user.token_version`.
+- `POST /api/auth/refresh` rejects the refresh token if `ver != user.token_version`.
+- **Logout** and **password-reset** do `user.token_version += 1` → every existing
+  refresh token for that user is instantly invalid (logout-everywhere). No Redis,
+  no per-token store.
+
+### Rotation
+
+Each successful `/api/auth/refresh` issues a **new access token AND a new refresh
+token** (sliding 7-day window), both stamped with the current `token_version`. The
+prior refresh token remains valid until its own `exp` or until `token_version` is
+bumped — there is no per-token invalidation (that was the declined Redis option).
+
+### Backward compatibility (no mass logout on deploy)
+
+Existing 7-day `access_token` cookies in the wild have no `type` claim.
+`get_current_user` accepts `type in {"access", None}` — a missing `type` is treated
+as a legacy access token. New logins immediately get the access+refresh pair; legacy
+tokens expire within ≤7 days naturally. (A later change can enforce `type=="access"`
+strictly once legacy tokens have aged out.)
+
+### Session key split
+
+Add `SESSION_SECRET_KEY` setting. `SessionMiddleware` uses it. It **defaults to
+`SECRET_KEY`** when unset so dev/existing envs don't break; production `.env` sets a
+distinct value. (`.env.gcp.example` updated to include it.)
+
+## Components & changes
+
+### Backend
+
+- `core/config.py`: `ACCESS_TOKEN_EXPIRE_MINUTES` → `60`; add
+  `REFRESH_TOKEN_EXPIRE_DAYS = 7`, `SESSION_SECRET_KEY: str = ""`.
+- `core/security.py`:
+  - `create_access_token(data)` adds `type:"access"`.
+  - new `create_refresh_token(sub: str, version: int) -> str` (type:"refresh", ver,
+    jti, 7d).
+  - `decode_token(token, expected_type: str | None = None)` — when
+    `expected_type` set, raise 401 on mismatch (treating missing type as "access").
+- `core/dependencies.py::get_current_user`: decode with `expected_type="access"`
+  (which permits legacy no-type tokens).
+- `models/user.py`: `token_version` column + Alembic migration
+  (`backend/migrations/versions/`).
+- `services/auth_service.py`: `authenticate_user` returns `(user, access, refresh)`.
+- `services/google_oauth_service.py`, `services/invitation_service.py`: return a
+  refresh token alongside access.
+- `api/routes/auth.py`:
+  - `login` / oauth / invitation responses include `refresh_token`.
+  - **new `POST /api/auth/refresh`** — input: refresh token (from `Authorization:
+    Bearer` supplied by the BFF refresh route); validates sig + exp + `type=="refresh"`
+    + `ver == user.token_version`; returns new `{access_token, refresh_token}`.
+  - `logout` (now takes db): `user.token_version += 1`, commit.
+  - `reset-password`: bump `token_version` on the affected user.
+- `schemas`: `TokenResponse` (+ refresh response schema) gains `refresh_token`.
+- `main.py`: `SessionMiddleware(secret_key=settings.SESSION_SECRET_KEY or settings.SECRET_KEY)`.
+
+### Frontend (BFF)
+
+- New `lib/auth-cookies.ts`: single helper that sets BOTH httpOnly cookies —
+  `access_token` (Max-Age 3600) and `refresh_token` (Max-Age 604800, `Path=/api/auth`
+  scope so it's only sent to auth routes). Replaces the 4 `buildCookie()` copies in
+  `login.ts`, `register.ts`, `oauth/google.ts`, `invitations/accept.ts`.
+- New `pages/api/auth/refresh.ts`: reads the `refresh_token` cookie, calls backend
+  `POST /api/auth/refresh` (Bearer = refresh token), sets the new cookie pair, returns
+  `{ok}`.
+- `middleware.ts`: add a refresh step **before** the existing validation. Cheaply
+  read the access token's `exp` (base64-decode payload, no signature check — backend
+  still verifies) — if absent or expired/near-expiry, call the refresh route using the
+  `refresh_token` cookie and set a fresh `access_token` before continuing. The
+  existing `/api/auth/me` validation + `context.locals.user`/`plan` population for
+  `/api/*` routes is unchanged. On refresh failure → delete both cookies → redirect
+  `/login` (pages) or 401 (api).
+- Proxy routes (`pages/api/*/[...path].ts`): shared helper — on a backend 401, call
+  the refresh route once, then retry the original request with the new token; if
+  refresh fails, surface 401.
+- `pages/api/auth/logout.ts`: call backend `/api/auth/logout` (to bump
+  `token_version`) and clear BOTH cookies.
+
+## Data flow
+
+1. **Login** → backend returns `{access_token(1h), refresh_token(7d)}` → BFF sets two
+   httpOnly cookies.
+2. **Normal request** → access token valid → proxy/SSR attaches it → backend serves.
+3. **Access expired** → middleware (page) or proxy (api 401) calls
+   `/api/auth/refresh` with the refresh cookie → backend checks `ver` → returns a new
+   pair → BFF sets cookies → request proceeds. Transparent to the user.
+4. **Logout / password reset** → `token_version++` → all refresh tokens fail the
+   `ver` check → next refresh attempt 401 → user re-authenticates.
+
+## Error handling
+
+- Refresh with wrong `type`, bad signature, expired, or stale `ver` → 401 from
+  `/api/auth/refresh`; BFF clears cookies and redirects to `/login`.
+- Backend 5xx during refresh → BFF surfaces 503 without clearing cookies (mirrors the
+  existing middleware policy so a deploy blip doesn't log everyone out).
+- Refresh-loop guard: the BFF attempts refresh at most once per request.
+
+## Testing
+
+### Backend (pytest, TDD)
+
+- `create_access_token` stamps `type:"access"`; `create_refresh_token` stamps
+  `type:"refresh"` + `ver` + 7d exp.
+- `get_current_user` accepts access + legacy(no-type); rejects a refresh token.
+- `POST /api/auth/refresh`: happy path returns a new pair; rejects wrong-type token,
+  expired token, and stale `ver` (after a `token_version` bump).
+- `logout` increments `token_version` and invalidates outstanding refresh tokens
+  (subsequent `/refresh` → 401).
+- password-reset bumps `token_version`.
+
+### E2E (Playwright)
+
+- Expired access + valid refresh → protected page loads with no `/login` bounce, and
+  a new `access_token` cookie is set.
+- Logout → a saved refresh token can no longer mint an access token (`/refresh` 401).
+
+## Out of scope / non-goals
+
+- Per-token (single-session) revocation and refresh-reuse theft detection (the Redis
+  `jti`-store option) — explicitly declined.
+- Migrating the backend to read the JWT from a cookie — it continues to read the
+  `Authorization` header (the BFF supplies it).
+- Touching the `ui_role` cookie or the SSR theming flow.
+
+## Files touched (summary)
+
+Backend: `config.py`, `security.py`, `dependencies.py`, `models/user.py`, a new
+migration, `services/auth_service.py`, `services/google_oauth_service.py`,
+`services/invitation_service.py`, `api/routes/auth.py`, `schemas` (token), `main.py`,
+`.env.gcp.example`.
+
+Frontend: new `lib/auth-cookies.ts`, new `pages/api/auth/refresh.ts`, `middleware.ts`,
+`pages/api/auth/login.ts`, `register.ts`, `oauth/google.ts`, `invitations/accept.ts`,
+`logout.ts`, and the proxy routes `pages/api/*/[...path].ts`.

--- a/e2e-tests/auth-refresh.spec.js
+++ b/e2e-tests/auth-refresh.spec.js
@@ -1,0 +1,46 @@
+const { test, expect } = require('@playwright/test');
+const { loginAsParent, BASE_URL } = require('./helpers/auth');
+
+test.describe('JWT access + refresh', () => {
+  test('expired access token is transparently refreshed (no login bounce)', async ({ page, context }) => {
+    await loginAsParent(page);
+    await expect(page).toHaveURL(/\/dashboard/);
+
+    // Simulate an expired/absent access token while keeping the refresh cookie:
+    // drop only access_token, leave refresh_token in place.
+    const cookies = await context.cookies();
+    expect(cookies.find((c) => c.name === 'refresh_token')).toBeTruthy();
+    const kept = cookies.filter((c) => c.name !== 'access_token');
+    await context.clearCookies();
+    await context.addCookies(kept);
+
+    // Navigating to a protected page must refresh in middleware, not redirect.
+    await page.goto(`${BASE_URL}/dashboard`);
+    await expect(page).toHaveURL(/\/dashboard/);
+
+    const after = await context.cookies();
+    expect(after.find((c) => c.name === 'access_token')).toBeTruthy();
+  });
+
+  test('logout invalidates the refresh token (logout-everywhere)', async ({ page, context }) => {
+    await loginAsParent(page);
+    const before = await context.cookies();
+    const refresh = before.find((c) => c.name === 'refresh_token');
+    expect(refresh).toBeTruthy();
+
+    // Log out (bumps server token_version), then replant the old refresh token.
+    await page.request.post(`${BASE_URL}/api/auth/logout`);
+    await context.clearCookies();
+    await context.addCookies([{ name: 'refresh_token', value: refresh.value, url: BASE_URL }]);
+
+    // The BFF refresh route must now fail — the old refresh token is revoked.
+    const resp = await page.request.post(`${BASE_URL}/api/auth/refresh`);
+    expect(resp.status()).toBe(401);
+  });
+
+  test('no cookies redirects to login', async ({ page, context }) => {
+    await context.clearCookies();
+    await page.goto(`${BASE_URL}/dashboard`);
+    await expect(page).toHaveURL(/\/login/);
+  });
+});

--- a/frontend/src/lib/auth-cookies.ts
+++ b/frontend/src/lib/auth-cookies.ts
@@ -1,0 +1,36 @@
+const ACCESS_MAX_AGE = 60 * 60;            // 1 hour
+const REFRESH_MAX_AGE = 60 * 60 * 24 * 7;  // 7 days
+
+function buildCookie(
+    name: string,
+    value: string,
+    opts: { maxAge: number; httpOnly?: boolean; secure: boolean }
+): string {
+    let c = `${name}=${encodeURIComponent(value)}`;
+    c += "; Path=/";
+    if (opts.httpOnly) c += "; HttpOnly";
+    if (opts.secure) c += "; Secure";
+    c += "; SameSite=Lax";
+    c += `; Max-Age=${opts.maxAge}`;
+    return c;
+}
+
+/** Set-Cookie header values for the access+refresh pair. Both httpOnly,
+ *  Path=/ so the middleware/proxies (which run on every route) can read the
+ *  refresh cookie to mint a fresh access token. */
+export function authCookies(accessToken: string, refreshToken: string, secure: boolean): string[] {
+    return [
+        buildCookie("access_token", accessToken, { maxAge: ACCESS_MAX_AGE, httpOnly: true, secure }),
+        buildCookie("refresh_token", refreshToken, { maxAge: REFRESH_MAX_AGE, httpOnly: true, secure }),
+    ];
+}
+
+/** Set-Cookie header values that clear both auth cookies (HTTP + HTTPS). */
+export function clearAuthCookies(): string[] {
+    return [
+        "access_token=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0",
+        "access_token=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0; Secure",
+        "refresh_token=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0",
+        "refresh_token=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0; Secure",
+    ];
+}

--- a/frontend/src/lib/server/refresh.ts
+++ b/frontend/src/lib/server/refresh.ts
@@ -30,3 +30,18 @@ export function readCookie(cookieHeader: string, name: string): string | undefin
     const m = cookieHeader.match(new RegExp(`(?:^|;\\s*)${name}=([^;]+)`));
     return m ? decodeURIComponent(m[1]) : undefined;
 }
+
+/** If a backend response is 401 and a refresh token is present, refresh once
+ *  and let the caller retry with the new access token. Returns the new token
+ *  + Set-Cookie list, or null if refresh isn't possible. */
+export async function tryRefreshFor401(
+    status: number,
+    cookieHeader: string
+): Promise<{ accessToken: string; setCookies: string[] } | null> {
+    if (status !== 401) return null;
+    const refreshToken = readCookie(cookieHeader, "refresh_token");
+    if (!refreshToken) return null;
+    const r = await refreshAccessToken(refreshToken);
+    if (!r.ok) return null;
+    return { accessToken: r.accessToken!, setCookies: r.setCookies! };
+}

--- a/frontend/src/lib/server/refresh.ts
+++ b/frontend/src/lib/server/refresh.ts
@@ -1,0 +1,32 @@
+import { authCookies } from "../auth-cookies";
+
+const API = () => process.env.API_BASE_URL || process.env.PUBLIC_API_BASE_URL || "http://localhost:8002";
+
+export interface RefreshResult {
+    ok: boolean;
+    accessToken?: string;
+    setCookies?: string[];
+}
+
+/** Exchange a refresh token for a new pair by calling the backend.
+ *  Returns the new access token + Set-Cookie header values on success. */
+export async function refreshAccessToken(refreshToken: string): Promise<RefreshResult> {
+    if (!refreshToken) return { ok: false };
+    const resp = await fetch(`${API()}/api/auth/refresh`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${refreshToken}` },
+    });
+    if (!resp.ok) return { ok: false };
+    const body = await resp.json();
+    return {
+        ok: true,
+        accessToken: body.access_token,
+        setCookies: authCookies(body.access_token, body.refresh_token, !import.meta.env.DEV),
+    };
+}
+
+/** Read a cookie value from a raw Cookie header. */
+export function readCookie(cookieHeader: string, name: string): string | undefined {
+    const m = cookieHeader.match(new RegExp(`(?:^|;\\s*)${name}=([^;]+)`));
+    return m ? decodeURIComponent(m[1]) : undefined;
+}

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -2,6 +2,24 @@ import { defineMiddleware } from "astro:middleware";
 import type { User } from "./types/api";
 
 /**
+ * Decode a JWT locally and decide whether it is expired (or unusable).
+ * Refreshes 30s early to avoid edge races near the boundary.
+ */
+function isExpired(jwt: string | undefined): boolean {
+    if (!jwt) return true;
+    const parts = jwt.split(".");
+    if (parts.length !== 3) return true;
+    try {
+        const payload = JSON.parse(atob(parts[1].replace(/-/g, "+").replace(/_/g, "/")));
+        if (!payload.exp) return true;
+        // Refresh 30s early to avoid edge races.
+        return Date.now() / 1000 >= payload.exp - 30;
+    } catch {
+        return true;
+    }
+}
+
+/**
  * Middleware for authentication checks and request logging
  */
 export const onRequest = defineMiddleware(async (context, next) => {
@@ -73,6 +91,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
         "/help",   // English user guide — linked from welcome email
         "/ayuda",  // Spanish user guide — linked from welcome email
         "/api/auth/login",
+        "/api/auth/refresh",  // BFF refresh route — callable even when the access token is dead
         "/api/auth/register",  // Frontend API route for registration (calls backend /api/auth/register-family)
         "/api/auth/register-family",  // Backend API route (for direct calls)
         "/api/auth/verify-email",
@@ -112,9 +131,31 @@ export const onRequest = defineMiddleware(async (context, next) => {
     }
 
     // Check authentication for protected routes
-    const token = cookies.get("access_token")?.value;
-    
-    if (!token) {
+    let accessToken = cookies.get("access_token")?.value;
+    const refreshToken = cookies.get("refresh_token")?.value;
+    let refreshedSetCookies: string[] | undefined;
+
+    // Transparently refresh the access token when it's missing/expired but a
+    // refresh cookie is present. Runs BEFORE the missing-token guard so a dead
+    // access token does not bounce the user to /login if the refresh succeeds.
+    if (isExpired(accessToken) && refreshToken) {
+        const { refreshAccessToken } = await import("./lib/server/refresh");
+        const r = await refreshAccessToken(refreshToken);
+        if (r.ok) {
+            accessToken = r.accessToken;
+            refreshedSetCookies = r.setCookies;
+            // Make the fresh token visible to this same request's downstream logic.
+            cookies.set("access_token", r.accessToken!, {
+                path: "/",
+                httpOnly: true,
+                sameSite: "lax",
+                secure: !import.meta.env.DEV,
+                maxAge: 3600,
+            });
+        }
+    }
+
+    if (!accessToken) {
         // Plain log works for both dev and prod. The previous prod branch
         // tried to enumerate cookies via `[...cookies]`, but AstroCookies
         // isn't iterable in the Astro 5 prod SSR build and the spread
@@ -122,14 +163,20 @@ export const onRequest = defineMiddleware(async (context, next) => {
         // unauthenticated request to a protected route into a 500 instead
         // of the intended 302 redirect to /login.
         console.log(`No access_token for protected route: ${path}`);
+        // The refresh cookie (if any) is stale/unusable — clear both cookies.
+        const { clearAuthCookies } = await import("./lib/auth-cookies");
         // Redirect to login for HTML pages
         if (!path.startsWith("/api/")) {
-            return redirect("/login", 302);
+            const response = redirect("/login", 302);
+            for (const c of clearAuthCookies()) response.headers.append("Set-Cookie", c);
+            return response;
         }
         // Return 401 for API routes
+        const headers = new Headers({ "Content-Type": "application/json" });
+        for (const c of clearAuthCookies()) headers.append("Set-Cookie", c);
         return new Response(
             JSON.stringify({ detail: "Unauthorized" }),
-            { status: 401, headers: { "Content-Type": "application/json" } }
+            { status: 401, headers }
         );
     }
 
@@ -140,7 +187,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
             const apiUrl = process.env.API_BASE_URL || process.env.PUBLIC_API_BASE_URL || "http://localhost:8002";
             const response = await fetch(`${apiUrl}/api/auth/me`, {
                 headers: {
-                    "Authorization": `Bearer ${token}`,
+                    "Authorization": `Bearer ${accessToken}`,
                 },
             });
 
@@ -151,10 +198,14 @@ export const onRequest = defineMiddleware(async (context, next) => {
                 // user's token may be perfectly valid. Surface a 503 without
                 // wiping the cookie so the user can retry.
                 if (response.status === 401 || response.status === 403) {
-                    cookies.delete("access_token", { path: "/" });
+                    // The (possibly just-refreshed) access token is still
+                    // rejected — clear both cookies so the client re-auths.
+                    const { clearAuthCookies } = await import("./lib/auth-cookies");
+                    const headers = new Headers({ "Content-Type": "application/json" });
+                    for (const c of clearAuthCookies()) headers.append("Set-Cookie", c);
                     return new Response(
                         JSON.stringify({ detail: "Invalid or expired token" }),
-                        { status: 401, headers: { "Content-Type": "application/json" } }
+                        { status: 401, headers }
                     );
                 }
                 return new Response(
@@ -170,12 +221,12 @@ export const onRequest = defineMiddleware(async (context, next) => {
             
             // Attach user to context for use in endpoints
             context.locals.user = user;
-            context.locals.token = token;
+            context.locals.token = accessToken;
 
             // Fetch family plan for premium gating
             try {
                 const planResponse = await fetch(`${apiUrl}/api/subscriptions/current`, {
-                    headers: { "Authorization": `Bearer ${token}` },
+                    headers: { "Authorization": `Bearer ${accessToken}` },
                 });
                 if (planResponse.ok) {
                     context.locals.plan = await planResponse.json();
@@ -199,5 +250,11 @@ export const onRequest = defineMiddleware(async (context, next) => {
         }
     }
 
-    return next();
+    const response = await next();
+    // Persist the rotated access+refresh cookies (if we refreshed above) so the
+    // browser stores the new pair for subsequent requests.
+    if (refreshedSetCookies) {
+        for (const c of refreshedSetCookies) response.headers.append("Set-Cookie", c);
+    }
+    return response;
 });

--- a/frontend/src/pages/api/analytics/[...path].ts
+++ b/frontend/src/pages/api/analytics/[...path].ts
@@ -1,4 +1,5 @@
 import type { APIRoute } from "astro";
+import { tryRefreshFor401 } from "../../../lib/server/refresh";
 
 const BACKEND_URL = process.env.API_BASE_URL || process.env.PUBLIC_API_BASE_URL || "http://localhost:8002";
 
@@ -22,14 +23,27 @@ async function proxy({ request, params }: { request: Request; params: Record<str
     const hasBody = !["GET", "HEAD"].includes(request.method.toUpperCase());
     const body = hasBody ? await request.arrayBuffer() : undefined;
     try {
-        const res = await fetch(backendUrl, {
+        let res = await fetch(backendUrl, {
             method: request.method, headers: forwardHeaders, body, redirect: "manual",
         });
+        // Transparently refresh once if the access token expired mid-request.
+        let refreshedSetCookies: string[] | undefined;
+        if (res.status === 401) {
+            const refreshed = await tryRefreshFor401(res.status, request.headers.get("cookie") ?? "");
+            if (refreshed) {
+                forwardHeaders.set("Authorization", `Bearer ${refreshed.accessToken}`);
+                res = await fetch(backendUrl, {
+                    method: request.method, headers: forwardHeaders, body, redirect: "manual",
+                });
+                refreshedSetCookies = refreshed.setCookies;
+            }
+        }
         const out = new Headers();
         for (const [k, v] of res.headers.entries()) {
             if (k.toLowerCase() === "transfer-encoding") continue;
             out.set(k, v);
         }
+        if (refreshedSetCookies) for (const c of refreshedSetCookies) out.append("Set-Cookie", c);
         return new Response(res.body, { status: res.status, statusText: res.statusText, headers: out });
     } catch (e: any) {
         return new Response(JSON.stringify({ error: "proxy_error", message: String(e?.message ?? e) }),

--- a/frontend/src/pages/api/auth/login.ts
+++ b/frontend/src/pages/api/auth/login.ts
@@ -1,5 +1,6 @@
 import type { APIRoute } from "astro";
 import type { LoginResponse, ApiError } from "../../../types/api";
+import { authCookies } from "../../../lib/auth-cookies";
 
 /**
  * Helper to build a Set-Cookie header string.
@@ -71,13 +72,7 @@ export const POST: APIRoute = async ({ request }) => {
         if (response.ok) {
             const result: LoginResponse = await response.json();
 
-            const tokenCookie = buildCookie("access_token", result.access_token, {
-                path: "/",
-                httpOnly: true,
-                sameSite: "Lax",
-                maxAge: 60 * 60 * 24 * 7, // 7 days
-                secure: !import.meta.env.DEV, // Only secure in production
-            });
+            const cookies = authCookies(result.access_token, result.refresh_token, !import.meta.env.DEV);
 
             // Stash role for UI theming (W4.2). Non-httpOnly so the
             // Astro server-side Layout can read it on subsequent renders.
@@ -105,7 +100,7 @@ export const POST: APIRoute = async ({ request }) => {
             if (isJsonRequest) {
                 // For fetch-based login: return JSON + Set-Cookie header
                 const headers = new Headers({ "Content-Type": "application/json" });
-                headers.append("Set-Cookie", tokenCookie);
+                for (const c of cookies) headers.append("Set-Cookie", c);
                 if (uiRoleCookie) headers.append("Set-Cookie", uiRoleCookie);
                 return new Response(
                     JSON.stringify({ success: true, redirect: "/dashboard" }),
@@ -115,7 +110,7 @@ export const POST: APIRoute = async ({ request }) => {
 
             // For native form POST: manually construct redirect with cookie
             const headers = new Headers({ Location: "/dashboard" });
-            headers.append("Set-Cookie", tokenCookie);
+            for (const c of cookies) headers.append("Set-Cookie", c);
             if (uiRoleCookie) headers.append("Set-Cookie", uiRoleCookie);
             return new Response(null, { status: 302, headers });
         } else {

--- a/frontend/src/pages/api/auth/logout.ts
+++ b/frontend/src/pages/api/auth/logout.ts
@@ -1,14 +1,22 @@
 import type { APIRoute } from "astro";
+import { clearAuthCookies } from "../../../lib/auth-cookies";
 
 /**
  * POST /api/auth/logout
- * Logs out a user by deleting the access_token cookie
+ * Best-effort revokes the session server-side (bumps token_version,
+ * logging out everywhere), then clears both auth cookies + ui_role.
  */
-export const POST: APIRoute = async ({ request }) => {
-    // Delete cookie both with and without Secure flag to handle HTTP and HTTPS environments
+export const POST: APIRoute = async ({ cookies }) => {
+    // Bump token_version server-side (logout-everywhere) before clearing cookies.
+    const access = cookies.get("access_token")?.value;
+    if (access) {
+        const api = process.env.API_BASE_URL || process.env.PUBLIC_API_BASE_URL || "http://localhost:8002";
+        try {
+            await fetch(`${api}/api/auth/logout`, { method: "POST", headers: { Authorization: `Bearer ${access}` } });
+        } catch { /* best-effort; still clear cookies below */ }
+    }
     const headers = new Headers({ Location: "/login" });
-    headers.append("Set-Cookie", "access_token=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0");
-    headers.append("Set-Cookie", "access_token=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0; Secure");
+    for (const c of clearAuthCookies()) headers.append("Set-Cookie", c);
     headers.append("Set-Cookie", "ui_role=; Path=/; SameSite=Lax; Max-Age=0");
     headers.append("Set-Cookie", "ui_role=; Path=/; SameSite=Lax; Max-Age=0; Secure");
     return new Response(null, { status: 302, headers });

--- a/frontend/src/pages/api/auth/refresh.ts
+++ b/frontend/src/pages/api/auth/refresh.ts
@@ -1,0 +1,16 @@
+import type { APIRoute } from "astro";
+import { refreshAccessToken } from "../../../lib/server/refresh";
+
+export const POST: APIRoute = async ({ cookies }) => {
+    const refreshToken = cookies.get("refresh_token")?.value ?? "";
+    const result = await refreshAccessToken(refreshToken);
+    if (!result.ok) {
+        return new Response(JSON.stringify({ ok: false }), {
+            status: 401,
+            headers: { "Content-Type": "application/json" },
+        });
+    }
+    const headers = new Headers({ "Content-Type": "application/json" });
+    for (const c of result.setCookies!) headers.append("Set-Cookie", c);
+    return new Response(JSON.stringify({ ok: true }), { status: 200, headers });
+};

--- a/frontend/src/pages/api/auth/register.ts
+++ b/frontend/src/pages/api/auth/register.ts
@@ -1,20 +1,6 @@
 import type { APIRoute } from "astro";
-
-function buildCookie(name: string, value: string, options: {
-    path?: string;
-    httpOnly?: boolean;
-    sameSite?: string;
-    maxAge?: number;
-    secure?: boolean;
-}): string {
-    let cookie = `${name}=${encodeURIComponent(value)}`;
-    if (options.path) cookie += `; Path=${options.path}`;
-    if (options.httpOnly) cookie += "; HttpOnly";
-    if (options.secure) cookie += "; Secure";
-    if (options.sameSite) cookie += `; SameSite=${options.sameSite}`;
-    if (options.maxAge !== undefined) cookie += `; Max-Age=${options.maxAge}`;
-    return cookie;
-}
+import type { LoginResponse } from "../../../types/api";
+import { authCookies } from "../../../lib/auth-cookies";
 
 /**
  * POST /api/auth/register
@@ -59,15 +45,10 @@ export const POST: APIRoute = async ({ request }) => {
         const data = await response.json();
 
         if (response.ok) {
-            const tokenCookie = buildCookie("access_token", data.access_token, {
-                path: "/",
-                httpOnly: true,
-                sameSite: "Lax",
-                maxAge: 60 * 60 * 24 * 7, // 7 days
-                secure: !import.meta.env.DEV, // Only secure in production
-            });
+            const result = data as LoginResponse;
+            const cookies = authCookies(result.access_token, result.refresh_token, !import.meta.env.DEV);
             const headers = new Headers({ "Content-Type": "application/json" });
-            headers.append("Set-Cookie", tokenCookie);
+            for (const c of cookies) headers.append("Set-Cookie", c);
             return new Response(
                 JSON.stringify({ success: true, redirect: "/dashboard" }),
                 { status: 200, headers }

--- a/frontend/src/pages/api/budget/[...path].ts
+++ b/frontend/src/pages/api/budget/[...path].ts
@@ -1,4 +1,5 @@
 import type { APIRoute } from "astro";
+import { tryRefreshFor401 } from "../../../lib/server/refresh";
 
 const BACKEND_URL = process.env.API_BASE_URL || process.env.PUBLIC_API_BASE_URL || "http://localhost:8002";
 
@@ -76,7 +77,17 @@ async function proxy({ request, params }: { request: Request; params: Record<str
     }
 
     try {
-        return await doFetch(backendUrl);
+        let res = await doFetch(backendUrl);
+        // Transparently refresh once if the access token expired mid-request.
+        if (res.status === 401) {
+            const refreshed = await tryRefreshFor401(res.status, request.headers.get("cookie") ?? "");
+            if (refreshed) {
+                forwardHeaders.set("Authorization", `Bearer ${refreshed.accessToken}`);
+                res = await doFetch(backendUrl);
+                for (const c of refreshed.setCookies) res.headers.append("Set-Cookie", c);
+            }
+        }
+        return res;
     } catch (e: any) {
         console.error(`[api/budget proxy] Error forwarding to ${backendUrl}:`, e?.message ?? e);
         return new Response(

--- a/frontend/src/pages/api/calendar/[...path].ts
+++ b/frontend/src/pages/api/calendar/[...path].ts
@@ -1,4 +1,5 @@
 import type { APIRoute } from "astro";
+import { tryRefreshFor401 } from "../../../lib/server/refresh";
 
 const BACKEND_URL = process.env.API_BASE_URL || process.env.PUBLIC_API_BASE_URL || "http://localhost:8002";
 
@@ -54,7 +55,17 @@ async function proxy({ request, params }: { request: Request; params: Record<str
     }
 
     try {
-        return await doFetch(backendUrl);
+        let res = await doFetch(backendUrl);
+        // Transparently refresh once if the access token expired mid-request.
+        if (res.status === 401) {
+            const refreshed = await tryRefreshFor401(res.status, request.headers.get("cookie") ?? "");
+            if (refreshed) {
+                forwardHeaders.set("Authorization", `Bearer ${refreshed.accessToken}`);
+                res = await doFetch(backendUrl);
+                for (const c of refreshed.setCookies) res.headers.append("Set-Cookie", c);
+            }
+        }
+        return res;
     } catch (e: any) {
         console.error(`[api/calendar proxy] Error forwarding to ${backendUrl}:`, e?.message ?? e);
         return new Response(

--- a/frontend/src/pages/api/chat/[...path].ts
+++ b/frontend/src/pages/api/chat/[...path].ts
@@ -1,4 +1,5 @@
 import type { APIRoute } from "astro";
+import { tryRefreshFor401 } from "../../../lib/server/refresh";
 
 const BACKEND_URL = process.env.API_BASE_URL || process.env.PUBLIC_API_BASE_URL || "http://localhost:8002";
 
@@ -22,14 +23,27 @@ async function proxy({ request, params }: { request: Request; params: Record<str
     const hasBody = !["GET", "HEAD"].includes(request.method.toUpperCase());
     const body = hasBody ? await request.arrayBuffer() : undefined;
     try {
-        const res = await fetch(backendUrl, {
+        let res = await fetch(backendUrl, {
             method: request.method, headers: forwardHeaders, body, redirect: "manual",
         });
+        // Transparently refresh once if the access token expired mid-request.
+        let refreshedSetCookies: string[] | undefined;
+        if (res.status === 401) {
+            const refreshed = await tryRefreshFor401(res.status, request.headers.get("cookie") ?? "");
+            if (refreshed) {
+                forwardHeaders.set("Authorization", `Bearer ${refreshed.accessToken}`);
+                res = await fetch(backendUrl, {
+                    method: request.method, headers: forwardHeaders, body, redirect: "manual",
+                });
+                refreshedSetCookies = refreshed.setCookies;
+            }
+        }
         const out = new Headers();
         for (const [k, v] of res.headers.entries()) {
             if (k.toLowerCase() === "transfer-encoding") continue;
             out.set(k, v);
         }
+        if (refreshedSetCookies) for (const c of refreshedSetCookies) out.append("Set-Cookie", c);
         return new Response(res.body, { status: res.status, statusText: res.statusText, headers: out });
     } catch (e: any) {
         return new Response(JSON.stringify({ error: "proxy_error", message: String(e?.message ?? e) }),

--- a/frontend/src/pages/api/dm/[...path].ts
+++ b/frontend/src/pages/api/dm/[...path].ts
@@ -1,4 +1,5 @@
 import type { APIRoute } from "astro";
+import { tryRefreshFor401 } from "../../../lib/server/refresh";
 
 const BACKEND_URL = process.env.API_BASE_URL || process.env.PUBLIC_API_BASE_URL || "http://localhost:8002";
 
@@ -22,14 +23,27 @@ async function proxy({ request, params }: { request: Request; params: Record<str
     const hasBody = !["GET", "HEAD"].includes(request.method.toUpperCase());
     const body = hasBody ? await request.arrayBuffer() : undefined;
     try {
-        const res = await fetch(backendUrl, {
+        let res = await fetch(backendUrl, {
             method: request.method, headers: forwardHeaders, body, redirect: "manual",
         });
+        // Transparently refresh once if the access token expired mid-request.
+        let refreshedSetCookies: string[] | undefined;
+        if (res.status === 401) {
+            const refreshed = await tryRefreshFor401(res.status, request.headers.get("cookie") ?? "");
+            if (refreshed) {
+                forwardHeaders.set("Authorization", `Bearer ${refreshed.accessToken}`);
+                res = await fetch(backendUrl, {
+                    method: request.method, headers: forwardHeaders, body, redirect: "manual",
+                });
+                refreshedSetCookies = refreshed.setCookies;
+            }
+        }
         const out = new Headers();
         for (const [k, v] of res.headers.entries()) {
             if (k.toLowerCase() === "transfer-encoding") continue;
             out.set(k, v);
         }
+        if (refreshedSetCookies) for (const c of refreshedSetCookies) out.append("Set-Cookie", c);
         return new Response(res.body, { status: res.status, statusText: res.statusText, headers: out });
     } catch (e: any) {
         return new Response(JSON.stringify({ error: "proxy_error", message: String(e?.message ?? e) }),

--- a/frontend/src/pages/api/gigs/[...path].ts
+++ b/frontend/src/pages/api/gigs/[...path].ts
@@ -1,4 +1,5 @@
 import type { APIRoute } from "astro";
+import { tryRefreshFor401 } from "../../../lib/server/refresh";
 
 const BACKEND_URL = process.env.API_BASE_URL || process.env.PUBLIC_API_BASE_URL || "http://localhost:8002";
 
@@ -77,7 +78,17 @@ async function proxy({ request, params }: { request: Request; params: Record<str
     }
 
     try {
-        return await doFetch(backendUrl);
+        let res = await doFetch(backendUrl);
+        // Transparently refresh once if the access token expired mid-request.
+        if (res.status === 401) {
+            const refreshed = await tryRefreshFor401(res.status, request.headers.get("cookie") ?? "");
+            if (refreshed) {
+                forwardHeaders.set("Authorization", `Bearer ${refreshed.accessToken}`);
+                res = await doFetch(backendUrl);
+                for (const c of refreshed.setCookies) res.headers.append("Set-Cookie", c);
+            }
+        }
+        return res;
     } catch (e: any) {
         console.error(`[api/gigs proxy] Error forwarding to ${backendUrl}:`, e?.message ?? e);
         return new Response(

--- a/frontend/src/pages/api/invitations/accept.ts
+++ b/frontend/src/pages/api/invitations/accept.ts
@@ -1,20 +1,6 @@
 import type { APIRoute } from "astro";
-
-function buildCookie(name: string, value: string, options: {
-    path?: string;
-    httpOnly?: boolean;
-    sameSite?: string;
-    maxAge?: number;
-    secure?: boolean;
-}): string {
-    let cookie = `${name}=${encodeURIComponent(value)}`;
-    if (options.path) cookie += `; Path=${options.path}`;
-    if (options.httpOnly) cookie += "; HttpOnly";
-    if (options.secure) cookie += "; Secure";
-    if (options.sameSite) cookie += `; SameSite=${options.sameSite}`;
-    if (options.maxAge !== undefined) cookie += `; Max-Age=${options.maxAge}`;
-    return cookie;
-}
+import type { LoginResponse } from "../../../types/api";
+import { authCookies } from "../../../lib/auth-cookies";
 
 /**
  * POST /api/invitations/accept
@@ -43,15 +29,10 @@ export const POST: APIRoute = async ({ request }) => {
         const data = await response.json();
 
         if (response.ok) {
-            const tokenCookie = buildCookie("access_token", data.access_token, {
-                path: "/",
-                httpOnly: true,
-                sameSite: "Lax",
-                maxAge: 60 * 60 * 24 * 7, // 7 days
-                secure: !import.meta.env.DEV,
-            });
+            const result = data as LoginResponse;
+            const cookies = authCookies(result.access_token, result.refresh_token, !import.meta.env.DEV);
             const headers = new Headers({ "Content-Type": "application/json" });
-            headers.append("Set-Cookie", tokenCookie);
+            for (const c of cookies) headers.append("Set-Cookie", c);
             return new Response(
                 JSON.stringify({ success: true, redirect: "/dashboard" }),
                 { status: 200, headers }

--- a/frontend/src/pages/api/jarvis/[...path].ts
+++ b/frontend/src/pages/api/jarvis/[...path].ts
@@ -1,4 +1,5 @@
 import type { APIRoute } from "astro";
+import { tryRefreshFor401 } from "../../../lib/server/refresh";
 
 const BACKEND_URL = process.env.API_BASE_URL || process.env.PUBLIC_API_BASE_URL || "http://localhost:8002";
 
@@ -22,14 +23,27 @@ async function proxy({ request, params }: { request: Request; params: Record<str
     const hasBody = !["GET", "HEAD"].includes(request.method.toUpperCase());
     const body = hasBody ? await request.arrayBuffer() : undefined;
     try {
-        const res = await fetch(backendUrl, {
+        let res = await fetch(backendUrl, {
             method: request.method, headers: forwardHeaders, body, redirect: "manual",
         });
+        // Transparently refresh once if the access token expired mid-request.
+        let refreshedSetCookies: string[] | undefined;
+        if (res.status === 401) {
+            const refreshed = await tryRefreshFor401(res.status, request.headers.get("cookie") ?? "");
+            if (refreshed) {
+                forwardHeaders.set("Authorization", `Bearer ${refreshed.accessToken}`);
+                res = await fetch(backendUrl, {
+                    method: request.method, headers: forwardHeaders, body, redirect: "manual",
+                });
+                refreshedSetCookies = refreshed.setCookies;
+            }
+        }
         const out = new Headers();
         for (const [k, v] of res.headers.entries()) {
             if (k.toLowerCase() === "transfer-encoding") continue;
             out.set(k, v);
         }
+        if (refreshedSetCookies) for (const c of refreshedSetCookies) out.append("Set-Cookie", c);
         return new Response(res.body, { status: res.status, statusText: res.statusText, headers: out });
     } catch (e: any) {
         return new Response(JSON.stringify({ error: "proxy_error", message: String(e?.message ?? e) }),

--- a/frontend/src/pages/api/kiosk/[...path].ts
+++ b/frontend/src/pages/api/kiosk/[...path].ts
@@ -1,4 +1,5 @@
 import type { APIRoute } from "astro";
+import { tryRefreshFor401 } from "../../../lib/server/refresh";
 
 const BACKEND_URL = process.env.API_BASE_URL || process.env.PUBLIC_API_BASE_URL || "http://localhost:8002";
 
@@ -28,17 +29,34 @@ async function proxy({ request, params }: { request: Request; params: Record<str
     const body = hasBody ? await request.arrayBuffer() : undefined;
 
     try {
-        const backendRes = await fetch(backendUrl, {
+        let backendRes = await fetch(backendUrl, {
             method: request.method,
             headers: forwardHeaders,
             body,
             redirect: "manual",
         });
+        // Transparently refresh once if the access token expired mid-request.
+        // Skip snapshot paths, which are token-gated via query param (no cookie auth).
+        let refreshedSetCookies: string[] | undefined;
+        if (backendRes.status === 401 && !path.startsWith("snapshot")) {
+            const refreshed = await tryRefreshFor401(backendRes.status, request.headers.get("cookie") ?? "");
+            if (refreshed) {
+                forwardHeaders.set("Authorization", `Bearer ${refreshed.accessToken}`);
+                backendRes = await fetch(backendUrl, {
+                    method: request.method,
+                    headers: forwardHeaders,
+                    body,
+                    redirect: "manual",
+                });
+                refreshedSetCookies = refreshed.setCookies;
+            }
+        }
         const responseHeaders = new Headers();
         for (const [key, value] of backendRes.headers.entries()) {
             if (key.toLowerCase() === "transfer-encoding") continue;
             responseHeaders.set(key, value);
         }
+        if (refreshedSetCookies) for (const c of refreshedSetCookies) responseHeaders.append("Set-Cookie", c);
         return new Response(backendRes.body, {
             status: backendRes.status,
             statusText: backendRes.statusText,

--- a/frontend/src/pages/api/meals/[...path].ts
+++ b/frontend/src/pages/api/meals/[...path].ts
@@ -1,4 +1,5 @@
 import type { APIRoute } from "astro";
+import { tryRefreshFor401 } from "../../../lib/server/refresh";
 
 const BACKEND_URL = process.env.API_BASE_URL || process.env.PUBLIC_API_BASE_URL || "http://localhost:8002";
 
@@ -22,14 +23,27 @@ async function proxy({ request, params }: { request: Request; params: Record<str
     const hasBody = !["GET", "HEAD"].includes(request.method.toUpperCase());
     const body = hasBody ? await request.arrayBuffer() : undefined;
     try {
-        const res = await fetch(backendUrl, {
+        let res = await fetch(backendUrl, {
             method: request.method, headers: forwardHeaders, body, redirect: "manual",
         });
+        // Transparently refresh once if the access token expired mid-request.
+        let refreshedSetCookies: string[] | undefined;
+        if (res.status === 401) {
+            const refreshed = await tryRefreshFor401(res.status, request.headers.get("cookie") ?? "");
+            if (refreshed) {
+                forwardHeaders.set("Authorization", `Bearer ${refreshed.accessToken}`);
+                res = await fetch(backendUrl, {
+                    method: request.method, headers: forwardHeaders, body, redirect: "manual",
+                });
+                refreshedSetCookies = refreshed.setCookies;
+            }
+        }
         const out = new Headers();
         for (const [k, v] of res.headers.entries()) {
             if (k.toLowerCase() === "transfer-encoding") continue;
             out.set(k, v);
         }
+        if (refreshedSetCookies) for (const c of refreshedSetCookies) out.append("Set-Cookie", c);
         return new Response(res.body, { status: res.status, statusText: res.statusText, headers: out });
     } catch (e: any) {
         return new Response(JSON.stringify({ error: "proxy_error", message: String(e?.message ?? e) }),

--- a/frontend/src/pages/api/oauth/google.ts
+++ b/frontend/src/pages/api/oauth/google.ts
@@ -1,24 +1,6 @@
 import type { APIRoute } from "astro";
 import type { LoginResponse, ApiError } from "../../../types/api";
-
-/**
- * Helper to build a Set-Cookie header string.
- */
-function buildCookie(name: string, value: string, options: {
-    path?: string;
-    httpOnly?: boolean;
-    sameSite?: string;
-    maxAge?: number;
-    secure?: boolean;
-}): string {
-    let cookie = `${name}=${encodeURIComponent(value)}`;
-    if (options.path) cookie += `; Path=${options.path}`;
-    if (options.httpOnly) cookie += "; HttpOnly";
-    if (options.secure) cookie += "; Secure";
-    if (options.sameSite) cookie += `; SameSite=${options.sameSite}`;
-    if (options.maxAge !== undefined) cookie += `; Max-Age=${options.maxAge}`;
-    return cookie;
-}
+import { authCookies } from "../../../lib/auth-cookies";
 
 /**
  * POST /api/oauth/google
@@ -50,17 +32,11 @@ export const POST: APIRoute = async ({ request }) => {
         if (response.ok) {
             const result = data as LoginResponse;
 
-            // Manually set cookie via Set-Cookie header for reliability
-            const tokenCookie = buildCookie("access_token", result.access_token, {
-                path: "/",
-                httpOnly: true,
-                sameSite: "Lax",
-                maxAge: 60 * 60 * 24 * 7, // 7 days
-                secure: !import.meta.env.DEV, // Only secure in production
-            });
+            // Manually set cookies via Set-Cookie header for reliability
+            const cookies = authCookies(result.access_token, result.refresh_token, !import.meta.env.DEV);
 
             const headers = new Headers({ "Content-Type": "application/json" });
-            headers.append("Set-Cookie", tokenCookie);
+            for (const c of cookies) headers.append("Set-Cookie", c);
 
             return new Response(
                 JSON.stringify({ success: true, user: result.user }),

--- a/frontend/src/pages/api/subscriptions/[...path].ts
+++ b/frontend/src/pages/api/subscriptions/[...path].ts
@@ -1,4 +1,5 @@
 import type { APIRoute } from "astro";
+import { tryRefreshFor401 } from "../../../lib/server/refresh";
 
 const BACKEND_URL = process.env.API_BASE_URL || process.env.PUBLIC_API_BASE_URL || "http://localhost:8002";
 
@@ -22,14 +23,28 @@ async function proxy({ request, params }: { request: Request; params: Record<str
     const hasBody = !["GET", "HEAD"].includes(request.method.toUpperCase());
     const body = hasBody ? await request.arrayBuffer() : undefined;
     try {
-        const res = await fetch(backendUrl, {
+        let res = await fetch(backendUrl, {
             method: request.method, headers: forwardHeaders, body, redirect: "manual",
         });
+        // Transparently refresh once if the access token expired mid-request.
+        // Skip webhook paths, which are unauthenticated (no cookie token injected).
+        let refreshedSetCookies: string[] | undefined;
+        if (res.status === 401 && !path.startsWith("webhook")) {
+            const refreshed = await tryRefreshFor401(res.status, request.headers.get("cookie") ?? "");
+            if (refreshed) {
+                forwardHeaders.set("Authorization", `Bearer ${refreshed.accessToken}`);
+                res = await fetch(backendUrl, {
+                    method: request.method, headers: forwardHeaders, body, redirect: "manual",
+                });
+                refreshedSetCookies = refreshed.setCookies;
+            }
+        }
         const out = new Headers();
         for (const [k, v] of res.headers.entries()) {
             if (k.toLowerCase() === "transfer-encoding") continue;
             out.set(k, v);
         }
+        if (refreshedSetCookies) for (const c of refreshedSetCookies) out.append("Set-Cookie", c);
         return new Response(res.body, { status: res.status, statusText: res.statusText, headers: out });
     } catch (e: any) {
         return new Response(JSON.stringify({ error: "proxy_error", message: String(e?.message ?? e) }),

--- a/frontend/src/pages/api/task-templates/[...path].ts
+++ b/frontend/src/pages/api/task-templates/[...path].ts
@@ -1,4 +1,5 @@
 import type { APIRoute } from "astro";
+import { tryRefreshFor401 } from "../../../lib/server/refresh";
 
 const BACKEND_URL = process.env.API_BASE_URL || process.env.PUBLIC_API_BASE_URL || "http://localhost:8000";
 
@@ -76,7 +77,17 @@ async function proxy({ request, params }: { request: Request; params: Record<str
     }
 
     try {
-        return await doFetch(backendUrl);
+        let res = await doFetch(backendUrl);
+        // Transparently refresh once if the access token expired mid-request.
+        if (res.status === 401) {
+            const refreshed = await tryRefreshFor401(res.status, request.headers.get("cookie") ?? "");
+            if (refreshed) {
+                forwardHeaders.set("Authorization", `Bearer ${refreshed.accessToken}`);
+                res = await doFetch(backendUrl);
+                for (const c of refreshed.setCookies) res.headers.append("Set-Cookie", c);
+            }
+        }
+        return res;
     } catch (e: any) {
         console.error(`[api/task-templates proxy] Error forwarding to ${backendUrl}:`, e?.message ?? e);
         return new Response(

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -14,6 +14,7 @@ export interface User {
 
 export interface LoginResponse {
     access_token: string;
+    refresh_token: string;
     token_type: string;
     user?: Record<string, unknown>;
 }


### PR DESCRIPTION
## Summary
- Replaces the single 7-day JWT with **access (1h) + refresh (7d, rotating)** tokens.
- **Revocation** via `User.token_version` (new column + migration `02b4ae6958cc`): logout **and** password-reset bump it → all that user's refresh tokens die (logout-everywhere). No Redis dependency.
- New `POST /api/auth/refresh` (typed + `token_version`-checked). `get_current_user` now rejects refresh tokens; legacy no-`type` tokens still accepted as access (no mass logout on deploy).
- **`SESSION_SECRET_KEY`** split out from `SECRET_KEY` for `SessionMiddleware`.
- **Astro BFF**: two httpOnly cookies (`access_token`/`refresh_token`, `Path=/`), shared `auth-cookies.ts`, new `/api/auth/refresh` route, middleware transparently refreshes expired access tokens, all 11 proxy routes refresh-once-on-401-and-retry, logout bumps server `token_version`.
- Built via spec → plan → subagent-driven TDD (backend A1–A10, frontend B1–B6, E2E C1); final whole-branch security review verdict: **SHIP**.

## Test Plan
- [x] Backend suite green: **979 passed, 11 xfailed, 0 failures**.
- [x] `astro check`: 0 errors / 0 warnings. `astro build`: clean.
- [x] Live backend smoke: login→access+refresh; refresh→new pair; `/me` rejects refresh (401); logout→refresh-after-logout 401 (revocation).
- [x] Live BFF (prod build + curl): login sets both httpOnly cookies (1h/7d); `/dashboard` with only the refresh cookie → 200 + fresh access (transparent refresh, no login bounce); no cookie → 302 `/login`.
- [ ] Playwright `e2e-tests/auth-refresh.spec.js` — run against a rebuilt frontend container.

## Deploy notes
- Prod `.env` **must** set a distinct `SESSION_SECRET_KEY` and `ACCESS_TOKEN_EXPIRE_MINUTES=60`.
- Run Alembic migration `02b4ae6958cc` (adds `users.token_version`) on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)