### PR TITLE
fix(infra): audit Bucket 2 — non-blocking PayPal + scheduled DB backups/restore

### DIFF
--- a/backend/app/api/routes/payment.py
+++ b/backend/app/api/routes/payment.py
@@ -4,6 +4,7 @@ PayPal Payment routes
 Handles PayPal payment creation, execution, and webhooks.
 """
 
+import asyncio
 from fastapi import APIRouter, Depends, status, Body, Request, Header
 from sqlalchemy.ext.asyncio import AsyncSession
 from pydantic import BaseModel, Field
@@ -47,7 +48,8 @@ async def create_payment(
     """
     paypal_service = PayPalService()
     
-    payment_info = paypal_service.create_payment(
+    payment_info = await asyncio.to_thread(
+        paypal_service.create_payment,
         amount=request.amount,
         currency=request.currency,
         description=request.description,
@@ -74,7 +76,8 @@ async def execute_payment(
     """
     paypal_service = PayPalService()
     
-    result = paypal_service.execute_payment(
+    result = await asyncio.to_thread(
+        paypal_service.execute_payment,
         payment_id=request.payment_id,
         payer_id=request.payer_id,
     )
@@ -101,7 +104,9 @@ async def get_payment_details(
     """
     paypal_service = PayPalService()
     
-    payment_details = paypal_service.get_payment_details(payment_id)
+    payment_details = await asyncio.to_thread(
+        paypal_service.get_payment_details, payment_id
+    )
     
     return payment_details
 

--- a/backend/app/api/routes/subscriptions.py
+++ b/backend/app/api/routes/subscriptions.py
@@ -5,6 +5,7 @@ Provides plan listing, current subscription info, usage tracking,
 checkout initiation, and cancellation.
 """
 
+import asyncio
 from datetime import datetime, timezone
 from typing import List
 
@@ -155,7 +156,8 @@ async def create_checkout(
 
     try:
         paypal_service = PayPalService()
-        result = paypal_service.create_subscription(
+        result = await asyncio.to_thread(
+            paypal_service.create_subscription,
             plan_id=paypal_plan_id,
             return_url=return_url,
             cancel_url=cancel_url,
@@ -250,7 +252,8 @@ async def activate_subscription(
 
     try:
         paypal_service = PayPalService()
-        paypal_service.execute_subscription(
+        await asyncio.to_thread(
+            paypal_service.execute_subscription,
             billing_agreement_id=request.paypal_subscription_id,
             token=request.paypal_subscription_id,
         )
@@ -312,7 +315,8 @@ async def cancel_subscription(
 
     if subscription.paypal_subscription_id:
         try:
-            PayPalService.cancel_subscription(
+            await asyncio.to_thread(
+                PayPalService.cancel_subscription,
                 subscription.paypal_subscription_id,
                 reason="User requested via app",
             )

--- a/backend/app/api/routes/subscriptions_webhook.py
+++ b/backend/app/api/routes/subscriptions_webhook.py
@@ -5,6 +5,7 @@ Public (unauthenticated) — PayPal posts here. Signature verified using the
 shared webhook_id, events deduplicated via Redis, dispatched to
 subscription_state transitions.
 """
+import asyncio
 import logging
 from datetime import datetime, timezone
 
@@ -94,7 +95,8 @@ async def receive_webhook(request: Request, db: AsyncSession = Depends(get_db)):
         )
 
     headers = request.headers
-    verified = PayPalService.verify_webhook_signature(
+    verified = await asyncio.to_thread(
+        PayPalService.verify_webhook_signature,
         transmission_id=headers.get("paypal-transmission-id", ""),
         transmission_time=headers.get("paypal-transmission-time", ""),
         cert_url=headers.get("paypal-cert-url", ""),

--- a/scripts/backup-db.sh
+++ b/scripts/backup-db.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Scheduled database backup — runs ON the GCP VM (via the systemd timer in
+# scripts/systemd/, or cron, or by hand). pg_dumps the postgres container to a
+# gzipped, --clean-able SQL file under backups/scheduled/ and prunes dumps
+# older than RETENTION_DAYS.
+#
+# Off-VM durability (upload to a GCS bucket) is intentionally a TODO — see the
+# note at the bottom. This script gives the VM local scheduled backups +
+# retention, which it previously lacked entirely (audit M7).
+#
+# Env overrides: APP_DIR, COMPOSE_FILE, RETENTION_DAYS.
+#
+set -euo pipefail
+
+APP_DIR="${APP_DIR:-/home/jc/family-task-manager}"
+COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.gcp.yml}"
+RETENTION_DAYS="${RETENTION_DAYS:-14}"
+
+cd "$APP_DIR"
+
+# POSTGRES_USER / POSTGRES_DB come from the deployed .env.
+set -a
+# shellcheck disable=SC1091
+source .env
+set +a
+
+mkdir -p backups/scheduled
+TS="$(date +%Y%m%d-%H%M%S)"
+OUT="backups/scheduled/db-${TS}.sql.gz"
+
+echo "[backup-db] dumping ${POSTGRES_DB} -> ${OUT}"
+# --clean --if-exists makes the dump idempotent to restore over a populated DB.
+sudo docker compose --env-file .env -f "$COMPOSE_FILE" exec -T postgres \
+    pg_dump --clean --if-exists -U "$POSTGRES_USER" "$POSTGRES_DB" | gzip > "$OUT"
+
+echo "[backup-db] wrote ${OUT} ($(du -h "$OUT" | cut -f1))"
+
+# Retention: delete gzipped dumps older than RETENTION_DAYS.
+find backups/scheduled -name 'db-*.sql.gz' -type f -mtime "+${RETENTION_DAYS}" -print -delete
+
+echo "[backup-db] done ($(find backups/scheduled -name 'db-*.sql.gz' | wc -l | tr -d ' ') dumps retained)"
+
+# TODO (off-VM durability): after writing $OUT, upload to a GCS bucket, e.g.
+#   gsutil cp "$OUT" "gs://<family-backups-bucket>/$(basename "$OUT")"
+# The VM service account needs roles/storage.objectCreator on that bucket.

--- a/scripts/restore-db.sh
+++ b/scripts/restore-db.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# Restore the database from a backup produced by backup-db.sh (or any plain
+# pg_dump, gzipped or not). Runs ON the GCP VM.
+#
+#   ./scripts/restore-db.sh backups/scheduled/db-YYYYMMDD-HHMMSS.sql.gz
+#
+# DESTRUCTIVE: with --clean dumps this drops and recreates objects, replacing
+# current data. Requires a typed confirmation.
+#
+# Env overrides: APP_DIR, COMPOSE_FILE.
+#
+set -euo pipefail
+
+APP_DIR="${APP_DIR:-/home/jc/family-task-manager}"
+COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.gcp.yml}"
+
+cd "$APP_DIR"
+
+FILE="${1:-}"
+if [[ -z "$FILE" ]]; then
+    echo "usage: $0 <backup.sql|backup.sql.gz>" >&2
+    echo "available:" >&2
+    ls -1t backups/scheduled/*.sql.gz backups/pre-deploy/*.sql 2>/dev/null | head -20 >&2 || true
+    exit 1
+fi
+if [[ ! -f "$FILE" ]]; then
+    echo "not found: $FILE" >&2
+    exit 1
+fi
+
+set -a
+# shellcheck disable=SC1091
+source .env
+set +a
+
+echo "About to RESTORE database '${POSTGRES_DB}' from:"
+echo "    $FILE ($(du -h "$FILE" | cut -f1))"
+echo "This OVERWRITES the current database contents and cannot be undone."
+read -r -p "Type 'restore' to confirm: " ans
+if [[ "$ans" != "restore" ]]; then
+    echo "aborted"
+    exit 1
+fi
+
+if [[ "$FILE" == *.gz ]]; then
+    DECOMP=(gunzip -c "$FILE")
+else
+    DECOMP=(cat "$FILE")
+fi
+
+"${DECOMP[@]}" | sudo docker compose --env-file .env -f "$COMPOSE_FILE" exec -T postgres \
+    psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+
+echo "[restore-db] restore complete"

--- a/scripts/systemd/README.md
+++ b/scripts/systemd/README.md
@@ -1,0 +1,43 @@
+# Scheduled DB backups (GCP VM)
+
+Daily PostgreSQL backups for the `family-app` GCP VM. Closes audit gap M7
+(previously: backups only ran at deploy time, no schedule, no restore script).
+
+## What it does
+
+`scripts/backup-db.sh` (run by the timer) `pg_dump`s the postgres container to
+`backups/scheduled/db-<timestamp>.sql.gz` and prunes dumps older than
+`RETENTION_DAYS` (default 14). Restore with `scripts/restore-db.sh <file>`.
+
+## Install (one-time, on the VM, as a sudoer)
+
+```bash
+cd /home/jc/family-task-manager
+chmod +x scripts/backup-db.sh scripts/restore-db.sh
+
+sudo cp scripts/systemd/family-backup.service /etc/systemd/system/
+sudo cp scripts/systemd/family-backup.timer   /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now family-backup.timer
+
+# Verify
+systemctl list-timers family-backup.timer
+sudo systemctl start family-backup.service   # run once now
+ls -lh backups/scheduled/
+```
+
+## Restore
+
+```bash
+cd /home/jc/family-task-manager
+./scripts/restore-db.sh backups/scheduled/db-YYYYMMDD-HHMMSS.sql.gz
+# (prompts for a typed 'restore' confirmation — it overwrites current data)
+```
+
+## Off-VM durability (TODO)
+
+These dumps live on the same boot disk as the DB — a disk loss takes both. To
+get off-VM durability, uncomment the `gsutil cp` block at the bottom of
+`backup-db.sh` and grant the VM service account `roles/storage.objectCreator`
+on a backups bucket. (school-admin uses `gs://icegg-db-backups-prod/` with the
+same pattern.)

--- a/scripts/systemd/family-backup.service
+++ b/scripts/systemd/family-backup.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Family Task Manager — daily PostgreSQL backup
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+# Runs as root so `sudo docker compose` needs no interactive password and the
+# dump can be written under /home/jc/family-task-manager/backups/.
+WorkingDirectory=/home/jc/family-task-manager
+ExecStart=/home/jc/family-task-manager/scripts/backup-db.sh

--- a/scripts/systemd/family-backup.timer
+++ b/scripts/systemd/family-backup.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run the Family Task Manager DB backup daily
+
+[Timer]
+# 03:30 VM-local time, with catch-up if the VM was off at the scheduled time.
+OnCalendar=*-*-* 03:30:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary
Two Bucket-2 infra items from the 2026-06-04 audit:

- **H18/B7 — non-blocking PayPal.** `paypal_service` makes synchronous `requests` calls; calling them straight from async route handlers froze the event loop for each PayPal round-trip. Wrapped all 7 call sites (subscriptions create/execute/cancel, payment create/execute/details, webhook verify) in `await asyncio.to_thread(...)`.
  - **Deliberate choice — to_thread over httpx rewrite:** it's the pattern this codebase already uses for sync I/O in async paths (per CLAUDE.md, pywebpush), keeps the payment service + its 8 test files untouched (no mock churn on a payment path), and fully removes the block. Behavior unchanged.
- **M7 — scheduled DB backups + restore.** Added `scripts/backup-db.sh` (pg_dump --clean → gzipped, retention), `scripts/restore-db.sh` (typed-confirm restore), `scripts/systemd/family-backup.{service,timer}` (daily 03:30), and a README with install steps. Off-VM (GCS) upload left as a documented TODO.

## Test Plan
- [x] Full backend suite: **968 passed, 11 xfailed, 0 failures**. PayPal/subscription/payment/webhook suite (54 tests) green — behavior preserved.
- [x] `bash -n` clean on both scripts.
- [ ] Install the timer on the VM (`scripts/systemd/README.md`) + run `restore-db.sh` against a dump to validate end-to-end on the VM.

## Notes
- Independent of the other open audit PRs (no shared files). No migration.
- Bucket-2 remaining after this: Sentry + structured logging (needs a DSN), dev/prod dependency split, `mark_overdue_all` per-family scan; plus deferred M11 point-split (product decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)