### PR TITLE
fix(budget): remove duplicate nav links from drawer

### DIFF
--- a/frontend/src/components/DrawerMenu.astro
+++ b/frontend/src/components/DrawerMenu.astro
@@ -13,18 +13,10 @@ const es = lang === "es";
 
 const sections = [
     {
-        title: es ? "Principal" : "Main",
-        links: [
-            { emoji: "📅", label: es ? "Vista del mes" : "Month view", href: "/budget/" },
-            { emoji: "📋", label: es ? "Movimientos" : "Transactions", href: "/budget/transactions" },
-            { emoji: "📊", label: es ? "Reportes" : "Reports", href: "/budget/reports" },
-        ],
-    },
-    {
         title: es ? "Gestión" : "Management",
         links: [
             { emoji: "🏦", label: es ? "Cuentas" : "Accounts", href: "/budget/settings#accounts" },
-            { emoji: "🏷️", label: es ? "Categorías" : "Categories", href: "/budget/" },
+            { emoji: "🏷️", label: es ? "Categorías" : "Categories", href: "/budget/settings" },
             { emoji: "👤", label: es ? "Beneficiarios" : "Payees", href: "/budget/settings#payees" },
         ],
     },


### PR DESCRIPTION
## Summary
- Removes the "Main" section (Month view / Transactions / Reports) from DrawerMenu — these three destinations are already reachable via the BudgetNavNew top tab bar on every budget page
- Fixes the Categories link that pointed to `/budget/` (dashboard) instead of `/budget/settings`
- Drawer now contains only management/tools: Accounts, Categories, Payees, Scan receipt, Import CSV, Recurring, Auto rules, Backups, Settings

## Test Plan
- [ ] Open budget drawer — no Month/Transactions/Reports links
- [ ] Categories drawer link → /budget/settings (not /budget/)
- [ ] Top tab bar still shows Month / Transactions / Reports tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)