### PR TITLE
chore(db): merge alembic heads — token_version + fk_indexes

### DIFF
--- a/backend/migrations/versions/2026_06_16_0151-eccb2d1e53e2_merge_token_version_and_fk_indexes_heads.py
+++ b/backend/migrations/versions/2026_06_16_0151-eccb2d1e53e2_merge_token_version_and_fk_indexes_heads.py
@@ -1,0 +1,24 @@
+"""merge token_version and fk_indexes heads
+
+Revision ID: eccb2d1e53e2
+Revises: 02b4ae6958cc, fcb015024c08
+Create Date: 2026-06-16 01:51:27.732322
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'eccb2d1e53e2'
+down_revision = ('02b4ae6958cc', 'fcb015024c08')
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary
- Creates the Alembic merge migration that resolves the two-head split from PRs #37 and #39 (both branched off `7a3b284cde5a`)
- Single head after: `eccb2d1e53e2`
- Verified locally: `alembic upgrade head` runs clean

## Test Plan
- [ ] `alembic upgrade head` succeeds on prod DB after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)