### PR TITLE
fix(ux): drop gig-mode badges (M34) + hide dead 'vs Budget' report tab

### DIFF
--- a/frontend/src/components/ReportSubTabs.astro
+++ b/frontend/src/components/ReportSubTabs.astro
@@ -16,7 +16,8 @@ const tabs = [
     { id: "spending" as const, label: es ? "Gastos" : "Spending" },
     { id: "cashflow" as const, label: es ? "Flujo" : "Cashflow" },
     { id: "networth" as const, label: es ? "Patrimonio" : "Net Worth" },
-    { id: "analysis" as const, label: es ? "vs Presupuesto" : "vs Budget" },
+    // "analysis" (Budget vs Actual) is hidden until built — it was a permanent
+    // "Coming soon" dead-end. Re-add here when the report is implemented.
 ];
 ---
 

--- a/frontend/src/components/SettingsAccordion.astro
+++ b/frontend/src/components/SettingsAccordion.astro
@@ -49,53 +49,92 @@ const { id, title, icon, defaultOpen = false } = Astro.props;
 </div>
 
 <script>
+    const LS_KEY = "settingsAccordionOpen";
+
+    function loadOpen(): Set<string> {
+        try {
+            return new Set(JSON.parse(localStorage.getItem(LS_KEY) || "[]"));
+        } catch {
+            return new Set();
+        }
+    }
+    function saveOpen(set: Set<string>) {
+        try {
+            localStorage.setItem(LS_KEY, JSON.stringify([...set]));
+        } catch {
+            /* storage unavailable (private mode) — non-fatal */
+        }
+    }
+    function setOpenState(content: HTMLElement, btn: HTMLButtonElement, open: boolean) {
+        content.classList.toggle("hidden", !open);
+        btn.querySelector(".accordion-chevron")?.classList.toggle("rotate-180", open);
+        btn.setAttribute("aria-expanded", open ? "true" : "false");
+    }
+
     function initAccordions() {
-        document.querySelectorAll<HTMLButtonElement>(".accordion-toggle").forEach((btn) => {
+        const toggles = document.querySelectorAll<HTMLButtonElement>(".accordion-toggle");
+
+        toggles.forEach((btn) => {
+            // Guard against double-binding: initAccordions runs on both initial
+            // load and astro:after-swap.
+            if (btn.dataset.accordionBound) return;
+            btn.dataset.accordionBound = "1";
+
             btn.addEventListener("click", () => {
                 const targetId = btn.dataset.target;
                 if (!targetId) return;
                 const content = document.getElementById(targetId);
                 if (!content) return;
 
-                const chevron = btn.querySelector(".accordion-chevron");
-                const isHidden = content.classList.contains("hidden");
+                const willOpen = content.classList.contains("hidden");
+                setOpenState(content, btn, willOpen);
 
-                if (isHidden) {
-                    content.classList.remove("hidden");
-                    chevron?.classList.add("rotate-180");
-                    btn.setAttribute("aria-expanded", "true");
-                } else {
-                    content.classList.add("hidden");
-                    chevron?.classList.remove("rotate-180");
-                    btn.setAttribute("aria-expanded", "false");
-                }
+                // Persist so the section stays open across the page's many
+                // post-mutation reloads (and on the next visit).
+                const id = targetId.replace("accordion-content-", "");
+                const open = loadOpen();
+                if (willOpen) open.add(id);
+                else open.delete(id);
+                saveOpen(open);
             });
         });
 
-        // Auto-open section from URL hash
+        // URL hash wins: auto-open + scroll to that section.
         const hash = window.location.hash?.replace("#", "");
         if (hash) {
             const content = document.getElementById(`accordion-content-${hash}`);
-            if (content) {
-                content.classList.remove("hidden");
-                const btn = document.querySelector<HTMLButtonElement>(
-                    `[data-target="accordion-content-${hash}"]`
-                );
-                if (btn) {
-                    btn.querySelector(".accordion-chevron")?.classList.add("rotate-180");
-                    btn.setAttribute("aria-expanded", "true");
-                }
-                // Scroll to it after a short delay to allow layout
+            const btn = document.querySelector<HTMLButtonElement>(
+                `[data-target="accordion-content-${hash}"]`
+            );
+            if (content && btn) {
+                setOpenState(content, btn, true);
                 setTimeout(() => {
                     content.scrollIntoView({ behavior: "smooth", block: "start" });
                 }, 100);
             }
+            return;
         }
+
+        // No hash: restore the sections the user last had open. On a first
+        // visit (nothing persisted) open the first section so the page doesn't
+        // greet the user with a wall of collapsed empty rows.
+        const open = loadOpen();
+        if (open.size === 0 && toggles.length > 0) {
+            const first = toggles[0];
+            const targetId = first.dataset.target;
+            const content = targetId ? document.getElementById(targetId) : null;
+            if (content) setOpenState(content, first, true);
+            return;
+        }
+        open.forEach((id) => {
+            const content = document.getElementById(`accordion-content-${id}`);
+            const btn = document.querySelector<HTMLButtonElement>(
+                `[data-target="accordion-content-${id}"]`
+            );
+            if (content && btn) setOpenState(content, btn, true);
+        });
     }
 
-    // Init on first load
     initAccordions();
-
-    // Re-init on Astro view transitions
     document.addEventListener("astro:after-swap", initAccordions);
 </script>

--- a/frontend/src/components/SettingsAccordion.astro
+++ b/frontend/src/components/SettingsAccordion.astro
@@ -115,24 +115,28 @@ const { id, title, icon, defaultOpen = false } = Astro.props;
             return;
         }
 
-        // No hash: restore the sections the user last had open. On a first
-        // visit (nothing persisted) open the first section so the page doesn't
-        // greet the user with a wall of collapsed empty rows.
+        // No hash: restore the sections the user last had open.
         const open = loadOpen();
-        if (open.size === 0 && toggles.length > 0) {
-            const first = toggles[0];
-            const targetId = first.dataset.target;
-            const content = targetId ? document.getElementById(targetId) : null;
-            if (content) setOpenState(content, first, true);
-            return;
-        }
+        let openedAny = false;
         open.forEach((id) => {
             const content = document.getElementById(`accordion-content-${id}`);
             const btn = document.querySelector<HTMLButtonElement>(
                 `[data-target="accordion-content-${id}"]`
             );
-            if (content && btn) setOpenState(content, btn, true);
+            if (content && btn) {
+                setOpenState(content, btn, true);
+                openedAny = true;
+            }
         });
+        // First visit (nothing persisted) OR every persisted id is stale
+        // (renamed/removed section): open the first section so the page doesn't
+        // greet the user with a wall of collapsed empty rows.
+        if (!openedAny && toggles.length > 0) {
+            const first = toggles[0];
+            const targetId = first.dataset.target;
+            const content = targetId ? document.getElementById(targetId) : null;
+            if (content) setOpenState(content, first, true);
+        }
     }
 
     initAccordions();

--- a/frontend/src/pages/budget/reports/budget-analysis.astro
+++ b/frontend/src/pages/budget/reports/budget-analysis.astro
@@ -1,3 +1,6 @@
 ---
-return Astro.redirect("/budget/reports?tab=analysis", 301);
+// The "analysis" (Budget vs Actual) sub-tab is hidden until the report is
+// built (was a permanent "Coming soon" dead-end), so send legacy/bookmarked
+// links to the default Reports view instead of an orphaned, unselectable tab.
+return Astro.redirect("/budget/reports", 301);
 ---

--- a/frontend/src/pages/dashboard.astro
+++ b/frontend/src/pages/dashboard.astro
@@ -360,23 +360,6 @@ if (flashError) Astro.cookies.delete("flash_error", { path: "/" });
                                                 <span class="text-xs font-semibold px-2 py-0.5 rounded-full bg-brand-sun/20 text-brand-sun-deep">
                                                     {t(lang, "dashboard_bonus_badge")}
                                                 </span>
-                                                {a.template_gig_mode === "competition" && (
-                                                    <span class="text-[10px] font-bold px-2 py-0.5 rounded-full bg-red-100 text-red-700">
-                                                        🏆 {lang === "es" ? "Competencia" : "First wins"}
-                                                    </span>
-                                                )}
-                                                {a.template_gig_mode === "rotation" && (
-                                                    <span class="text-[10px] font-bold px-2 py-0.5 rounded-full bg-brand-sky/20 text-brand-sky-deep">
-                                                        🔄 {lang === "es" ? "Tu turno" : "Your turn"}
-                                                    </span>
-                                                )}
-                                                {a.template_gig_mode === "collaboration" && (
-                                                    <span class="text-[10px] font-bold px-2 py-0.5 rounded-full bg-brand-mint/20 text-brand-mint-deep">
-                                                        🤝 {lang === "es"
-                                                            ? `Colab (÷${a.template_collaboration_min_count})`
-                                                            : `Collab (÷${a.template_collaboration_min_count})`}
-                                                    </span>
-                                                )}
                                             </div>
                                             <p class="text-brand-ink-soft text-sm line-clamp-2">
                                                 {(lang === "es" && a.template_description_es ? a.template_description_es : a.template_description) || "--"}

--- a/frontend/src/pages/parent/gigs.astro
+++ b/frontend/src/pages/parent/gigs.astro
@@ -83,7 +83,7 @@ if (flashError) Astro.cookies.delete("flash_error", { path: "/" });
                 {offerings.map((item: any) => {
                     const o = item.offering ?? item;
                     return (
-                        <div class="bg-brand-cream rounded-2xl p-5 shadow-[var(--shadow-card)] border border-brand-ink/10">
+                        <div data-gig-card class="bg-brand-cream rounded-2xl p-5 shadow-[var(--shadow-card)] border border-brand-ink/10">
                             <div class="flex justify-between items-start">
                                 <div class="flex-1 pr-4">
                                     <h3 class="font-bold text-brand-ink">{o.title}</h3>
@@ -250,7 +250,17 @@ document.querySelectorAll(".archive-gig-btn").forEach(btn => {
         if (!confirm(lang === "es" ? "¿Archivar esta gig?" : "Archive this gig?")) return;
         const b = btn as HTMLElement;
         const res = await fetch(`/api/gigs/offerings/${b.dataset.id}`, { method: "DELETE" });
-        if (res.ok) window.location.reload();
+        if (res.ok) {
+            // Drop the card in place. If it was the last one, reload so the
+            // server-rendered empty state shows cleanly.
+            b.closest("[data-gig-card]")?.remove();
+            if (document.querySelectorAll("[data-gig-card]").length === 0) {
+                window.location.reload();
+            }
+        } else {
+            const err = await res.json().catch(() => ({ detail: "Error" }));
+            alert(err.detail ?? "Error");
+        }
     });
 });
 </script>

--- a/frontend/src/pages/parent/members.astro
+++ b/frontend/src/pages/parent/members.astro
@@ -249,7 +249,7 @@ if (!joinCodeOk && joinCodeError) {
       <!-- Pending Invitations Section -->
       {
         pendingInvitations.length > 0 && (
-          <section class="bg-brand-cream rounded-2xl p-5 shadow-[var(--shadow-card)] border border-brand-sun">
+          <section data-pending-section class="bg-brand-cream rounded-2xl p-5 shadow-[var(--shadow-card)] border border-brand-sun">
             <div class="flex items-center gap-2 mb-4">
               <svg class="h-5 w-5 text-brand-sun-deep animate-pulse" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
@@ -257,14 +257,14 @@ if (!joinCodeOk && joinCodeError) {
               <h2 class="font-bold text-brand-ink">
                 {lang === "es" ? "Invitaciones Pendientes" : "Pending Invitations"}
               </h2>
-              <span class="ml-auto text-xs bg-brand-sun/20 text-brand-sun-deep px-2 py-1 rounded-full font-semibold">
+              <span data-inv-count class="ml-auto text-xs bg-brand-sun/20 text-brand-sun-deep px-2 py-1 rounded-full font-semibold">
                 {pendingInvitations.length}
               </span>
             </div>
             <div class="space-y-3">
               {
                 pendingInvitations.map((inv: any) => (
-                  <div class="flex items-center justify-between p-4 bg-gradient-to-r from-amber-50 to-orange-50 rounded-xl border border-brand-sun hover:border-brand-sun transition-colors">
+                  <div data-inv-row class="flex items-center justify-between p-4 bg-gradient-to-r from-amber-50 to-orange-50 rounded-xl border border-brand-sun hover:border-brand-sun transition-colors">
                     <div class="flex-1 min-w-0">
                       <p class="text-sm font-semibold text-brand-ink break-all">
                         {inv.invited_email}
@@ -293,7 +293,7 @@ if (!joinCodeOk && joinCodeError) {
                         {lang === "es" ? "Reenviar" : "Resend"}
                       </button>
                       <button
-                        onclick={`cancelInvitation('${inv.id}', '${user.family_id}', '${lang}')`}
+                        onclick={`cancelInvitation('${inv.id}', '${user.family_id}', '${lang}', this)`}
                         class="p-2 text-red-600 hover:bg-red-100 rounded-lg transition-colors"
                         title={lang === "es" ? "Cancelar invitación" : "Cancel invitation"}
                       >
@@ -478,7 +478,7 @@ if (!joinCodeOk && joinCodeError) {
     // Cancel pending invitation. Auth rides the httpOnly cookie via
     // credentials:'include' — the proxy reads it server-side (locals.token),
     // so we must NOT try to read access_token from document.cookie here.
-    (window as any).cancelInvitation = async (invitationId: string, familyId: string, lang = 'en') => {
+    (window as any).cancelInvitation = async (invitationId: string, familyId: string, lang = 'en', btn?: HTMLButtonElement) => {
       if (!confirm(lang === "es" ? "¿Cancelar esta invitación?" : "Cancel this invitation?")) {
         return;
       }
@@ -488,7 +488,19 @@ if (!joinCodeOk && joinCodeError) {
           { method: "DELETE", headers: { "Content-Type": "application/json" }, credentials: 'include' }
         );
         if (response.ok || response.status === 204) {
-          window.location.reload();
+          // In-place: drop the row, decrement the count, and remove the whole
+          // section once the last pending invitation is gone.
+          const row = btn?.closest('[data-inv-row]');
+          const section = btn?.closest('[data-pending-section]') as HTMLElement | null;
+          row?.remove();
+          const remaining = section?.querySelectorAll('[data-inv-row]').length ?? 0;
+          if (section && remaining === 0) {
+            section.remove();
+          } else {
+            const countEl = section?.querySelector('[data-inv-count]');
+            if (countEl) countEl.textContent = String(remaining);
+          }
+          showToast(lang === "es" ? "Invitación cancelada" : "Invitation canceled", 'success');
         } else {
           const data = await response.json().catch(() => ({}));
           showToast(data.error || (lang === "es" ? "Error al cancelar la invitación" : "Error canceling invitation"), 'error');


### PR DESCRIPTION
UX-polish subset from the audit (#10). Scoped conservatively from a 10-agent analysis of all 23 location.reload/UX sites: do the low-risk, high-value, self-contained changes; leave working reloads whose in-place conversion is high-risk; defer those needing a shared SSR card-renderer.

## Changes
- **M34** — remove competition/rotation/collaboration mode badges from the kid dashboard (single-claim board decision; the gig-create modal has no mode field).
- **Reports** — remove the dead 'vs Budget' (analysis) sub-tab pill (permanent 'Coming soon' dead-end).
- **members.astro** — cancel-invitation in place: remove row, decrement count badge, drop the Pending section when empty (+ success toast).
- **parent/gigs.astro** — archive gig in place (reload only when the last card goes, so the server empty-state renders); surfaces a failure alert (was silent).
- **SettingsAccordion** — persist open sections to localStorage + auto-open the first on a fresh visit (blunts settings.astro's 12 post-mutation reloads + the 'wall of collapsed rows' first impression); double-bind guard; try/catch storage.

## Verification
`astro check`: **0 errors**. Runtime browser verification is **pending** — the local podman machine (applehv) was unstable all session (wedged 5×), so the full stack couldn't stay up to click through. Changes are low-risk by construction (each owns its data-hooks + query in one file; edge cases fall back to reload). Please confirm visually, or I can once the env is healthy.

## Deliberately not done
- **EditMemberModal** role-edit (cross-component card update — wants browser verification first).
- **transactions/settings CRUD reloads, scan-receipt, PointsConverter, AssignFundsModal, chat reactions, subscription cancel**: left as working reloads — in-place conversion is high-risk / needs server-side recompute (per the analysis).
- **gig create/edit/claim/proof**: deferred until a shared SSR card-render helper exists.

Independent of backend PRs #52/#53/#54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)