### PR TITLE
fix(jarvis): default to gemini-2.5-flash — the only LiteLLM model that works end-to-end

### DIFF
--- a/backend/app/api/routes/jarvis.py
+++ b/backend/app/api/routes/jarvis.py
@@ -20,11 +20,12 @@ from app.services.jarvis_service import JarvisService
 router = APIRouter()
 
 
-# Only models the FTM LiteLLM virtual key is granted (see jctux/platform#86).
-# qwen3 + claude-haiku were offered but the key grants qwen2.5 + haiku, so
-# selecting them returned 401 key_model_access_denied. Re-add qwen3 here once
-# platform grants the key access to it.
-ALLOWED_MODELS = {"haiku", "claude-sonnet", "gpt-4o", "gemini-2.5-flash"}
+# gemini-2.5-flash is the only model the FTM key reaches end-to-end today: the
+# granted Anthropic/OpenAI routes 401 upstream and qwen/mistral aliases are
+# invalid on the proxy (see jctux/platform#86). Any other selection falls back
+# to the default (also gemini) below. Re-expand this once platform fixes the
+# other upstreams.
+ALLOWED_MODELS = {"gemini-2.5-flash"}
 
 
 class ChatRequest(BaseModel):

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -53,10 +53,13 @@ class Settings(BaseSettings):
     # exchange counts as one message. Prevents accidental spend overruns
     # on the LiteLLM proxy. 0 = unlimited.
     JARVIS_DAILY_MESSAGE_CAP: int = 100
-    # LiteLLM model alias for Jarvis chat. Must be a model the FTM virtual key
-    # is granted (the proxy alias is "haiku", not "claude-haiku" — see
-    # jctux/platform#86). Override via JARVIS_MODEL env.
-    JARVIS_MODEL: str = "haiku"
+    # LiteLLM model alias for Jarvis chat. gemini-2.5-flash is the only model
+    # the FTM virtual key can actually reach end-to-end right now — the granted
+    # Anthropic (haiku/claude-sonnet) + OpenAI (gpt-4o) routes 401 upstream and
+    # qwen2.5/mistral aliases 400 as invalid (see jctux/platform#86). It's also
+    # the receipt scanner's model, so the proxy path is proven. Override via
+    # JARVIS_MODEL env once platform fixes the other upstreams.
+    JARVIS_MODEL: str = "gemini-2.5-flash"
 
     # Stripe settings removed 2026-05-24. PayPal is the canonical
     # billing path. See feedback_no_stripe memory entry.

--- a/backend/tests/test_jarvis_models.py
+++ b/backend/tests/test_jarvis_models.py
@@ -1,31 +1,28 @@
 """Jarvis must only offer / default to models the family-task-manager LiteLLM
-virtual key is actually granted — otherwise the proxy returns
-401 key_model_access_denied (see jctux/platform#86, which tracks adding qwen3).
+key reaches END-TO-END. Being *granted* isn't enough — verified on prod
+(2026-06-22) that the granted Anthropic (haiku/claude-sonnet) + OpenAI (gpt-4o)
+routes 401 upstream and qwen2.5/mistral aliases 400 as invalid; only
+gemini-2.5-flash actually returns a completion. Tracked in jctux/platform#86;
+re-expand this set as upstreams are fixed.
 """
 from app.api.routes.jarvis import ALLOWED_MODELS
 from app.core.config import settings
 
-# Models the FTM virtual key is granted on the LiteLLM proxy, verbatim from the
-# proxy's key_model_access list. Update this (and the issue) if platform grants
-# more (e.g. re-adds qwen3).
-KEY_GRANTED_MODELS = {
-    "agent-custom", "gpt-4o", "claude-sonnet", "gemini-2.5-flash", "haiku",
-    "mistral-small", "qwen2.5", "qwen2.5vl-frigate", "qwen2.5vl-frigate:latest",
-    "qwen-vl",
-}
+# Models that work end-to-end with the FTM key (prod-probe verified).
+WORKING_MODELS = {"gemini-2.5-flash"}
 
 
-def test_all_offered_models_are_key_granted():
-    ungranted = ALLOWED_MODELS - KEY_GRANTED_MODELS
-    assert not ungranted, f"Jarvis offers models the key can't access: {ungranted}"
+def test_all_offered_models_work_end_to_end():
+    broken = ALLOWED_MODELS - WORKING_MODELS
+    assert not broken, f"Jarvis offers models that don't work with the key: {broken}"
 
 
-def test_default_jarvis_model_is_key_granted():
-    assert settings.JARVIS_MODEL in KEY_GRANTED_MODELS, (
-        f"default JARVIS_MODEL={settings.JARVIS_MODEL!r} not in the key's grants"
+def test_default_jarvis_model_works_end_to_end():
+    assert settings.JARVIS_MODEL in WORKING_MODELS, (
+        f"default JARVIS_MODEL={settings.JARVIS_MODEL!r} is not a working model"
     )
 
 
 def test_qwen3_not_offered_until_platform_grants_it():
-    # The exact model that triggered the 401; keep it out until platform#86 lands.
+    # The model that triggered the original 401; keep it out until platform#86.
     assert "qwen3" not in ALLOWED_MODELS

--- a/frontend/src/pages/parent/jarvis.astro
+++ b/frontend/src/pages/parent/jarvis.astro
@@ -82,11 +82,10 @@ const labels = {
                     id="model-select"
                     class="w-full bg-white/15 text-white text-xs font-semibold rounded-xl px-3 py-2 border border-white/30 focus:outline-none focus:ring-2 focus:ring-white/50 appearance-none cursor-pointer"
                 >
-                    <option value="claude-haiku">⚡ Claude Haiku — fast &amp; cheap (default)</option>
-                    <option value="claude-sonnet">🧠 Claude Sonnet — smarter, slower</option>
-                    <option value="gpt-4o">🟢 GPT-4o</option>
+                    <!-- gemini-2.5-flash is the only model the LiteLLM key
+                         currently reaches end-to-end (see jctux/platform#86);
+                         re-add others once their upstreams are fixed. -->
                     <option value="gemini-2.5-flash">💎 Gemini 2.5 Flash</option>
-                    <option value="qwen3">🖥️ Qwen 2.5 3B — local GPU, free</option>
                 </select>
             </div>
     </Fragment>
@@ -140,10 +139,12 @@ const labels = {
         const scroll = document.getElementById("chat-scroll");
         if (!form || !input) return;
 
-        // Restore persisted model choice (migrate deprecated qwen-coder → mistral-nemo)
-        let savedModel = localStorage.getItem("jarvis-model") || "claude-haiku";
-        if (["qwen-coder", "mistral-nemo", "gemma3"].includes(savedModel)) {
-            savedModel = "qwen3";
+        // gemini-2.5-flash is the only model the LiteLLM key reaches today, so
+        // pin to it and migrate any stale persisted choice (platform#86).
+        const WORKING_MODEL = "gemini-2.5-flash";
+        let savedModel = localStorage.getItem("jarvis-model");
+        if (savedModel !== WORKING_MODEL) {
+            savedModel = WORKING_MODEL;
             localStorage.setItem("jarvis-model", savedModel);
         }
         if (modelSelect) {
@@ -161,7 +162,7 @@ const labels = {
             if (!message) return;
             input.value = "";
             input.disabled = true;
-            const selectedModel = modelSelect?.value || "claude-haiku";
+            const selectedModel = modelSelect?.value || "gemini-2.5-flash";
 
             // Optimistic user bubble
             if (scroll) {


### PR DESCRIPTION
Follow-up to #57. Prod probe with the FTM key proved 'granted' != 'works': haiku/claude-sonnet 401 upstream (broken Anthropic creds), gpt-4o 401 (OpenAI), qwen2.5/mistral 400 (invalid aliases) — only **gemini-2.5-flash** returns a completion (= receipt-scanner model). Default + menu (backend ALLOWED_MODELS + frontend dropdown) pinned to gemini-2.5-flash; stale persisted choices migrated. Broader upstream breakage tracked in jctux/platform#86 (commented). 20 jarvis tests + astro check pass.