### PR TITLE
fix(jarvis): align model menu + default to LiteLLM key grants (fixes 401 key_model_access_denied)

### DIFF
--- a/backend/app/api/routes/jarvis.py
+++ b/backend/app/api/routes/jarvis.py
@@ -20,7 +20,11 @@ from app.services.jarvis_service import JarvisService
 router = APIRouter()
 
 
-ALLOWED_MODELS = {"claude-haiku", "claude-sonnet", "qwen3", "gpt-4o", "gemini-2.5-flash"}
+# Only models the FTM LiteLLM virtual key is granted (see jctux/platform#86).
+# qwen3 + claude-haiku were offered but the key grants qwen2.5 + haiku, so
+# selecting them returned 401 key_model_access_denied. Re-add qwen3 here once
+# platform grants the key access to it.
+ALLOWED_MODELS = {"haiku", "claude-sonnet", "gpt-4o", "gemini-2.5-flash"}
 
 
 class ChatRequest(BaseModel):

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -53,9 +53,10 @@ class Settings(BaseSettings):
     # exchange counts as one message. Prevents accidental spend overruns
     # on the LiteLLM proxy. 0 = unlimited.
     JARVIS_DAILY_MESSAGE_CAP: int = 100
-    # LiteLLM model alias for Jarvis chat. Defaults to receipt scanner's
-    # claude-haiku for shared budget. Override via JARVIS_MODEL env.
-    JARVIS_MODEL: str = "claude-haiku"
+    # LiteLLM model alias for Jarvis chat. Must be a model the FTM virtual key
+    # is granted (the proxy alias is "haiku", not "claude-haiku" — see
+    # jctux/platform#86). Override via JARVIS_MODEL env.
+    JARVIS_MODEL: str = "haiku"
 
     # Stripe settings removed 2026-05-24. PayPal is the canonical
     # billing path. See feedback_no_stripe memory entry.

--- a/backend/tests/test_jarvis_models.py
+++ b/backend/tests/test_jarvis_models.py
@@ -1,0 +1,31 @@
+"""Jarvis must only offer / default to models the family-task-manager LiteLLM
+virtual key is actually granted — otherwise the proxy returns
+401 key_model_access_denied (see jctux/platform#86, which tracks adding qwen3).
+"""
+from app.api.routes.jarvis import ALLOWED_MODELS
+from app.core.config import settings
+
+# Models the FTM virtual key is granted on the LiteLLM proxy, verbatim from the
+# proxy's key_model_access list. Update this (and the issue) if platform grants
+# more (e.g. re-adds qwen3).
+KEY_GRANTED_MODELS = {
+    "agent-custom", "gpt-4o", "claude-sonnet", "gemini-2.5-flash", "haiku",
+    "mistral-small", "qwen2.5", "qwen2.5vl-frigate", "qwen2.5vl-frigate:latest",
+    "qwen-vl",
+}
+
+
+def test_all_offered_models_are_key_granted():
+    ungranted = ALLOWED_MODELS - KEY_GRANTED_MODELS
+    assert not ungranted, f"Jarvis offers models the key can't access: {ungranted}"
+
+
+def test_default_jarvis_model_is_key_granted():
+    assert settings.JARVIS_MODEL in KEY_GRANTED_MODELS, (
+        f"default JARVIS_MODEL={settings.JARVIS_MODEL!r} not in the key's grants"
+    )
+
+
+def test_qwen3_not_offered_until_platform_grants_it():
+    # The exact model that triggered the 401; keep it out until platform#86 lands.
+    assert "qwen3" not in ALLOWED_MODELS


### PR DESCRIPTION
Jarvis 401'd because it offered `qwen3` and defaulted to `claude-haiku`, neither granted to the FTM LiteLLM virtual key (which grants `qwen2.5` + `haiku`). Drop qwen3, rename claude-haiku→haiku, default JARVIS_MODEL=haiku. Menu now all key-granted. Platform re-adds qwen3 via jctux/platform#86. Regression test pins offered/default models to the key's grant list. 20 jarvis tests pass.