### PR TITLE
fix(roles): kid-gating role comparisons use lowercase enum values

### DIFF
--- a/frontend/src/pages/dashboard.astro
+++ b/frontend/src/pages/dashboard.astro
@@ -51,7 +51,7 @@ const progressPercent = requiredTotal > 0 ? Math.round((requiredCompleted / requ
 // Gig trust streak — mirrors backend GIG_AUTO_APPROVE_STREAK default (3).
 // Once a kid hits the threshold, their submitted gigs auto-approve.
 const TRUST_THRESHOLD = 3;
-const isKid = user.role === "TEEN" || user.role === "CHILD";
+const isKid = user.role === "teen" || user.role === "child";
 const trustStreak = user.gig_trust_streak ?? 0;
 const toAutoApprove = Math.max(0, TRUST_THRESHOLD - trustStreak);
 
@@ -176,8 +176,8 @@ if (flashError) Astro.cookies.delete("flash_error", { path: "/" });
     <Fragment slot="banner">
         <GigsIntroBanner lang={lang} show={!user.acknowledged_gigs_intro} />
 
-        <!-- Points Converter (only for TEEN/CHILD users) -->
-        {(user.role === "TEEN" || user.role === "CHILD") && (
+        <!-- Points Converter (only for teen/child users) -->
+        {(user.role === "teen" || user.role === "child") && (
             <PointsConverter
                 userId={user.id}
                 currentPoints={user.points}

--- a/frontend/src/pages/rewards.astro
+++ b/frontend/src/pages/rewards.astro
@@ -54,7 +54,7 @@ const rewards: any[] = Array.isArray(rewardsRaw) ? rewardsRaw : [];
 const blockingTitles: string[] = Array.isArray(blockingRaw) ? blockingRaw : [];
 const isLocked = blockingTitles.length > 0;
 const activeGoal: any = activeGoalRaw ?? null;
-const isKid = user?.role === "CHILD" || user?.role === "TEEN";
+const isKid = user?.role === "child" || user?.role === "teen";
 
 const flash = Astro.cookies.get("flash")?.value;
 const flashError = Astro.cookies.get("flash_error")?.value;

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -6,7 +6,7 @@ export interface User {
     id: string;
     email: string;
     name: string;
-    role: "PARENT" | "CHILD" | "TEEN";
+    role: "parent" | "child" | "teen";
     points: number;
     family_id: string;
     is_active: boolean;


### PR DESCRIPTION
## Problem
`UserRole` serializes to **lowercase** (`parent`/`child`/`teen`, `backend/app/models/user.py:13-15`) and `/api/auth/me` returns it that way. But several frontend gates compared `user.role` against **uppercase** `"TEEN"`/`"CHILD"`, so those conditions were **always false** and the kid-only UI silently never rendered in production.

## Impact (all live regressions)
- **`dashboard.astro:180`** — the **PointsConverter never showed for kids** (they couldn't convert points → rewards from the dashboard).
- **`dashboard.astro:54` (`isKid`)** — trust-streak chip, affordability goal card, and the push-enable prompt never showed for kids.
- **`rewards.astro:57` (`isKid`)** — goal highlighting on reward cards never applied for kids.
- **`types/api.ts:9`** — the `User.role` union mislabeled the actual values.

## Fix
All four sites now use the lowercase literals, matching the already-correct pattern in `profile.astro` / `parent/index.astro`. 5 lines, no behavior change for parents.

Found during the code review of #59 (flagged as pre-existing, out of scope there).

## Verify
`astro check`: 0 errors / 0 warnings; `npm run build`: ✓. No uppercase role literals remain in `frontend/src`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)