### PR TITLE
feat(monitoring): Sentry stub — activates only when SENTRY_DSN is set

### DIFF
--- a/.env.gcp.example
+++ b/.env.gcp.example
@@ -86,6 +86,11 @@ SMTP_USER=info@agent-ia.mx
 SMTP_PASSWORD=
 SMTP_USE_TLS=true
 
+# ── Sentry error monitoring ───────────────────────────────────────────────
+# Set to your project DSN to enable; leave empty to disable entirely.
+SENTRY_DSN=
+SENTRY_TRACES_SAMPLE_RATE=0.1
+
 # ── Vault (disabled on GCP) ───────────────────────────────────────────────
 VAULT_ENABLED=false
 VAULT_ADDR=

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -187,6 +187,10 @@ class Settings(BaseSettings):
     
     # Logging
     LOG_LEVEL: str = "INFO"
+
+    # Error monitoring — set SENTRY_DSN to activate; empty string = disabled
+    SENTRY_DSN: str = ""
+    SENTRY_TRACES_SAMPLE_RATE: float = 0.1
     
     @field_validator('ALLOWED_ORIGINS', mode='before')
     @classmethod

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -23,11 +23,25 @@ from app.services.pet_service import PetService
 from app.services.analytics_service import AnalyticsService
 from app.services.jarvis_schedule_service import JarvisScheduleService
 
-# Configure logging
+# Configure logging — level driven by LOG_LEVEL env var (default "INFO")
 logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    level=getattr(logging, settings.LOG_LEVEL.upper(), logging.INFO),
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
 logger = logging.getLogger(__name__)
+
+# Error monitoring — activates only when SENTRY_DSN is set in .env
+if settings.SENTRY_DSN:
+    import sentry_sdk
+    from sentry_sdk.integrations.fastapi import FastApiIntegration
+    from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
+
+    sentry_sdk.init(
+        dsn=settings.SENTRY_DSN,
+        traces_sample_rate=settings.SENTRY_TRACES_SAMPLE_RATE,
+        integrations=[FastApiIntegration(), SqlalchemyIntegration()],
+        environment="production" if not settings.DEBUG else "development",
+    )
 
 
 async def _overdue_sweep_loop() -> None:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -89,3 +89,6 @@ google-cloud-storage>=2.18
 
 # Rate limiting (B1) — auth + AI endpoint abuse protection
 slowapi==0.1.9
+
+# Error monitoring — disabled unless SENTRY_DSN is set in .env
+sentry-sdk[fastapi]==2.8.0


### PR DESCRIPTION
## Summary
- `sentry-sdk[fastapi]==2.8.0` in `requirements.txt` (FastAPI + SQLAlchemy integrations).
- `SENTRY_DSN: str = ""` + `SENTRY_TRACES_SAMPLE_RATE: float = 0.1` in `config.py`.
- `main.py`: `sentry_sdk.init()` inside `if settings.SENTRY_DSN:` — completely inert when DSN is empty. No change to local dev or prod without a DSN configured.
- `.env.gcp.example`: `SENTRY_DSN=` and `SENTRY_TRACES_SAMPLE_RATE=0.1` slots added.
- Also applies the LOG_LEVEL fix (hardcoded `INFO` → `settings.LOG_LEVEL`).

## To activate
Set `SENTRY_DSN=https://<key>@o<org>.ingest.sentry.io/<project>` in the VM `.env`, then `./scripts/deploy-gcp.sh --skip-backup -y`.

## Test Plan
- [ ] `podman compose build backend && podman compose up -d` — boots without `SENTRY_DSN` set, no errors
- [ ] `podman exec -e PYTHONPATH=/app family_app_backend pytest tests/ -v` — full suite passes
- [ ] (Optional) Set a real DSN, hit an endpoint, verify event appears in Sentry

🤖 Generated with [Claude Code](https://claude.com/claude-code)