### PR TITLE
fix(audit-tail-2): PayPal backoff (L4) + report int casts (L9/L14) + UX e2e specs

### DIFF
--- a/backend/app/services/budget/report_service.py
+++ b/backend/app/services/budget/report_service.py
@@ -98,7 +98,7 @@ class ReportService:
         total_amount = 0
         
         for row in rows:
-            amount = row.total or 0
+            amount = int(row.total or 0)
             categories.append({
                 "category_id": str(row.id),
                 "category_name": row.name,
@@ -158,7 +158,7 @@ class ReportService:
         total_amount = 0
         
         for row in rows:
-            amount = row.total or 0
+            amount = int(row.total or 0)
             groups.append({
                 "group_id": str(row.id),
                 "group_name": row.name,
@@ -219,7 +219,7 @@ class ReportService:
         total_amount = 0
         
         for row in rows:
-            amount = row.total or 0
+            amount = int(row.total or 0)
             months.append({
                 "month": row.month.strftime("%Y-%m") if row.month else None,
                 "amount": amount,
@@ -283,7 +283,7 @@ class ReportService:
         total_amount = 0
         
         for row in rows:
-            amount = row.total or 0
+            amount = int(row.total or 0)
             payees.append({
                 "payee_id": str(row.id),
                 "payee_name": row.name,
@@ -369,9 +369,9 @@ class ReportService:
         total_expense = 0
         
         for row in rows:
-            income = row.income or 0
-            expense = row.expense or 0
-            net = row.net or 0
+            income = int(row.income or 0)
+            expense = int(row.expense or 0)
+            net = int(row.net or 0)
             
             periods.append({
                 "period": row.period.isoformat() if row.period else None,
@@ -438,8 +438,8 @@ class ReportService:
             balance_info = await AccountService.get_balance(
                 db, account.id, family_id, as_of_date
             )
-            balance = balance_info["balance"]
-            
+            balance = int(balance_info["balance"])
+
             # Determine if asset or liability based on account type and balance
             is_liability = account.type in ["credit_card", "loan"] or balance < 0
             
@@ -534,7 +534,7 @@ class ReportService:
             )
             .group_by(BudgetTransaction.account_id)
         )
-        prior_by_acct: dict = {row.account_id: row.amt for row in (await db.execute(prior_q)).all()}
+        prior_by_acct: dict = {row.account_id: int(row.amt or 0) for row in (await db.execute(prior_q)).all()}
 
         # Per-month activity per account, single query
         month_col = func.date_trunc("month", BudgetTransaction.date).label("month")
@@ -558,7 +558,7 @@ class ReportService:
         activity: dict = {}
         for row in (await db.execute(period_q)).all():
             month_key = row.month.date() if hasattr(row.month, "date") else row.month
-            activity[(row.account_id, date(month_key.year, month_key.month, 1))] = row.amt
+            activity[(row.account_id, date(month_key.year, month_key.month, 1))] = int(row.amt or 0)
 
         running = {
             acct_id: prior_by_acct.get(acct_id, 0)
@@ -662,7 +662,7 @@ class ReportService:
             )
             .group_by(BudgetTransaction.category_id)
         )
-        activity_by_cat = {row.category_id: row.amt for row in (await db.execute(act_q)).all()}
+        activity_by_cat = {row.category_id: int(row.amt or 0) for row in (await db.execute(act_q)).all()}
 
         result_groups: list = []
         current_group_id = None

--- a/backend/app/services/paypal_service.py
+++ b/backend/app/services/paypal_service.py
@@ -40,6 +40,12 @@ class _PayPalV2HTTP:
     _token: Optional[str] = None
     _token_exp: float = 0.0
 
+    # Transient-failure retry policy. These calls run via asyncio.to_thread,
+    # so a blocking backoff sleep is fine. 401 → refresh token + retry;
+    # 429/5xx → bounded exponential backoff.
+    _RETRY_ATTEMPTS: int = 3
+    _BACKOFF_BASE: float = 0.5
+
     @classmethod
     def _base(cls) -> str:
         mode = settings.PAYPAL_MODE or "sandbox"
@@ -68,19 +74,33 @@ class _PayPalV2HTTP:
         cls._token_exp = 0.0
 
     @classmethod
+    def _retry(cls, do_request):
+        """Run do_request() (no-arg, returns a requests.Response), retrying:
+        a 401 (likely a revoked token) refreshes the token and retries; a 429
+        or 5xx (transient) retries after bounded exponential backoff. Returns
+        the final Response (the last one if attempts are exhausted)."""
+        r = None
+        for attempt in range(cls._RETRY_ATTEMPTS):
+            r = do_request()
+            last = attempt == cls._RETRY_ATTEMPTS - 1
+            if r.status_code == 401 and not last:
+                cls._invalidate_token()
+                continue
+            if (r.status_code == 429 or r.status_code >= 500) and not last:
+                time.sleep(cls._BACKOFF_BASE * (2 ** attempt))
+                continue
+            break
+        return r
+
+    @classmethod
     def get(cls, path: str) -> Dict[str, Any]:
-        for attempt in range(2):
-            r = requests.get(
+        r = cls._retry(
+            lambda: requests.get(
                 f"{cls._base()}{path}",
                 headers={"Authorization": f"Bearer {cls._auth()}"},
                 timeout=15,
             )
-            # A 401 likely means the cached token was revoked before its
-            # natural expiry — refresh once and retry rather than wedging.
-            if r.status_code == 401 and attempt == 0:
-                cls._invalidate_token()
-                continue
-            break
+        )
         if r.status_code == 404:
             raise NotFoundException(f"PayPal resource not found: {path}")
         r.raise_for_status()
@@ -90,8 +110,8 @@ class _PayPalV2HTTP:
     def post(
         cls, path: str, body: Optional[Dict[str, Any]] = None
     ) -> Dict[str, Any]:
-        for attempt in range(2):
-            r = requests.post(
+        r = cls._retry(
+            lambda: requests.post(
                 f"{cls._base()}{path}",
                 headers={
                     "Authorization": f"Bearer {cls._auth()}",
@@ -100,10 +120,7 @@ class _PayPalV2HTTP:
                 json=body if body is not None else {},
                 timeout=15,
             )
-            if r.status_code == 401 and attempt == 0:
-                cls._invalidate_token()
-                continue
-            break
+        )
         if r.status_code == 404:
             raise NotFoundException(f"PayPal resource not found: {path}")
         if r.status_code >= 400:

--- a/backend/tests/test_paypal_token_retry.py
+++ b/backend/tests/test_paypal_token_retry.py
@@ -10,11 +10,13 @@ from requests import HTTPError
 from app.services.paypal_service import _PayPalV2HTTP
 
 
-def _resp(status, body=None, text=""):
+def _resp(status, body=None, text=None):
+    import json
     m = MagicMock()
     m.status_code = status
     m.json.return_value = body or {}
-    m.text = text
+    # post() returns {} when r.text is empty, so a body implies non-empty text.
+    m.text = text if text is not None else (json.dumps(body) if body else "")
 
     def _raise():
         if status >= 400:
@@ -39,5 +41,61 @@ def test_get_invalidates_token_and_retries_once_on_401():
         assert fake.get.call_count == 2, "must retry the GET once after a 401"
         assert _PayPalV2HTTP._token == "fresh", "stale token must be refreshed"
     finally:
+        _PayPalV2HTTP._token = None
+        _PayPalV2HTTP._token_exp = 0.0
+
+
+def _seed_token():
+    _PayPalV2HTTP._token = "t"
+    _PayPalV2HTTP._token_exp = time.time() + 3600
+
+
+def test_get_backs_off_and_retries_on_503_then_succeeds():
+    _seed_token()
+    orig = _PayPalV2HTTP._BACKOFF_BASE
+    _PayPalV2HTTP._BACKOFF_BASE = 0  # no real sleep in tests
+    try:
+        fake = MagicMock()
+        fake.get.side_effect = [_resp(503), _resp(503), _resp(200, {"ok": True})]
+        with patch("app.services.paypal_service.requests", fake):
+            out = _PayPalV2HTTP.get("/x")
+        assert out == {"ok": True}
+        assert fake.get.call_count == 3, "must retry transient 5xx with backoff"
+    finally:
+        _PayPalV2HTTP._BACKOFF_BASE = orig
+        _PayPalV2HTTP._token = None
+        _PayPalV2HTTP._token_exp = 0.0
+
+
+def test_post_retries_on_429_then_succeeds():
+    _seed_token()
+    orig = _PayPalV2HTTP._BACKOFF_BASE
+    _PayPalV2HTTP._BACKOFF_BASE = 0
+    try:
+        fake = MagicMock()
+        fake.post.side_effect = [_resp(429), _resp(200, {"ok": True})]
+        with patch("app.services.paypal_service.requests", fake):
+            out = _PayPalV2HTTP.post("/x", {"a": 1})
+        assert out == {"ok": True}
+        assert fake.post.call_count == 2
+    finally:
+        _PayPalV2HTTP._BACKOFF_BASE = orig
+        _PayPalV2HTTP._token = None
+        _PayPalV2HTTP._token_exp = 0.0
+
+
+def test_get_gives_up_after_max_attempts_on_persistent_5xx():
+    _seed_token()
+    orig = _PayPalV2HTTP._BACKOFF_BASE
+    _PayPalV2HTTP._BACKOFF_BASE = 0
+    try:
+        fake = MagicMock()
+        fake.get.side_effect = [_resp(503), _resp(503), _resp(503), _resp(503)]
+        with patch("app.services.paypal_service.requests", fake):
+            with pytest.raises(HTTPError):
+                _PayPalV2HTTP.get("/x")
+        assert fake.get.call_count == _PayPalV2HTTP._RETRY_ATTEMPTS
+    finally:
+        _PayPalV2HTTP._BACKOFF_BASE = orig
         _PayPalV2HTTP._token = None
         _PayPalV2HTTP._token_exp = 0.0

--- a/backend/tests/test_reports_and_recurring.py
+++ b/backend/tests/test_reports_and_recurring.py
@@ -455,3 +455,47 @@ class TestPostAllDue:
         assert len(result["transactions"]) == 2
         names = {t["recurring_name"] for t in result["transactions"]}
         assert names == {"Rent", "Internet"}
+
+
+class TestReportNumericTypes:
+    """L9/L14: cents fields must serialize as JSON integers (not Decimal/float)
+    for strict-Int mobile decoders; *_currency stays numeric dollars."""
+
+    @pytest.mark.asyncio
+    async def test_income_vs_expense_and_net_worth_cents_are_int(
+        self, db: AsyncSession, family_id
+    ):
+        from decimal import Decimal
+
+        acct = await AccountService.create(
+            db, family_id,
+            AccountCreate(name="Chk", type="checking", starting_balance=100_000),
+        )
+        today = date.today()
+        await TransactionService.create(
+            db, family_id,
+            TransactionCreate(account_id=acct.id, date=today, amount=50_000),
+        )
+        await TransactionService.create(
+            db, family_id,
+            TransactionCreate(account_id=acct.id, date=today, amount=-20_000),
+        )
+
+        ive = await ReportService.get_income_vs_expense(
+            db, family_id, date(today.year, 1, 1), date(today.year, 12, 31)
+        )
+        assert ive["periods"], "expected at least one period"
+        for p in ive["periods"]:
+            for k in ("income", "expense", "net"):
+                assert isinstance(p[k], int), f"{k} must be int, got {type(p[k])}"
+                assert not isinstance(p[k], Decimal)
+        for k in ("income", "expense", "net"):
+            assert isinstance(ive["totals"][k], int)
+
+        nw = await ReportService.get_net_worth(db, family_id)
+        for k in ("assets", "liabilities", "net_worth"):
+            assert isinstance(nw[k], int), f"{k} must be int, got {type(nw[k])}"
+        for a in nw["accounts"]:
+            assert isinstance(a["balance"], int)
+        # currency (dollars) must not leak a Decimal
+        assert not isinstance(nw["net_worth_currency"], Decimal)

--- a/e2e-tests/ux-polish.spec.js
+++ b/e2e-tests/ux-polish.spec.js
@@ -1,0 +1,68 @@
+const { test, expect } = require('@playwright/test');
+const { loginAsParent, BASE_URL } = require('./helpers/auth');
+
+// Regression coverage for the #55 UX-polish changes (manually browser-verified
+// 2026-06-21): dead report tab removed, settings accordion auto-open + persist,
+// and in-place gig archive.
+test.describe('UX polish (#55)', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAsParent(page);
+  });
+
+  test('reports has no dead "vs Budget" sub-tab', async ({ page }) => {
+    await page.goto(`${BASE_URL}/budget/reports`);
+    await page.waitForLoadState('networkidle');
+    await expect(page.locator('.report-tab')).toHaveCount(3); // Spending/Cashflow/Net Worth
+    await expect(page.getByText('vs Budget', { exact: true })).toHaveCount(0);
+    await expect(page.getByText('vs Presupuesto', { exact: true })).toHaveCount(0);
+  });
+
+  test('settings auto-opens the first accordion when nothing is persisted', async ({ page }) => {
+    await page.goto(`${BASE_URL}/budget/settings`);
+    await page.evaluate(() => localStorage.removeItem('settingsAccordionOpen'));
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+    const openCount = await page.$$eval(
+      '.accordion-toggle',
+      (els) => els.filter((e) => e.getAttribute('aria-expanded') === 'true').length
+    );
+    expect(openCount).toBe(1);
+  });
+
+  test('settings persists an explicitly-opened accordion across reload', async ({ page }) => {
+    await page.goto(`${BASE_URL}/budget/settings`);
+    await page.evaluate(() => localStorage.removeItem('settingsAccordionOpen'));
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+    // Open a non-default section, then reload.
+    await page.$$eval('.accordion-toggle', (els) => els[2].click());
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+    const openLabels = await page.$$eval('.accordion-toggle', (els) =>
+      els
+        .filter((e) => e.getAttribute('aria-expanded') === 'true')
+        .map((e) => e.textContent.trim().split('\n')[0])
+    );
+    expect(openLabels.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test('archiving a gig removes its card in place when others remain', async ({ page }) => {
+    for (const title of ['E2E Gig A', 'E2E Gig B']) {
+      const r = await page.request.post(`${BASE_URL}/api/gigs/offerings`, {
+        data: { title, description: 'e2e', points: 12, difficulty: 1, category: 'other' },
+      });
+      expect(r.status()).toBe(201);
+    }
+    page.on('dialog', (d) => d.accept()); // auto-accept the "Archive?" confirm
+    await page.goto(`${BASE_URL}/parent/gigs`);
+    await page.waitForLoadState('networkidle');
+
+    expect(await page.locator('[data-gig-card]').count()).toBeGreaterThanOrEqual(2);
+    const cardA = page.locator('[data-gig-card]', { hasText: 'E2E Gig A' });
+    await cardA.locator('.archive-gig-btn').click();
+
+    // In-place removal: A vanishes, B stays — no full-page reload to empty-state.
+    await expect(page.locator('[data-gig-card]', { hasText: 'E2E Gig A' })).toHaveCount(0);
+    await expect(page.locator('[data-gig-card]', { hasText: 'E2E Gig B' })).toHaveCount(1);
+  });
+});


### PR DESCRIPTION
Deferred-backlog tail, picked up after the main audit shipped. All TDD, machine-verified.

- **L4** — `_PayPalV2HTTP` now retries 429/5xx with bounded exponential backoff (`_retry` helper; 401 token-refresh retry kept). Was failing a payment call on any transient PayPal blip. Tests: 503→200, 429→200, persistent-5xx-gives-up.
- **L9/L14** — report_service packed `func.sum` Decimals into untyped dicts; FastAPI renders Decimal as a JSON float, so cents fields serialized as `15050.0` → strict-Int mobile decoders fail. `int()` every cents value at extraction across all 5 report methods; `*_currency` dollars stay float. Test asserts cents are `int`, no Decimal leaks.
- **e2e** — Playwright specs for the #55 UX flows (no dead 'vs Budget' tab, settings auto-open + persist, in-place gig archive). 4 pass.

Full backend suite was green pre-branch; these are additive. Independent of any open PR (off current main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)