### PR TITLE
fix(tests): green the full suite — sync 410 tombstone + date-robust assignment queries

### DIFF
--- a/backend/app/api/routes/sync.py
+++ b/backend/app/api/routes/sync.py
@@ -1,0 +1,24 @@
+"""Sync API — decommissioned in Phase 10 (budget went native PostgreSQL).
+
+Every /api/sync/* endpoint returns 410 Gone. Kept as a small tombstone so any
+old client gets a clear, permanent signal (and a pointer to the replacement)
+instead of a bare 404. See CLAUDE.md: "/api/sync/* — returns 410 Gone".
+"""
+from fastapi import APIRouter, HTTPException, status
+
+router = APIRouter()
+
+
+@router.api_route(
+    "/{path:path}",
+    methods=["GET", "POST", "PUT", "PATCH", "DELETE"],
+    include_in_schema=False,
+)
+async def sync_gone(path: str = ""):
+    raise HTTPException(
+        status_code=status.HTTP_410_GONE,
+        detail=(
+            "The sync API was decommissioned in Phase 10. "
+            "Budget data is now native; use /api/budget/."
+        ),
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,7 +15,7 @@ from app.core.exception_handlers import register_exception_handlers
 from app.api.routes import auth, users, rewards, consequences, families, task_templates, task_assignments, oauth, payment, points_conversion, invitations, subscriptions, push, shopping, calendar, notifications, kiosk, pet, analytics, jarvis, meals, family_chat, jarvis_schedules, dm
 from app.api.routes.budget import router as budget_router
 from app.api.routes.gigs import router as gigs_router
-from app.api.routes import oversight, onboarding
+from app.api.routes import oversight, onboarding, sync
 from app.jobs.subscription_sweep import run_sweep
 from app.services.task_assignment_service import TaskAssignmentService
 from app.services.consequence_service import ConsequenceService
@@ -216,6 +216,7 @@ app.include_router(invitations.router, prefix="/api/invitations", tags=["Invitat
 app.include_router(budget_router, prefix="/api/budget", tags=["Budget"])
 app.include_router(gigs_router, prefix="/api/gigs", tags=["Gigs"])
 app.include_router(oversight.router, prefix="/api/oversight", tags=["Oversight"])
+app.include_router(sync.router, prefix="/api/sync", tags=["Sync (gone)"])
 app.include_router(points_conversion.router, prefix="/api/points-conversion", tags=["Points Conversion"])
 app.include_router(subscriptions.router, prefix="/api/subscriptions", tags=["Subscriptions"])
 from app.api.routes import subscriptions_webhook  # noqa: E402

--- a/backend/tests/test_task_assignment_service.py
+++ b/backend/tests/test_task_assignment_service.py
@@ -211,11 +211,16 @@ class TestAssignmentQueries:
             db_session, test_family.id, test_parent_user.id,
             title="Daily", interval_days=1
         )
-        await TaskAssignmentService.shuffle_tasks(db_session, test_family.id)
+        assignments = await TaskAssignmentService.shuffle_tasks(
+            db_session, test_family.id
+        )
 
-        today = date.today()
+        # Anchor to the week shuffle actually populated. It assigns to the
+        # upcoming week, which is next week's Monday when run on a Sunday — so
+        # date.today() would query the wrong (empty) week every Sunday.
+        in_week = assignments[0].week_of
         week_list = await TaskAssignmentService.list_assignments_for_week(
-            db_session, test_family.id, today
+            db_session, test_family.id, in_week
         )
         assert len(week_list) == 7  # Daily = 7 instances
 
@@ -226,11 +231,13 @@ class TestAssignmentQueries:
             db_session, test_family.id, test_parent_user.id,
             title="Daily", interval_days=1
         )
-        await TaskAssignmentService.shuffle_tasks(db_session, test_family.id)
+        assignments = await TaskAssignmentService.shuffle_tasks(
+            db_session, test_family.id
+        )
 
-        today = date.today()
+        in_week = assignments[0].week_of
         child_list = await TaskAssignmentService.list_assignments_for_week(
-            db_session, test_family.id, today, user_id=test_child_user.id
+            db_session, test_family.id, in_week, user_id=test_child_user.id
         )
         # Should have some assignments but not all 7
         assert 0 < len(child_list) <= 7
@@ -242,13 +249,17 @@ class TestAssignmentQueries:
             db_session, test_family.id, test_parent_user.id,
             title="Daily", interval_days=1
         )
-        await TaskAssignmentService.shuffle_tasks(db_session, test_family.id)
-
-        today = date.today()
-        today_list = await TaskAssignmentService.list_assignments_for_date(
-            db_session, test_family.id, today
+        assignments = await TaskAssignmentService.shuffle_tasks(
+            db_session, test_family.id
         )
-        # Daily task: exactly 1 instance for today (assigned to one member by round-robin)
+
+        # Query a date shuffle actually populated (not date.today(), which is
+        # outside the populated week when run on a Sunday).
+        a_date = assignments[0].assigned_date
+        today_list = await TaskAssignmentService.list_assignments_for_date(
+            db_session, test_family.id, a_date
+        )
+        # Daily task: exactly 1 instance per date (assigned to one member by round-robin)
         assert len(today_list) == 1
 
 


### PR DESCRIPTION
Greens the only 6 failures in the full backend suite (the long-standing "full suite never run green" item). Stacked on #52 (base = `hardening/audit-tail-batch1`); GitHub will retarget to `main` once #52 merges.

## Fixes
- **L13 — `/api/sync/* → 410` tombstone.** The sync router was deleted in the hygiene sweep, so the endpoints returned 404, but CLAUDE.md and `test_sync_deprecated` document **410 Gone**. Restored a minimal tombstone router that 410s any `/api/sync/*` path and points clients at `/api/budget/`.
- **TestAssignmentQueries (3 tests) — date-fragile.** `shuffle_tasks` assigns to the *upcoming* week (next Monday when run on a Sunday), but the tests queried `date.today()`'s week — so they failed **every Sunday** (today, 2026-06-21, is a Sunday). The product behavior is correct; the tests now anchor their queries to the week/date `shuffle` actually populated.

## Verification
Full suite: **1013 passed, 0 failed, 11 xfailed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
