### PR TITLE
fix(budget): allocate-modal sends allocation to correct selected month

### DIFF
--- a/frontend/src/components/AssignFundsModal.astro
+++ b/frontend/src/components/AssignFundsModal.astro
@@ -20,6 +20,8 @@ interface Props {
     t: (lang: string, key: string) => string;
     formatCurrency: (amount: number) => string;
     baseRoute?: string;
+    year: number;
+    month: number;
 }
 
 const {
@@ -28,7 +30,9 @@ const {
     lang,
     t,
     formatCurrency,
-    baseRoute = 'assign-funds'
+    baseRoute = 'assign-funds',
+    year,
+    month,
 } = Astro.props;
 ---
 
@@ -139,7 +143,7 @@ const {
     </div>
 </div>
 
-<script define:vars={{ readyToAssign, baseRoute, lang }}>
+<script define:vars={{ readyToAssign, baseRoute, lang, year, month }}>
     document.addEventListener('astro:page-load', () => {
     // Quick amount button handlers
     document.querySelectorAll(`.${baseRoute}-quick-amount`).forEach(btn => {
@@ -187,12 +191,8 @@ const {
 
         confirmBtn.disabled = true;
         try {
-            // Get current month from page URL: /budget/month/YYYY/MM
-            const parts = window.location.pathname.split('/');
-            const yearIdx = parts.indexOf('month') + 1;
-            const monthStr = yearIdx > 0
-                ? `${parts[yearIdx]}-${String(parts[yearIdx + 1]).padStart(2, '0')}-01`
-                : new Date().toISOString().slice(0, 7) + '-01';
+            // Use server-rendered year/month (query params, not pathname)
+            const monthStr = `${year}-${String(month).padStart(2, '0')}-01`;
 
             const res = await fetch('/api/budget/allocations/set', {
                 method: 'POST',

--- a/frontend/src/pages/budget/index.astro
+++ b/frontend/src/pages/budget/index.astro
@@ -171,6 +171,8 @@ const allCategories = (allGroups || [])
             lang={lang}
             t={t}
             formatCurrency={formatCurrency}
+            year={year}
+            month={month}
         />
     </Fragment>
 </BudgetShell>


### PR DESCRIPTION
## Bug
`AssignFundsModal` tried to extract year/month from the URL pathname pattern `/budget/month/YYYY/MM`. The budget index page actually uses query params (`?year=2026&month=4`), so `parts.indexOf('month')` always returned -1, the fallback was `new Date()`, and **every allocation silently posted to the current month** when navigating to past months.

## Fix
- Added `year: number` and `month: number` as required props on `AssignFundsModal`.
- Injected via `define:vars` into the client script.
- `monthStr` built from the server-rendered values — no URL parsing needed.
- `budget/index.astro` passes `{year}` and `{month}` (already computed from query params at SSR time).

## Test Plan
- [ ] Navigate to `/budget?year=2026&month=4` (or use the `<` arrow in the month nav)
- [ ] Open "Assign Funds" modal, allocate an amount to any category → confirm the allocation appears in April's budget, not June's
- [ ] Also verify the same flow works for the current month (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)