### PR TITLE
test(onboarding): e2e for kid tour, kid-gating, eligible converter

### DIFF
--- a/backend/seed_data.py
+++ b/backend/seed_data.py
@@ -188,8 +188,13 @@ async def create_task_templates(session: AsyncSession, family, parent):
     return templates
 
 
-async def create_assignments(session: AsyncSession, family, templates, members):
-    """Shuffle tasks into weekly assignments"""
+async def create_assignments(session: AsyncSession, family, templates, members, eligible_kid=None):
+    """Shuffle tasks into weekly assignments.
+
+    If eligible_kid is given, ALL of that kid's regular (non-bonus) current-week
+    assignments are marked completed so the demo — and the points-converter e2e —
+    reliably shows an eligible "Convert Points to Money" card for them.
+    """
     print("\nCreating weekly task assignments...")
     week_monday = TODAY - timedelta(days=TODAY.weekday())
     regular = [t for t in templates if not t.is_bonus]
@@ -229,6 +234,16 @@ async def create_assignments(session: AsyncSession, family, templates, members):
         if a.assigned_date < TODAY and random.random() < 0.7:
             a.status = AssignmentStatus.COMPLETED
             a.completed_at = datetime.combine(a.assigned_date, datetime.min.time()).replace(hour=15, minute=30)
+
+    # Deterministically complete one kid's regular current-week tasks (100%) so
+    # points conversion is reliably eligible for them in the demo + e2e.
+    if eligible_kid is not None:
+        regular_ids = {t.id for t in regular}
+        for a in assignments:
+            if a.assigned_to == eligible_kid.id and a.template_id in regular_ids:
+                a.status = AssignmentStatus.COMPLETED
+                if a.completed_at is None:
+                    a.completed_at = datetime.combine(a.assigned_date, datetime.min.time()).replace(hour=15, minute=30)
 
     session.add_all(assignments)
     await session.commit()
@@ -868,7 +883,7 @@ async def main():
 
         # Tasks
         templates = await create_task_templates(session, family, mom)
-        assignments = await create_assignments(session, family, templates, all_members)
+        assignments = await create_assignments(session, family, templates, all_members, eligible_kid=emma)
 
         # Rewards & consequences
         rewards = await create_rewards(session, family, mom)

--- a/e2e-tests/kid-onboarding.spec.js
+++ b/e2e-tests/kid-onboarding.spec.js
@@ -1,0 +1,90 @@
+const { test, expect } = require('@playwright/test');
+
+/**
+ * Kid-side onboarding coverage:
+ *  - the kid welcome tour auto-starts on /dashboard, is skippable, and stays
+ *    dismissed after a reload (the onDestroyStarted/sendBeacon persistence fix);
+ *  - the dashboard is kid-gated (the isKid-only push-enable button renders for a
+ *    child — guards the lowercase-role fix in PR #60);
+ *  - an eligible kid sees the green points-converter card.
+ *
+ * Requires the dev stack on :3003 with the current build + seeded demo data
+ * (emma@demo.com is seeded with completed current-week tasks => eligible).
+ */
+test.describe('Kid onboarding', () => {
+  const BASE_URL = process.env.BASE_URL || 'http://localhost:3003';
+  const PASS = 'KidOnb123!';
+
+  test('kid tour auto-starts, is skippable, persists; dashboard is kid-gated', async ({ page, context }) => {
+    const ts = Date.now();
+    const parentEmail = `kid-onb-parent-${ts}@example.com`;
+    const kidEmail = `kid-onb-kid-${ts}@example.com`;
+
+    // Register a fresh family (creates a PARENT).
+    await page.goto(`${BASE_URL}/register`);
+    await page.waitForLoadState('networkidle');
+    await page.fill('input[name="family_name"]', `KidOnb ${ts}`);
+    await page.fill('input[name="name"]', 'Onb Parent');
+    await page.fill('input[name="email"]', parentEmail);
+    await page.fill('input[name="password"]', PASS);
+    await page.fill('input[name="password_confirm"]', PASS);
+    await page.click('#register-submit-btn');
+    await page.waitForURL(/\/(dashboard|parent)/, { timeout: 30000 });
+
+    // Create a child login via the members "Register Member" form.
+    await page.goto(`${BASE_URL}/parent/members`);
+    await page.waitForLoadState('networkidle');
+    const form = page.locator('form:has(input[name="password"])');
+    await form.locator('input[name="name"]').fill('Onb Kid');
+    await form.locator('input[name="email"]').fill(kidEmail);
+    await form.locator('input[name="password"]').fill(PASS);
+    await form.locator('select[name="role"]').selectOption('child');
+    await page.click('button:has-text("Register Member")');
+    await page.waitForLoadState('networkidle');
+    await expect(page.locator('body')).toContainText('Onb Kid');
+
+    // Log out, log in as the child.
+    await context.clearCookies();
+    await page.goto(`${BASE_URL}/login`);
+    await page.fill('input[name="email"]', kidEmail);
+    await page.fill('input[name="password"]', PASS);
+    await page.click('#login-submit-btn');
+    await page.waitForURL('**/dashboard', { timeout: 30000 });
+
+    // Kid welcome tour auto-starts.
+    const popover = page.locator('.driver-popover');
+    await expect(popover).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('.driver-popover-title')).toHaveText(/Welcome/i);
+
+    // Kid-gating: the push-enable button is rendered only inside {isKid && ...}.
+    await expect(page.locator('#enable-push-btn')).toHaveCount(1);
+
+    // Skip, then confirm it does not return after an immediate reload.
+    await page.locator('.driver-popover-close-btn').click();
+    await expect(popover).toBeHidden({ timeout: 5000 });
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(1500);
+    await expect(page.locator('.driver-popover')).toHaveCount(0);
+  });
+
+  test('eligible kid sees the points converter', async ({ page }) => {
+    // emma is seeded eligible (completed current-week tasks + 150 pts).
+    await page.goto(`${BASE_URL}/login`);
+    await page.fill('input[name="email"]', 'emma@demo.com');
+    await page.fill('input[name="password"]', 'password123');
+    await page.click('#login-submit-btn');
+    await page.waitForURL('**/dashboard', { timeout: 30000 });
+
+    // Dismiss the welcome tour if it shows (emma's first visit).
+    const close = page.locator('.driver-popover-close-btn');
+    if (await close.isVisible().catch(() => false)) {
+      await close.click();
+      await page.waitForTimeout(300);
+    }
+
+    await expect(page.locator('body')).toContainText(/Convert Points to Money/i, {
+      timeout: 10000,
+    });
+  });
+});


### PR DESCRIPTION
Locks in kid-side onboarding behavior previously verified only by hand (3 passing specs):
- kid welcome tour auto-starts on `/dashboard`, skippable, stays dismissed after an immediate reload (guards the `onDestroyStarted`/`sendBeacon` persistence fix from #61);
- dashboard is kid-gated — the `isKid`-only push-enable button renders for a child (guards the lowercase-role fix from #60);
- an eligible kid sees the green "Convert Points to Money" card.

`seed_data`: `create_assignments` gains an `eligible_kid` arg; emma's regular current-week tasks are completed so points conversion is deterministically eligible for her in the demo + e2e.

Verified: `npx playwright test kid-onboarding.spec.js welcome-tour.spec.js` → 3 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)