### PR TITLE
fix(security): audit Bucket 1 — gig constraint, double-award locks, upload hardening

### DIFF
--- a/backend/app/api/routes/budget/transactions.py
+++ b/backend/app/api/routes/budget/transactions.py
@@ -16,6 +16,12 @@ from app.core.dependencies import get_current_user, require_parent_role
 from app.core.type_utils import to_uuid_required
 from app.core.premium import require_feature
 from app.core.rate_limiter import limiter, AI_LIMIT
+from app.core.upload_validation import (
+    read_upload_capped,
+    sniff_mime,
+    MAX_IMPORT_BYTES,
+    MAX_RECEIPT_BYTES,
+)
 from app.services.budget.transaction_service import TransactionService
 from app.services.usage_service import UsageService
 from app.services.budget.csv_import_service import CSVImportService
@@ -416,8 +422,8 @@ async def import_csv_transactions(
     Returns import statistics and detailed error information.
     """
     try:
-        # Read CSV file content
-        csv_content = await file.read()
+        # Read CSV file content (capped so a large upload can't exhaust memory)
+        csv_content = await read_upload_capped(file, MAX_IMPORT_BYTES)
         csv_text = csv_content.decode('utf-8')
         
         # Parse column mapping if provided
@@ -497,7 +503,7 @@ async def import_file_transactions_endpoint(
             db, account_id, to_uuid_required(current_user.family_id)
         )
 
-        file_bytes = await file.read()
+        file_bytes = await read_upload_capped(file, MAX_IMPORT_BYTES)
         result = await import_file_transactions(
             db=db,
             family_id=to_uuid_required(current_user.family_id),
@@ -577,16 +583,32 @@ async def scan_receipt_endpoint(
             "transaction_id": None,
         }
 
-    file_bytes = await file.read()
-
-    # Max 10MB (applies to the raw upload; rasterized PNG will be smaller)
-    if len(file_bytes) > 10 * 1024 * 1024:
+    # Read with a hard cap so a large upload can't exhaust the worker
+    # (rasterized PNG will be smaller than the raw upload).
+    try:
+        file_bytes = await read_upload_capped(file, MAX_RECEIPT_BYTES)
+    except HTTPException:
         return {
             "success": False,
-            "message": "File too large. Maximum size is 10MB.",
+            "message": f"File too large. Maximum size is {MAX_RECEIPT_BYTES // (1024 * 1024)}MB.",
             "scanned_data": None,
             "transaction_id": None,
         }
+
+    # Authoritative type check: sniff the real bytes. The client-declared
+    # Content-Type is not trusted for what we feed to the vision pipeline.
+    sniffed = sniff_mime(file_bytes)
+    if sniffed not in allowed_types:
+        return {
+            "success": False,
+            "message": (
+                "Unsupported or unrecognized file content. "
+                "Use JPEG, PNG, WebP, GIF, or PDF."
+            ),
+            "scanned_data": None,
+            "transaction_id": None,
+        }
+    content_type = sniffed
 
     result = await scan_and_create_transaction(
         db=db,

--- a/backend/app/api/routes/task_assignments.py
+++ b/backend/app/api/routes/task_assignments.py
@@ -194,16 +194,22 @@ async def upload_gig_proof(
     import uuid as _uuid
     import os as _os
 
+    from app.core.upload_validation import (
+        read_upload_capped,
+        assert_allowed_type,
+        MAX_PROOF_BYTES,
+    )
+
     allowed = {"image/jpeg", "image/png", "image/webp"}
     content_type = (file.content_type or "").lower()
     if content_type not in allowed:
         raise HTTPException(status_code=415, detail=f"Unsupported type {content_type}")
 
-    body = await file.read()
-    if len(body) > 5 * 1024 * 1024:
-        raise HTTPException(status_code=413, detail="File too large (max 5MB)")
+    body = await read_upload_capped(file, MAX_PROOF_BYTES)
+    # Authoritative check: sniff the real bytes, not the client-declared type.
+    real_type = assert_allowed_type(body, allowed)
 
-    ext = {"image/jpeg": "jpg", "image/png": "png", "image/webp": "webp"}[content_type]
+    ext = {"image/jpeg": "jpg", "image/png": "png", "image/webp": "webp"}[real_type]
     fname = f"{_uuid.uuid4().hex}.{ext}"
     dest_dir = "/app/uploads/gig-proofs"
     _os.makedirs(dest_dir, exist_ok=True)

--- a/backend/app/core/upload_validation.py
+++ b/backend/app/core/upload_validation.py
@@ -1,0 +1,76 @@
+"""Shared upload hardening: magic-byte sniffing + size-capped reads.
+
+Client-supplied Content-Type is attacker-controlled, so the real type is
+sniffed from the file's leading bytes. Reads are streamed with a hard byte
+cap so a large authenticated upload cannot exhaust a worker's memory.
+"""
+from typing import Optional, Set
+
+from fastapi import UploadFile, HTTPException
+
+# Size limits (bytes).
+MB = 1024 * 1024
+MAX_IMPORT_BYTES = 10 * MB        # CSV / OFX / QIF / CAMT bank files
+MAX_RECEIPT_BYTES = 15 * MB       # receipt photos / scanned PDFs
+MAX_PROOF_BYTES = 5 * MB          # gig proof images
+
+_CHUNK = 64 * 1024
+
+
+def sniff_mime(data: bytes) -> Optional[str]:
+    """Return the MIME type implied by the leading magic bytes, or None.
+
+    Recognizes the formats this app accepts for upload (images + PDF). Anything
+    else returns None so callers can reject it regardless of the claimed type.
+    """
+    if len(data) < 4:
+        return None
+    if data[:3] == b"\xff\xd8\xff":
+        return "image/jpeg"
+    if data[:8] == b"\x89PNG\r\n\x1a\n":
+        return "image/png"
+    if data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return "image/webp"
+    if data[:6] in (b"GIF87a", b"GIF89a"):
+        return "image/gif"
+    if data[:4] == b"%PDF":
+        return "application/pdf"
+    return None
+
+
+def assert_allowed_type(data: bytes, allowed: Set[str]) -> str:
+    """Sniff the real type and raise 415 unless it is in ``allowed``.
+
+    Returns the detected MIME type on success.
+    """
+    detected = sniff_mime(data)
+    if detected not in allowed:
+        raise HTTPException(
+            status_code=415,
+            detail=(
+                "Unsupported or unrecognized file content. "
+                f"Allowed: {', '.join(sorted(allowed))}."
+            ),
+        )
+    return detected
+
+
+async def read_upload_capped(file: UploadFile, max_bytes: int) -> bytes:
+    """Read an UploadFile in chunks, aborting with 413 if it exceeds max_bytes.
+
+    Avoids loading an unbounded body into memory via a single ``file.read()``.
+    """
+    chunks = []
+    total = 0
+    while True:
+        chunk = await file.read(_CHUNK)
+        if not chunk:
+            break
+        total += len(chunk)
+        if total > max_bytes:
+            raise HTTPException(
+                status_code=413,
+                detail=f"File too large (max {max_bytes // MB} MB).",
+            )
+        chunks.append(chunk)
+    return b"".join(chunks)

--- a/backend/app/models/gig.py
+++ b/backend/app/models/gig.py
@@ -6,7 +6,8 @@ from sqlalchemy import (
     DateTime,
     ForeignKey,
     Text,
-    UniqueConstraint,
+    Index,
+    text,
     Enum as SQLEnum,
 )
 from sqlalchemy.dialects.postgresql import UUID, JSONB
@@ -81,13 +82,17 @@ class GigClaim(Base):
 
     __tablename__ = "gig_claims"
     __table_args__ = (
-        UniqueConstraint(
+        # Partial unique: one ACTIVE (non-rejected) claim per user per gig.
+        # A rejected claim must not block re-claiming, so the index excludes
+        # status='rejected'. Mirrors the raw SQL in migration
+        # 2026_06_01_gig_tables.py exactly so create_all (test DB) and the
+        # deployed schema enforce the same rule.
+        Index(
+            "uq_gig_claim_active",
             "gig_id",
             "claimed_by",
-            name="uq_gig_claim_active",
-            # Partial unique enforced via CHECK + application logic:
-            # only one non-REJECTED claim per user per gig.
-            # Full partial unique index added in migration.
+            unique=True,
+            postgresql_where=text("status != 'rejected'"),
         ),
     )
 

--- a/backend/app/services/gig_claim_service.py
+++ b/backend/app/services/gig_claim_service.py
@@ -86,10 +86,12 @@ class GigClaimService:
         COMPLETED and notifies parents that a gig awaits review."""
         from app.core.config import settings
 
+        # Lock the row: two concurrent proof submissions on the same claim must
+        # not both reach the auto-approve branch and double-award points.
         result = await db.execute(
-            select(GigClaim).where(
-                and_(GigClaim.id == claim_id, GigClaim.claimed_by == user_id)
-            )
+            select(GigClaim)
+            .where(and_(GigClaim.id == claim_id, GigClaim.claimed_by == user_id))
+            .with_for_update()
         )
         claim = result.scalar_one_or_none()
         if not claim:
@@ -323,10 +325,12 @@ class GigClaimService:
         if approver.family_id != family_id or approver.role != UserRole.PARENT:
             raise ForbiddenException("Solo padres pueden aprobar gigs")
 
+        # Lock the row: two concurrent approvals of the same claim must not
+        # both pass the status check and double-award points.
         result = await db.execute(
-            select(GigClaim).where(
-                and_(GigClaim.id == claim_id, GigClaim.family_id == family_id)
-            )
+            select(GigClaim)
+            .where(and_(GigClaim.id == claim_id, GigClaim.family_id == family_id))
+            .with_for_update()
         )
         claim = result.scalar_one_or_none()
         if not claim:

--- a/backend/app/services/task_assignment_service.py
+++ b/backend/app/services/task_assignment_service.py
@@ -472,9 +472,16 @@ class TaskAssignmentService(BaseFamilyService[TaskAssignment]):
 
     @staticmethod
     async def get_assignment(
-        db: AsyncSession, assignment_id: UUID, family_id: UUID
+        db: AsyncSession, assignment_id: UUID, family_id: UUID,
+        for_update: bool = False,
     ) -> TaskAssignment:
-        """Get an assignment by ID with template eagerly loaded"""
+        """Get an assignment by ID with template eagerly loaded.
+
+        Pass for_update=True to take a row lock (SELECT ... FOR UPDATE) so
+        concurrent state transitions (approve / claim) serialize and cannot
+        both pass a check-then-write guard. selectinload issues separate
+        queries, so the lock applies only to the task_assignments row.
+        """
         query = (
             select(TaskAssignment)
             .options(
@@ -488,6 +495,8 @@ class TaskAssignmentService(BaseFamilyService[TaskAssignment]):
                 )
             )
         )
+        if for_update:
+            query = query.with_for_update(of=TaskAssignment)
         result = await db.execute(query)
         assignment = result.scalar_one_or_none()
         if not assignment:
@@ -814,6 +823,42 @@ class TaskAssignmentService(BaseFamilyService[TaskAssignment]):
         if assignment.assigned_to != user_id:
             raise ForbiddenException("Only the assigned user can claim this gig")
 
+        tmpl = assignment.template
+
+        # Competition mode is "first claim wins". Serialize every claim for
+        # this template+week by locking the whole sibling set in one
+        # deterministic (id-ordered) SELECT ... FOR UPDATE — a single ordered
+        # lock acquisition, so concurrent claimers queue instead of
+        # deadlocking. populate_existing refreshes our own already-loaded row
+        # from the locked read, so a claimer that lost the race sees its row
+        # cancelled (and/or a sibling already CLAIMED) and is rejected,
+        # guaranteeing exactly one winner.
+        if tmpl.is_bonus and tmpl.gig_mode == "competition":
+            siblings = (
+                await db.execute(
+                    select(TaskAssignment)
+                    .where(
+                        and_(
+                            TaskAssignment.family_id == family_id,
+                            TaskAssignment.template_id == tmpl.id,
+                            TaskAssignment.week_of == assignment.week_of,
+                        )
+                    )
+                    .order_by(TaskAssignment.id)
+                    .with_for_update()
+                    .execution_options(populate_existing=True)
+                )
+            ).scalars().all()
+            assignment = next(
+                (s for s in siblings if s.id == assignment.id), assignment
+            )
+            if any(
+                s.id != assignment.id
+                and s.status in (AssignmentStatus.CLAIMED, AssignmentStatus.COMPLETED)
+                for s in siblings
+            ):
+                raise ValidationException("Esta gig ya fue reclamada por alguien más")
+
         if not assignment.can_claim:
             raise ValidationException(
                 f"Gig cannot be claimed in status {assignment.status.value}"
@@ -829,10 +874,9 @@ class TaskAssignmentService(BaseFamilyService[TaskAssignment]):
         assignment.status = AssignmentStatus.CLAIMED
         assignment.claimed_at = datetime.now(timezone.utc)
 
-        # Competition mode: first claim wins, cancel sibling assignments for
-        # the same template+week so other kids see the gig disappear.
-        tmpl = assignment.template
-        if tmpl and tmpl.is_bonus and tmpl.gig_mode == "competition":
+        # Competition mode: cancel the sibling assignments (already locked
+        # above) for the same template+week so other kids see it disappear.
+        if tmpl.is_bonus and tmpl.gig_mode == "competition":
             from sqlalchemy import update as sql_update
             stmt = (
                 sql_update(TaskAssignment)
@@ -896,7 +940,9 @@ class TaskAssignmentService(BaseFamilyService[TaskAssignment]):
         if parent.family_id != family_id or parent.role != UserRole.PARENT:
             raise ForbiddenException("Only parents in this family can approve gigs")
 
-        assignment = await TaskAssignmentService.get_assignment(db, assignment_id, family_id)
+        assignment = await TaskAssignmentService.get_assignment(
+            db, assignment_id, family_id, for_update=True
+        )
 
         if assignment.approval_status != ApprovalStatus.PENDING:
             raise ValidationException(

--- a/backend/tests/test_gig_claim_constraint.py
+++ b/backend/tests/test_gig_claim_constraint.py
@@ -1,0 +1,69 @@
+"""gig_claims partial-unique constraint.
+
+The deployed migration creates a PARTIAL unique index
+(uq_gig_claim_active ON gig_claims (gig_id, claimed_by) WHERE status != 'rejected'):
+one ACTIVE (non-rejected) claim per user per gig, but a REJECTED claim must not
+block re-claiming the same gig. The ORM declaration must match so that
+Base.metadata.create_all (used by the test DB) enforces the same rule as prod.
+"""
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from app.models.gig import GigOffering, GigClaim, GigClaimStatus
+
+
+async def _offering(db, family_id, created_by):
+    o = GigOffering(
+        family_id=family_id, title="Wash car", points=10, created_by=created_by
+    )
+    db.add(o)
+    await db.flush()
+    return o
+
+
+@pytest.mark.asyncio
+async def test_reclaim_allowed_after_rejection(
+    db_session, test_family, test_child_user, test_parent_user
+):
+    """A REJECTED claim must NOT block a fresh claim on the same gig+user."""
+    offering = await _offering(db_session, test_family.id, test_parent_user.id)
+
+    rejected = GigClaim(
+        gig_id=offering.id, family_id=test_family.id,
+        claimed_by=test_child_user.id, status=GigClaimStatus.REJECTED,
+    )
+    db_session.add(rejected)
+    await db_session.commit()
+
+    fresh = GigClaim(
+        gig_id=offering.id, family_id=test_family.id,
+        claimed_by=test_child_user.id, status=GigClaimStatus.CLAIMED,
+    )
+    db_session.add(fresh)
+    await db_session.commit()  # must NOT raise — prior claim is rejected
+
+    await db_session.refresh(fresh)
+    assert fresh.status == GigClaimStatus.CLAIMED
+
+
+@pytest.mark.asyncio
+async def test_two_active_claims_forbidden(
+    db_session, test_family, test_child_user, test_parent_user
+):
+    """Two non-rejected claims on the same gig+user must violate uniqueness."""
+    offering = await _offering(db_session, test_family.id, test_parent_user.id)
+
+    first = GigClaim(
+        gig_id=offering.id, family_id=test_family.id,
+        claimed_by=test_child_user.id, status=GigClaimStatus.CLAIMED,
+    )
+    db_session.add(first)
+    await db_session.commit()
+
+    second = GigClaim(
+        gig_id=offering.id, family_id=test_family.id,
+        claimed_by=test_child_user.id, status=GigClaimStatus.COMPLETED,
+    )
+    db_session.add(second)
+    with pytest.raises(IntegrityError):
+        await db_session.commit()

--- a/backend/tests/test_gig_claim_race.py
+++ b/backend/tests/test_gig_claim_race.py
@@ -1,0 +1,120 @@
+"""Concurrency / double-award protection for gig claims.
+
+Two parents (or two browser tabs) approving the same COMPLETED claim at the
+same time must award points exactly once. Without a row lock both calls read
+status=COMPLETED, both award, and two PointTransaction rows are written.
+"""
+import asyncio
+
+import pytest
+from sqlalchemy import select, func
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.models.gig import GigOffering, GigClaim, GigClaimStatus
+from app.models.point_transaction import PointTransaction
+from app.services.gig_claim_service import GigClaimService
+from app.core.exceptions import ValidationException
+
+
+async def _completed_claim(db, family, parent, child, points=25):
+    offering = GigOffering(
+        family_id=family.id, title="Wash car", points=points, created_by=parent.id,
+    )
+    db.add(offering)
+    await db.flush()
+    claim = GigClaim(
+        gig_id=offering.id, family_id=family.id,
+        claimed_by=child.id, status=GigClaimStatus.COMPLETED,
+    )
+    db.add(claim)
+    await db.commit()
+    return claim
+
+
+@pytest.mark.asyncio
+async def test_concurrent_approve_awards_points_once(
+    test_engine, db_session, test_family, test_parent_user, test_child_user
+):
+    claim = await _completed_claim(
+        db_session, test_family, test_parent_user, test_child_user, points=25
+    )
+    claim_id = claim.id
+    points_before = test_child_user.points
+    streak_before = test_child_user.gig_trust_streak
+
+    maker = async_sessionmaker(test_engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def _approve():
+        async with maker() as s:
+            return await GigClaimService.approve(
+                s, claim_id, test_parent_user.id, test_family.id,
+                approved=True, notes=None,
+            )
+
+    results = await asyncio.gather(_approve(), _approve(), return_exceptions=True)
+
+    succeeded = [r for r in results if isinstance(r, GigClaim)]
+    failed = [r for r in results if isinstance(r, Exception)]
+    assert len(succeeded) == 1, f"expected 1 success, got {results}"
+    assert len(failed) == 1 and isinstance(failed[0], ValidationException), (
+        f"expected 1 ValidationException, got {results}"
+    )
+
+    # Points credited exactly once.
+    txn_count = await db_session.scalar(
+        select(func.count())
+        .select_from(PointTransaction)
+        .where(PointTransaction.gig_claim_id == claim_id)
+    )
+    assert txn_count == 1, f"double-award: {txn_count} point transactions"
+
+    await db_session.refresh(test_child_user)
+    assert test_child_user.points == points_before + 25
+    assert test_child_user.gig_trust_streak == streak_before + 1
+
+
+@pytest.mark.asyncio
+async def test_concurrent_complete_auto_approve_awards_once(
+    test_engine, db_session, test_family, test_parent_user, test_child_user
+):
+    """Trusted-kid auto-approve path: two concurrent proof submissions on the
+    same CLAIMED claim must auto-approve and award points only once."""
+    from app.core.config import settings
+
+    # Make the child trusted so complete() takes the auto-approve branch.
+    test_child_user.gig_trust_streak = max(1, settings.GIG_AUTO_APPROVE_STREAK)
+    offering = GigOffering(
+        family_id=test_family.id, title="Sweep", points=15,
+        created_by=test_parent_user.id,
+    )
+    db_session.add(offering)
+    await db_session.flush()
+    claim = GigClaim(
+        gig_id=offering.id, family_id=test_family.id,
+        claimed_by=test_child_user.id, status=GigClaimStatus.CLAIMED,
+    )
+    db_session.add(claim)
+    await db_session.commit()
+    claim_id = claim.id
+
+    maker = async_sessionmaker(test_engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def _complete():
+        async with maker() as s:
+            return await GigClaimService.complete(
+                s, claim_id, test_child_user.id, proof_text="done",
+            )
+
+    results = await asyncio.gather(_complete(), _complete(), return_exceptions=True)
+
+    failed = [r for r in results if isinstance(r, Exception)]
+    assert len(failed) == 1 and isinstance(failed[0], ValidationException), (
+        f"expected 1 ValidationException, got {results}"
+    )
+
+    txn_count = await db_session.scalar(
+        select(func.count())
+        .select_from(PointTransaction)
+        .where(PointTransaction.gig_claim_id == claim_id)
+    )
+    assert txn_count == 1, f"double-award: {txn_count} point transactions"

--- a/backend/tests/test_task_assignment_race.py
+++ b/backend/tests/test_task_assignment_race.py
@@ -1,0 +1,131 @@
+"""Concurrency / double-award + single-winner protection for TaskAssignment gigs."""
+import asyncio
+from datetime import date, timedelta
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select, func
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.models.task_assignment import TaskAssignment, AssignmentStatus, ApprovalStatus
+from app.models.point_transaction import PointTransaction
+from app.services.task_assignment_service import TaskAssignmentService
+from app.core.exceptions import ValidationException, ForbiddenException
+
+
+def _monday_of(d):
+    return d - timedelta(days=d.weekday())
+
+
+async def _pending_approval(db, family, child, template):
+    today = date.today()
+    a = TaskAssignment(
+        id=uuid4(), template_id=template.id, assigned_to=child.id,
+        family_id=family.id, assigned_date=today, week_of=_monday_of(today),
+        status=AssignmentStatus.COMPLETED,
+        approval_status=ApprovalStatus.PENDING,
+        proof_text="did the thing",
+    )
+    db.add(a)
+    await db.commit()
+    return a
+
+
+@pytest.mark.asyncio
+async def test_concurrent_approve_gig_awards_points_once(
+    test_engine, db_session, test_family, test_parent_user, test_child_user,
+    gig_template_factory,
+):
+    gig = await gig_template_factory(family=test_family, points=25)
+    assignment = await _pending_approval(db_session, test_family, test_child_user, gig)
+    assignment_id = assignment.id
+    points_before = test_child_user.points
+
+    maker = async_sessionmaker(test_engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def _approve():
+        async with maker() as s:
+            return await TaskAssignmentService.approve_gig(
+                s, assignment_id, test_family.id, test_parent_user.id,
+                approve=True, notes=None,
+            )
+
+    results = await asyncio.gather(_approve(), _approve(), return_exceptions=True)
+
+    succeeded = [r for r in results if isinstance(r, TaskAssignment)]
+    failed = [r for r in results if isinstance(r, Exception)]
+    assert len(succeeded) == 1, f"expected 1 success, got {results}"
+    assert len(failed) == 1 and isinstance(failed[0], ValidationException), (
+        f"expected 1 ValidationException, got {results}"
+    )
+
+    txn_count = await db_session.scalar(
+        select(func.count())
+        .select_from(PointTransaction)
+        .where(PointTransaction.assignment_id == assignment_id)
+    )
+    assert txn_count == 1, f"double-award: {txn_count} point transactions"
+
+    await db_session.refresh(test_child_user)
+    assert test_child_user.points == points_before + 25
+
+
+async def _competition_template(db, family, points=20):
+    from app.models.task_template import TaskTemplate, AssignmentType
+
+    t = TaskTemplate(
+        id=uuid4(), title="Race to finish", points=points, interval_days=7,
+        assignment_type=AssignmentType.AUTO, is_bonus=True, is_active=True,
+        gig_mode="competition", family_id=family.id,
+    )
+    db.add(t)
+    await db.commit()
+    return t
+
+
+async def _pending_gig(db, family, user, template, week):
+    a = TaskAssignment(
+        id=uuid4(), template_id=template.id, assigned_to=user.id,
+        family_id=family.id, assigned_date=week, week_of=week,
+        status=AssignmentStatus.PENDING,
+    )
+    db.add(a)
+    await db.commit()
+    return a
+
+
+@pytest.mark.asyncio
+async def test_competition_claim_single_winner(
+    test_engine, db_session, test_family, test_child_user, test_teen_user,
+):
+    """Competition mode is 'first claim wins'. Two kids claiming their own
+    sibling assignments at the same time must yield exactly ONE CLAIMED winner."""
+    week = _monday_of(date.today())
+    tmpl = await _competition_template(db_session, test_family)
+    a_child = await _pending_gig(db_session, test_family, test_child_user, tmpl, week)
+    a_teen = await _pending_gig(db_session, test_family, test_teen_user, tmpl, week)
+
+    maker = async_sessionmaker(test_engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def _claim(aid, uid):
+        async with maker() as s:
+            return await TaskAssignmentService.claim_gig(s, aid, test_family.id, uid)
+
+    results = await asyncio.gather(
+        _claim(a_child.id, test_child_user.id),
+        _claim(a_teen.id, test_teen_user.id),
+        return_exceptions=True,
+    )
+
+    claimed_count = await db_session.scalar(
+        select(func.count())
+        .select_from(TaskAssignment)
+        .where(
+            TaskAssignment.template_id == tmpl.id,
+            TaskAssignment.week_of == week,
+            TaskAssignment.status == AssignmentStatus.CLAIMED,
+        )
+    )
+    assert claimed_count == 1, (
+        f"competition must have ONE winner, got {claimed_count}; results={results}"
+    )

--- a/backend/tests/test_upload_endpoints.py
+++ b/backend/tests/test_upload_endpoints.py
@@ -1,0 +1,47 @@
+"""End-to-end upload hardening at the HTTP layer: magic-byte sniffing on the
+gig proof upload and a size cap on CSV import."""
+from uuid import uuid4
+
+import pytest
+
+REAL_JPEG = b"\xff\xd8\xff\xe0\x00\x10JFIF" + b"\x00" * 64
+
+
+@pytest.mark.asyncio
+async def test_proof_upload_rejects_spoofed_content_type(client, auth_headers):
+    """A text payload that merely *claims* image/jpeg must be rejected (415)."""
+    files = {"file": ("fake.jpg", b"this is plain text, not an image", "image/jpeg")}
+    resp = await client.post(
+        "/api/task-assignments/proof-upload", files=files, headers=auth_headers
+    )
+    assert resp.status_code == 415, resp.text
+
+
+@pytest.mark.asyncio
+async def test_proof_upload_accepts_real_jpeg(client, auth_headers):
+    files = {"file": ("real.jpg", REAL_JPEG, "image/jpeg")}
+    resp = await client.post(
+        "/api/task-assignments/proof-upload", files=files, headers=auth_headers
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["proof_image_url"].startswith("/uploads/gig-proofs/")
+
+
+@pytest.mark.asyncio
+async def test_csv_import_rejects_oversized_file(client, auth_headers):
+    """An over-cap CSV must be refused before the whole body is buffered.
+
+    The size check fires before account validation, so a placeholder
+    account_id is fine — the response must cite the size limit, not 'account
+    not found' (which is what an unguarded read would surface)."""
+    oversized = b"x" * (10 * 1024 * 1024 + 1)
+    files = {"file": ("big.csv", oversized, "text/csv")}
+    resp = await client.post(
+        f"/api/budget/transactions/import/csv?account_id={uuid4()}",
+        files=files,
+        headers=auth_headers,
+    )
+    body = resp.json()
+    assert body["success"] is False, body
+    err = str(body.get("error", "")).lower()
+    assert "mb" in err or "too large" in err, body

--- a/backend/tests/test_upload_validation.py
+++ b/backend/tests/test_upload_validation.py
@@ -1,0 +1,70 @@
+"""Upload hardening: magic-byte sniffing + size-capped reads.
+
+Client-supplied Content-Type is not trusted; the real type is sniffed from the
+leading bytes. Reads are capped so a large authed upload can't exhaust a worker.
+"""
+import io
+
+import pytest
+from fastapi import UploadFile, HTTPException
+
+from app.core.upload_validation import (
+    sniff_mime,
+    read_upload_capped,
+    assert_allowed_type,
+)
+
+JPEG = b"\xff\xd8\xff\xe0\x00\x10JFIF" + b"\x00" * 32
+PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+WEBP = b"RIFF\x24\x00\x00\x00WEBPVP8 " + b"\x00" * 16
+GIF = b"GIF89a" + b"\x00" * 32
+PDF = b"%PDF-1.7\n" + b"\x00" * 32
+TEXT = b"id,amount,payee\n1,100,Store\n"
+
+
+@pytest.mark.parametrize(
+    "data,expected",
+    [
+        (JPEG, "image/jpeg"),
+        (PNG, "image/png"),
+        (WEBP, "image/webp"),
+        (GIF, "image/gif"),
+        (PDF, "application/pdf"),
+        (TEXT, None),
+        (b"", None),
+        (b"\x00\x01\x02\x03not-an-image", None),
+    ],
+)
+def test_sniff_mime(data, expected):
+    assert sniff_mime(data) == expected
+
+
+def test_assert_allowed_type_accepts_real_image():
+    # Must not raise — JPEG bytes are in the allow-list.
+    assert_allowed_type(JPEG, {"image/jpeg", "image/png"})
+
+
+def test_assert_allowed_type_rejects_spoofed_content_type():
+    # Text payload masquerading as a JPEG upload must be rejected (415).
+    with pytest.raises(HTTPException) as exc:
+        assert_allowed_type(TEXT, {"image/jpeg", "image/png"})
+    assert exc.value.status_code == 415
+
+
+def _upload(data: bytes) -> UploadFile:
+    return UploadFile(file=io.BytesIO(data), filename="f.bin")
+
+
+@pytest.mark.asyncio
+async def test_read_upload_capped_under_limit():
+    up = _upload(b"x" * 1000)
+    data = await read_upload_capped(up, max_bytes=2000)
+    assert data == b"x" * 1000
+
+
+@pytest.mark.asyncio
+async def test_read_upload_capped_over_limit_raises_413():
+    up = _upload(b"x" * 5000)
+    with pytest.raises(HTTPException) as exc:
+        await read_upload_capped(up, max_bytes=2000)
+    assert exc.value.status_code == 413


### PR DESCRIPTION
## Summary
Three independent security / data-integrity fixes from the 2026-06-04 audit (Bucket 1):

- **#11 gig_claims partial-unique index** — ORM declared a *full* `UniqueConstraint` while the deployed migration created a *partial* unique index (`WHERE status != 'rejected'`). Tests (built from `create_all`) enforced full uniqueness while prod enforced partial, and autogenerate would churn. ORM now matches the migration; re-claiming after rejection works.
- **#1 double-award row locks** — all gig point-award paths did check-then-write with no row lock, so two concurrent requests both awarded. Added `.with_for_update()` to `GigClaim.approve`/`complete`, `TaskAssignment.approve_gig` (`get_assignment(for_update=True)`), and the competition-claim sibling set (single ordered `FOR UPDATE` + `populate_existing` → exactly one winner).
- **#2/#3 upload hardening** — new `app/core/upload_validation.py` (`read_upload_capped` → 413, `sniff_mime`/`assert_allowed_type` → 415). Wired into CSV/OFX import (size cap), receipt scan (cap + authoritative magic-byte sniff, passing the sniffed type downstream), and gig proof upload.

## Test Plan
- [x] New tests: `test_gig_claim_constraint.py`, `test_gig_claim_race.py` (2 concurrent sessions), `test_task_assignment_race.py`, `test_upload_validation.py`, `test_upload_endpoints.py` — all RED→GREEN.
- [x] Full backend suite green, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)