### PR TITLE
fix(deps): split dev deps into requirements-dev.txt; apply LOG_LEVEL

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -15,12 +15,19 @@ RUN apt-get update && apt-get install -y \
     postgresql-client \
     && rm -rf /var/lib/apt/lists/*
 
+# INSTALL_DEV=true → also installs test/lint tools (local dev only)
+ARG INSTALL_DEV=false
+
 # Copy requirements first for better caching
-COPY requirements.txt .
+COPY requirements.txt requirements-dev.txt ./
 
 # Install Python dependencies
 RUN pip install --upgrade pip && \
-    pip install -r requirements.txt
+    if [ "$INSTALL_DEV" = "true" ]; then \
+        pip install -r requirements-dev.txt; \
+    else \
+        pip install -r requirements.txt; \
+    fi
 
 # Copy project
 COPY . .

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -23,9 +23,10 @@ from app.services.pet_service import PetService
 from app.services.analytics_service import AnalyticsService
 from app.services.jarvis_schedule_service import JarvisScheduleService
 
-# Configure logging
+# Configure logging — level driven by LOG_LEVEL env var (default "INFO")
 logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    level=getattr(logging, settings.LOG_LEVEL.upper(), logging.INFO),
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
 logger = logging.getLogger(__name__)
 

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,0 +1,16 @@
+# Development and test dependencies — NOT installed in the production image.
+# Install with: pip install -r requirements-dev.txt
+# (which installs requirements.txt first via the -r directive)
+-r requirements.txt
+
+# Testing
+pytest==7.4.4
+pytest-asyncio==0.23.3
+pytest-cov==4.1.0
+factory-boy==3.3.0
+
+# Code Quality
+black==24.1.1
+flake8==7.0.0
+mypy==1.8.0
+isort==5.13.2

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -24,8 +24,6 @@ resend==2.4.0
 
 # Redis (Optional - for caching)
 redis==5.0.1
-aioredis==2.0.1
-
 # HTTP Client
 httpx==0.26.0
 
@@ -33,18 +31,6 @@ httpx==0.26.0
 google-auth==2.27.0
 google-auth-oauthlib==1.2.0
 paypalrestsdk==1.13.1
-
-# Testing
-pytest==7.4.4
-pytest-asyncio==0.23.3
-pytest-cov==4.1.0
-factory-boy==3.3.0
-
-# Code Quality
-black==24.1.1
-flake8==7.0.0
-mypy==1.8.0
-isort==5.13.2
 
 # AI / Vision
 # Anthropic SDK kept as a transitive fallback and for any code path that

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,8 @@ services:
     build:
       context: ./backend
       dockerfile: Dockerfile
+      args:
+        INSTALL_DEV: "true"
     container_name: family_app_backend
     # Load secrets that aren't in the explicit `environment:` block from
     # the host .env file. Order of precedence inside the container:


### PR DESCRIPTION
## Summary
- **Dev/prod dep split**: pytest, coverage, black, flake8, mypy, isort, factory-boy moved from `requirements.txt` → `requirements-dev.txt`. Prod image no longer ships test tools.
- **Dockerfile `INSTALL_DEV` arg**: local `docker-compose.yml` sets `INSTALL_DEV=true` → dev containers still get pytest for `podman exec … pytest` workflows. GCP image stays lean (default `false`).
- **`aioredis` removed**: dead dep — all Redis usage is `redis.asyncio` from the `redis` package.
- **LOG_LEVEL applied**: `main.py` `logging.basicConfig` now reads `settings.LOG_LEVEL` instead of hardcoded `INFO`. Set `LOG_LEVEL=DEBUG` in `.env` to get verbose output locally.

Closes audit gaps: dev/prod dep split, LOG_LEVEL ignored.

## Test Plan
- [ ] `podman compose build backend` locally (rebuild image) — confirm pytest available inside container via `podman exec family_app_backend pytest --version`
- [ ] GCP: `./scripts/deploy-gcp.sh --skip-backup -y` — verify image builds without test tools; confirm app starts normally
- [ ] Set `LOG_LEVEL=DEBUG` in local `.env`, restart backend, confirm DEBUG lines appear in `podman compose logs -f backend`

🤖 Generated with [Claude Code](https://claude.com/claude-code)