### PR TITLE
fix(gigs): remove MXN cash framing — show points only

### DIFF
--- a/frontend/src/pages/gigs/index.astro
+++ b/frontend/src/pages/gigs/index.astro
@@ -44,7 +44,7 @@ const catLabel = (cat: string) => categoryLabels[cat]?.[lang] ?? cat;
     <header slot="header" class="bg-gradient-to-br from-violet-700 to-violet-500 text-white pt-12 pb-6 px-6 rounded-b-[var(--radius-tile)] shadow-[var(--shadow-card)]">
             <div class="flex justify-between items-center mb-4">
                 <div>
-                    <p class="text-violet-200 text-sm font-medium">{lang === "es" ? "¡Gana dinero extra!" : "Earn extra money!"}</p>
+                    <p class="text-violet-200 text-sm font-medium">{lang === "es" ? "¡Gana puntos extra!" : "Earn bonus points!"}</p>
                     <h1 class="text-2xl font-bold">{lang === "es" ? "Gigs" : "Gigs"}</h1>
                 </div>
                 <a href="/gigs/my-gigs" class="bg-white/20 backdrop-blur-sm border border-white/30 text-white text-sm font-semibold px-4 py-2 rounded-xl hover:bg-white/30 transition-colors">
@@ -53,8 +53,8 @@ const catLabel = (cat: string) => categoryLabels[cat]?.[lang] ?? cat;
             </div>
             <div class="bg-white/15 backdrop-blur-sm rounded-2xl px-4 py-3 text-sm text-violet-100">
                 {lang === "es"
-                    ? "Reclama gigs, complétalas con evidencia y gana puntos que valen pesos."
-                    : "Claim gigs, complete them with proof, and earn points worth real pesos."}
+                    ? "Reclama gigs, complétalas con evidencia y gana puntos extra."
+                    : "Claim gigs, complete them with proof, and earn bonus points."}
             </div>
         </header>
             {flash && (
@@ -98,7 +98,7 @@ const catLabel = (cat: string) => categoryLabels[cat]?.[lang] ?? cat;
                                     </div>
                                     <div class="text-right flex-shrink-0">
                                         <p class="text-2xl font-extrabold text-violet-600">{o.points}</p>
-                                        <p class="text-xs text-brand-ink-soft font-medium">pts / ${o.points} MXN</p>
+                                        <p class="text-xs text-brand-ink-soft font-medium">pts</p>
                                     </div>
                                 </div>
                                 <div class="flex items-center gap-2 flex-wrap mb-4">

--- a/frontend/src/pages/gigs/my-gigs.astro
+++ b/frontend/src/pages/gigs/my-gigs.astro
@@ -90,7 +90,7 @@ const sl = (s: string) => statusLabel[s]?.[lang] ?? s;
                                 {claim.status === "approved" && (
                                     <div class="text-right">
                                         <p class="text-2xl font-extrabold text-emerald-600">+{claim.points_awarded}</p>
-                                        <p class="text-xs text-brand-ink-soft">pts / ${claim.points_awarded} MXN</p>
+                                        <p class="text-xs text-brand-ink-soft">pts</p>
                                     </div>
                                 )}
                             </div>

--- a/frontend/src/pages/parent/gigs.astro
+++ b/frontend/src/pages/parent/gigs.astro
@@ -94,7 +94,6 @@ if (flashError) Astro.cookies.delete("flash_error", { path: "/" });
                                 </div>
                                 <div class="text-right flex-shrink-0">
                                     <p class="text-xl font-extrabold text-violet-600">{o.points} pts</p>
-                                    <p class="text-xs text-brand-ink-soft">${o.points} MXN</p>
                                 </div>
                             </div>
                             <div class="flex gap-2 mt-4">
@@ -145,7 +144,7 @@ if (flashError) Astro.cookies.delete("flash_error", { path: "/" });
             </div>
             <div class="grid grid-cols-2 gap-3">
                 <div>
-                    <label class="block text-sm font-medium text-brand-ink mb-1">{lang === "es" ? "Puntos / $MXN *" : "Points / $MXN *"}</label>
+                    <label class="block text-sm font-medium text-brand-ink mb-1">{lang === "es" ? "Puntos *" : "Points *"}</label>
                     <input type="number" id="f-points" name="points" required min="1"
                         class="w-full rounded-xl border border-brand-ink/20 bg-brand-cream-deep px-3 py-2 text-sm text-brand-ink focus:outline-none focus:ring-2 focus:ring-violet-400"
                         placeholder="50" />


### PR DESCRIPTION
## Summary
- Removes `$X MXN` secondary display from gig offering cards (parent and kid views)
- Changes kid-facing header copy: "Earn extra money!" → "Earn bonus points!" (ES: "¡Gana dinero extra!" → "¡Gana puntos extra!")
- Changes subheader: "earn points worth real pesos" → "earn bonus points"
- Removes `pts / $X MXN` label from my-gigs approved card; shows `pts` only
- Changes parent create-form label "Points / \$MXN *" → "Points *"

## Why
No cash payout backend exists. The MXN framing implied a real money withdrawal path that doesn't exist, setting up a trust/expectation failure when kids see money numbers but can only redeem through the rewards flow.

## Test Plan
- [ ] Visit `/gigs` as child — confirm "Earn bonus points!" header, no MXN in point display
- [ ] Visit `/gigs/my-gigs` — approved gig shows `+N pts` with no MXN
- [ ] Visit `/parent/gigs` — offering card shows only `N pts`; create form label reads "Points *"

🤖 Generated with [Claude Code](https://claude.com/claude-code)