### PR TITLE
fix(tasks): create-modal propagates preset points; validates points >= 1

### DIFF
--- a/frontend/src/components/TaskCreateModal.astro
+++ b/frontend/src/components/TaskCreateModal.astro
@@ -498,6 +498,7 @@ const customPreset = { emoji: "✏️", title: "", effort_level: 1, interval_day
             try {
                 const preset = JSON.parse(card.dataset.preset || "{}");
                 if (nameInput) nameInput.value = preset.title || "";
+                if (pointsInput) pointsInput.value = String(preset.points ?? 10);
                 activateChip("effort", String(preset.effort_level || "1"));
                 activateChip("interval", String(preset.interval_days || "1"));
                 showStep(2);
@@ -525,12 +526,21 @@ const customPreset = { emoji: "✏️", title: "", effort_level: 1, interval_day
         const assignedUserIds = Array.from(modal.querySelectorAll(".tcm-member-cb:checked")).map((cb) => cb.value);
         const allowedRoles = Array.from(modal.querySelectorAll(".tcm-role-cb:checked")).map((cb) => cb.value);
 
+        const points = parseInt(pointsInput?.value, 10);
+        if (isNaN(points) || points < 1) {
+            showError(document.documentElement.lang === "es"
+                ? "Los puntos deben ser al menos 1"
+                : "Points must be at least 1");
+            pointsInput?.focus();
+            return;
+        }
+
         const payload = {
             title,
             description,
             title_es: null,
             description_es: null,
-            points: Math.max(0, parseInt(pointsInput?.value, 10) || 0), // explicit at create time
+            points,
             effort_level: parseInt(chipState.effort, 10),
             interval_days: parseInt(chipState.interval, 10),
             is_bonus: isBonus,


### PR DESCRIPTION
## Bugs fixed

### 1. Preset click didn't set points
`TaskCreateModal` preset card click handler set `title`, `effort_level`, `interval_days` — but NOT `points`. So clicking a preset like "Clean bathroom" (5 pts) left the points input at the previous value (default 10 or whatever was typed). Every task created from a preset had the wrong point value.

**Fix:** `pointsInput.value = String(preset.points ?? 10)` added in the preset click handler.

### 2. Empty points field silently created 0-point tasks
`parseInt(pointsInput?.value, 10) || 0` — if user cleared the field, `parseInt("")` = `NaN`, `NaN || 0` = `0`. Task created with 0 points, no error shown.

**Fix:** Validate `points >= 1` before submitting; show inline error message if not.

## Test Plan
- [ ] Open task create modal → pick a preset (e.g., one with 5 pts) → verify points field updates to 5
- [ ] Open task create modal → clear the points field → click Create → verify error "Points must be at least 1" appears
- [ ] Normal flow: create a task with points = 15 → verify it saves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)