### PR TITLE
feat(onboarding): welcome-tour funnel analytics

### DIFF
--- a/backend/app/api/routes/onboarding.py
+++ b/backend/app/api/routes/onboarding.py
@@ -2,10 +2,14 @@
 from fastapi import APIRouter, Depends, Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.dependencies import get_db, require_parent_role
+from app.core.dependencies import get_db, get_current_user, require_parent_role
 from app.core.type_utils import to_uuid_required
 from app.models.user import User
-from app.schemas.onboarding import OnboardingState
+from app.schemas.onboarding import (
+    OnboardingState,
+    OnboardingEventCreate,
+    OnboardingAnalytics,
+)
 from app.services.onboarding_service import OnboardingService
 
 router = APIRouter()
@@ -28,3 +32,26 @@ async def dismiss_onboarding(
     family_id = to_uuid_required(current_user.family_id)
     await OnboardingService.dismiss(family_id, db)
     return Response(status_code=204)
+
+
+@router.post("/events", status_code=204)
+async def record_onboarding_event(
+    payload: OnboardingEventCreate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Record a welcome-tour funnel event (any family member)."""
+    await OnboardingService.record_event(
+        current_user, payload.event_type, payload.step_index, db
+    )
+    return Response(status_code=204)
+
+
+@router.get("/analytics", response_model=OnboardingAnalytics)
+async def get_onboarding_analytics(
+    current_user: User = Depends(require_parent_role),
+    db: AsyncSession = Depends(get_db),
+):
+    """Parent-facing onboarding funnel: tour completion per member + checklist."""
+    family_id = to_uuid_required(current_user.family_id)
+    return await OnboardingService.get_analytics(family_id, db)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -51,6 +51,7 @@ from app.models.jarvis_schedule import JarvisSchedule
 from app.models.dm import DMThread, DMMessage
 from app.models.gig import GigOffering, GigClaim, GigCategory, GigClaimStatus
 from app.models.reward_goal import UserRewardGoal
+from app.models.onboarding_event import OnboardingEvent, ONBOARDING_EVENT_TYPES
 
 __all__ = [
     "Base",
@@ -116,6 +117,9 @@ __all__ = [
     "GigClaimStatus",
     # Reward goals
     "UserRewardGoal",
+    # Onboarding analytics
+    "OnboardingEvent",
+    "ONBOARDING_EVENT_TYPES",
     # Enums
     "UserRole",
     "TaskStatus",

--- a/backend/app/models/onboarding_event.py
+++ b/backend/app/models/onboarding_event.py
@@ -1,0 +1,39 @@
+"""OnboardingEvent — funnel events for the welcome tour + onboarding.
+
+One row per event (tour started / completed / skipped / replayed) so the parent
+can see whether new family members actually finish onboarding, not just whether
+they were shown it (that's the boolean users.completed_welcome_tour flag).
+"""
+from sqlalchemy import Column, String, Integer, DateTime, ForeignKey
+from sqlalchemy.dialects.postgresql import UUID
+from datetime import datetime
+import uuid
+
+from app.core.database import Base
+
+# Recognized event types. Kept as plain strings (not a DB enum) so adding a new
+# event never needs a migration; the route validates against this set.
+ONBOARDING_EVENT_TYPES = frozenset(
+    {"tour_started", "tour_completed", "tour_skipped", "tour_replayed"}
+)
+
+
+class OnboardingEvent(Base):
+    __tablename__ = "onboarding_events"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    family_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("families.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    event_type = Column(String(40), nullable=False)
+    step_index = Column(Integer, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)

--- a/backend/app/schemas/onboarding.py
+++ b/backend/app/schemas/onboarding.py
@@ -1,3 +1,5 @@
+from typing import List, Optional
+
 from pydantic import BaseModel, model_validator
 
 
@@ -20,3 +22,29 @@ class OnboardingState(BaseModel):
         return self
 
     model_config = {"from_attributes": True}
+
+
+class OnboardingEventCreate(BaseModel):
+    """Body for recording a welcome-tour funnel event."""
+    event_type: str
+    step_index: Optional[int] = None
+
+
+class MemberOnboarding(BaseModel):
+    user_id: str
+    name: str
+    role: str
+    completed_welcome_tour: bool
+    # completed | skipped | started | not_started — derived from events + flag.
+    tour_status: str
+
+
+class OnboardingAnalytics(BaseModel):
+    """Parent-facing onboarding funnel for the family."""
+    total_members: int
+    tour_completed: int
+    tour_skipped: int
+    tour_started: int
+    tour_not_started: int
+    checklist: OnboardingState
+    members: List[MemberOnboarding]

--- a/backend/app/services/onboarding_service.py
+++ b/backend/app/services/onboarding_service.py
@@ -2,11 +2,17 @@
 import logging
 from uuid import UUID
 
-from sqlalchemy import update
+from sqlalchemy import update, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.family import Family
-from app.schemas.onboarding import OnboardingState
+from app.models.user import User
+from app.models.onboarding_event import OnboardingEvent, ONBOARDING_EVENT_TYPES
+from app.schemas.onboarding import (
+    OnboardingState,
+    OnboardingAnalytics,
+    MemberOnboarding,
+)
 
 log = logging.getLogger(__name__)
 
@@ -55,3 +61,71 @@ class OnboardingService:
             .values(onboarding_dismissed=True)
         )
         await db.commit()
+
+    @staticmethod
+    async def record_event(
+        user: User, event_type: str, step_index, db: AsyncSession
+    ) -> bool:
+        """Record a welcome-tour funnel event. Returns False for unknown types."""
+        if event_type not in ONBOARDING_EVENT_TYPES:
+            log.warning("OnboardingService.record_event: unknown type %r", event_type)
+            return False
+        db.add(OnboardingEvent(
+            user_id=user.id,
+            family_id=user.family_id,
+            event_type=event_type,
+            step_index=step_index,
+        ))
+        await db.commit()
+        return True
+
+    @staticmethod
+    async def get_analytics(family_id: UUID, db: AsyncSession) -> OnboardingAnalytics:
+        """Funnel summary: per-member tour status + family checklist progress."""
+        members = (await db.execute(
+            select(User).where(
+                User.family_id == family_id, User.is_active.is_(True)
+            )
+        )).scalars().all()
+        event_rows = (await db.execute(
+            select(OnboardingEvent.user_id, OnboardingEvent.event_type)
+            .where(OnboardingEvent.family_id == family_id)
+        )).all()
+
+        by_user: dict = {}
+        for uid, etype in event_rows:
+            by_user.setdefault(uid, set()).add(etype)
+
+        def status_for(u: User) -> str:
+            types = by_user.get(u.id, set())
+            if "tour_completed" in types:
+                return "completed"
+            if "tour_skipped" in types:
+                return "skipped"
+            if "tour_started" in types:
+                return "started"
+            return "not_started"
+
+        rows = []
+        counts = {"completed": 0, "skipped": 0, "started": 0, "not_started": 0}
+        for u in members:
+            st = status_for(u)
+            counts[st] += 1
+            rows.append(MemberOnboarding(
+                user_id=str(u.id),
+                name=u.name,
+                role=u.role.value if hasattr(u.role, "value") else str(u.role),
+                completed_welcome_tour=bool(u.completed_welcome_tour),
+                tour_status=st,
+            ))
+
+        checklist = await OnboardingService.get_state(family_id, db)
+        return OnboardingAnalytics(
+            total_members=len(members),
+            tour_completed=counts["completed"],
+            tour_skipped=counts["skipped"],
+            tour_started=counts["started"],
+            tour_not_started=counts["not_started"],
+            checklist=checklist,
+            members=rows,
+        )

--- a/backend/migrations/versions/2026_06_22_onboarding_events.py
+++ b/backend/migrations/versions/2026_06_22_onboarding_events.py
@@ -1,0 +1,37 @@
+"""create onboarding_events table
+
+Revision ID: onboarding_events
+Revises: welcome_tour_flag
+Create Date: 2026-06-22
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = 'onboarding_events'
+down_revision = 'welcome_tour_flag'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'onboarding_events',
+        sa.Column('id', UUID(as_uuid=True), primary_key=True),
+        sa.Column('user_id', UUID(as_uuid=True),
+                  sa.ForeignKey('users.id', ondelete='CASCADE'), nullable=False),
+        sa.Column('family_id', UUID(as_uuid=True),
+                  sa.ForeignKey('families.id', ondelete='CASCADE'), nullable=False),
+        sa.Column('event_type', sa.String(length=40), nullable=False),
+        sa.Column('step_index', sa.Integer(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+    )
+    op.create_index('ix_onboarding_events_user_id', 'onboarding_events', ['user_id'])
+    op.create_index('ix_onboarding_events_family_id', 'onboarding_events', ['family_id'])
+
+
+def downgrade() -> None:
+    op.drop_index('ix_onboarding_events_family_id', table_name='onboarding_events')
+    op.drop_index('ix_onboarding_events_user_id', table_name='onboarding_events')
+    op.drop_table('onboarding_events')

--- a/backend/tests/test_onboarding_analytics.py
+++ b/backend/tests/test_onboarding_analytics.py
@@ -1,0 +1,63 @@
+"""Tests for onboarding funnel events + analytics."""
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_record_event_and_analytics(client: AsyncClient, auth_headers):
+    r = await client.post(
+        "/api/families/onboarding/events",
+        headers=auth_headers,
+        json={"event_type": "tour_completed", "step_index": 7},
+    )
+    assert r.status_code == 204
+
+    a = await client.get(
+        "/api/families/onboarding/analytics", headers=auth_headers
+    )
+    assert a.status_code == 200
+    data = a.json()
+    assert data["tour_completed"] >= 1
+    assert any(m["tour_status"] == "completed" for m in data["members"])
+    assert "checklist" in data
+    assert data["total_members"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_unknown_event_type_is_ignored(client: AsyncClient, auth_headers):
+    r = await client.post(
+        "/api/families/onboarding/events",
+        headers=auth_headers,
+        json={"event_type": "bogus"},
+    )
+    assert r.status_code == 204
+    a = await client.get(
+        "/api/families/onboarding/analytics", headers=auth_headers
+    )
+    assert a.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_skipped_vs_completed_precedence(client: AsyncClient, auth_headers):
+    # A skip followed by a completion should read as completed (completed wins).
+    await client.post(
+        "/api/families/onboarding/events",
+        headers=auth_headers,
+        json={"event_type": "tour_skipped"},
+    )
+    await client.post(
+        "/api/families/onboarding/events",
+        headers=auth_headers,
+        json={"event_type": "tour_completed"},
+    )
+    a = await client.get(
+        "/api/families/onboarding/analytics", headers=auth_headers
+    )
+    data = a.json()
+    assert any(m["tour_status"] == "completed" for m in data["members"])
+
+
+@pytest.mark.asyncio
+async def test_analytics_requires_auth(client: AsyncClient):
+    r = await client.get("/api/families/onboarding/analytics")
+    assert r.status_code in (401, 403)

--- a/frontend/src/lib/tour.ts
+++ b/frontend/src/lib/tour.ts
@@ -54,6 +54,31 @@ function ackTour(): void {
     }
 }
 
+/** Fire-and-forget onboarding funnel event (survives navigation via beacon). */
+function recordEvent(eventType: string, stepIndex?: number): void {
+    try {
+        const body = JSON.stringify({
+            event_type: eventType,
+            step_index: stepIndex ?? null,
+        });
+        if (typeof navigator !== "undefined" && navigator.sendBeacon) {
+            navigator.sendBeacon(
+                "/api/onboarding/events",
+                new Blob([body], { type: "application/json" }),
+            );
+        } else {
+            void fetch("/api/onboarding/events", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body,
+                keepalive: true,
+            });
+        }
+    } catch {
+        /* analytics is best-effort */
+    }
+}
+
 /**
  * Drive the tour. Steps whose element is not present in the DOM are dropped
  * (e.g. the checklist widget after it's dismissed) so the tour never points at
@@ -61,7 +86,11 @@ function ackTour(): void {
  * onDestroyStarted, which fires the moment teardown begins (before the exit
  * animation) so the guard lands even on an immediate reload.
  */
-export function runTour(steps: TourStep[], btn: TourButtons): void {
+export function runTour(
+    steps: TourStep[],
+    btn: TourButtons,
+    startEvent = "tour_started",
+): void {
     // Keep element-less steps (centered modals); for targeted steps, require the
     // element to be present AND actually visible — a nav item collapsed at the
     // current breakpoint (display:none / zero-size) would otherwise get an empty
@@ -74,6 +103,8 @@ export function runTour(steps: TourStep[], btn: TourButtons): void {
         return rect.width > 0 && rect.height > 0 && el.offsetParent !== null;
     });
     if (present.length === 0) return;
+
+    recordEvent(startEvent);
 
     const d = driver({
         showProgress: true,
@@ -95,7 +126,11 @@ export function runTour(steps: TourStep[], btn: TourButtons): void {
         // Fires on every exit path (X, done, ESC, overlay) the instant teardown
         // starts. Overriding it means we own the destroy() call.
         onDestroyStarted: () => {
+            const idx = (d as any).getActiveIndex?.();
+            const completed =
+                typeof idx === "number" && idx >= present.length - 1;
             ackTour();
+            recordEvent(completed ? "tour_completed" : "tour_skipped", idx);
             d.destroy();
         },
     });
@@ -109,7 +144,7 @@ export function replayTour(steps: TourStep[], btn: TourButtons): void {
     } catch {
         /* ignore */
     }
-    runTour(steps, btn);
+    runTour(steps, btn, "tour_replayed");
 }
 
 /** True if the tour was already finished/skipped on this device. */

--- a/frontend/src/pages/api/onboarding/events.ts
+++ b/frontend/src/pages/api/onboarding/events.ts
@@ -1,0 +1,39 @@
+import type { APIRoute } from "astro";
+
+/**
+ * POST /api/onboarding/events — forwards a welcome-tour funnel event to the
+ * backend. Called via navigator.sendBeacon (which can't set an Authorization
+ * header but does send cookies), so we read the access_token cookie and attach
+ * the Bearer token, then pipe the JSON body through.
+ */
+export const POST: APIRoute = async ({ request, cookies }) => {
+    const token = cookies.get("access_token")?.value;
+    if (!token) return new Response(null, { status: 401 });
+
+    const apiUrl =
+        process.env.API_BASE_URL ||
+        process.env.PUBLIC_API_BASE_URL ||
+        "http://backend:8000";
+
+    let body = "{}";
+    try {
+        body = (await request.text()) || "{}";
+    } catch {
+        /* keep default */
+    }
+
+    try {
+        const r = await fetch(`${apiUrl}/api/families/onboarding/events`, {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${token}`,
+                "Content-Type": "application/json",
+            },
+            body,
+        });
+        return new Response(null, { status: r.status });
+    } catch (e) {
+        console.error("onboarding events proxy error:", e);
+        return new Response(null, { status: 502 });
+    }
+};

--- a/frontend/src/pages/parent/analytics.astro
+++ b/frontend/src/pages/parent/analytics.astro
@@ -13,9 +13,10 @@ if (!user) {
 }
 if (user.role !== "parent") return Astro.redirect("/dashboard");
 
-const [{ data: pup }, { data: historyRaw }] = await Promise.all([
+const [{ data: pup }, { data: historyRaw }, { data: onb }] = await Promise.all([
     apiFetch<any>("/api/analytics/pup-score", { token }),
     apiFetch<any[]>("/api/analytics/pup-history?days=30", { token }),
+    apiFetch<any>("/api/families/onboarding/analytics", { token }),
 ]);
 const history: any[] = Array.isArray(historyRaw) ? historyRaw : [];
 
@@ -49,6 +50,17 @@ const labels = {
     gigs_done: lang === "es" ? "Gigs hechos" : "Gigs done",
     late: lang === "es" ? "Tareas tarde" : "Late",
     penalties: lang === "es" ? "Penalizaciones auto" : "Auto-penalties",
+    onb_title: lang === "es" ? "Bienvenida" : "Onboarding",
+    onb_completed: lang === "es" ? "Completaron" : "Completed",
+    onb_skipped: lang === "es" ? "Saltaron" : "Skipped",
+    onb_pending: lang === "es" ? "Pendientes" : "Pending",
+};
+
+const tourStatusLabel: Record<string, { e: string; c: string; en: string; es: string }> = {
+    completed: { e: "✅", c: "text-brand-mint-deep", en: "completed", es: "completó" },
+    skipped: { e: "⏭️", c: "text-brand-sun-deep", en: "skipped", es: "saltó" },
+    started: { e: "▶️", c: "text-brand-sky-deep", en: "started", es: "empezó" },
+    not_started: { e: "◻️", c: "text-brand-ink-soft", en: "not started", es: "sin empezar" },
 };
 
 const scoreColor =
@@ -84,6 +96,40 @@ const scoreColor =
             </p>
         </div>
     </div>
+
+    {onb && (
+        <section class="bg-brand-cream rounded-2xl p-4 border border-brand-ink/10 shadow-[var(--shadow-card)]">
+            <h2 class="text-sm font-bold text-brand-ink mb-3">🚀 {labels.onb_title}</h2>
+            <div class="grid grid-cols-3 gap-2 text-center mb-3">
+                <div class="bg-brand-mint/20 rounded-xl p-2">
+                    <p class="text-2xl font-extrabold text-brand-mint-deep">{onb.tour_completed}</p>
+                    <p class="text-[11px] text-brand-mint-deep font-medium">{labels.onb_completed}</p>
+                </div>
+                <div class="bg-brand-sun/20 rounded-xl p-2">
+                    <p class="text-2xl font-extrabold text-brand-sun-deep">{onb.tour_skipped}</p>
+                    <p class="text-[11px] text-brand-sun-deep font-medium">{labels.onb_skipped}</p>
+                </div>
+                <div class="bg-brand-cream-deep rounded-xl p-2">
+                    <p class="text-2xl font-extrabold text-brand-ink-soft">{(onb.tour_started ?? 0) + (onb.tour_not_started ?? 0)}</p>
+                    <p class="text-[11px] text-brand-ink-soft font-medium">{labels.onb_pending}</p>
+                </div>
+            </div>
+            <ul class="space-y-1.5">
+                {(onb.members ?? []).map((m: any) => {
+                    const s = tourStatusLabel[m.tour_status] ?? tourStatusLabel.not_started;
+                    return (
+                        <li class="flex items-center justify-between text-sm">
+                            <span class="text-brand-ink">
+                                {m.name}
+                                <span class="ml-1 text-xs text-brand-ink-soft capitalize">{m.role}</span>
+                            </span>
+                            <span class={`text-xs font-medium ${s.c}`}>{s.e} {lang === "es" ? s.es : s.en}</span>
+                        </li>
+                    );
+                })}
+            </ul>
+        </section>
+    )}
 
     {sparklinePath && (
         <section class="bg-brand-cream rounded-2xl p-4 border border-brand-ink/10 shadow-[var(--shadow-card)]">


### PR DESCRIPTION
See whether new family members actually **finish** onboarding, not just whether they were shown it.

## Backend
- `onboarding_events` table + migration (user, family, `event_type`, `step_index`).
- `POST /api/families/onboarding/events` records `tour_started` / `tour_completed` / `tour_skipped` / `tour_replayed` (any member); `GET /api/families/onboarding/analytics` (parent) returns funnel counts + per-member tour status + the existing checklist state.

## Frontend
- `tour.ts` fires the events via `navigator.sendBeacon` (survives navigation); completed-vs-skipped is decided from the active step index on teardown. Replays record `tour_replayed`.
- New beacon proxy `api/onboarding/events.ts`.
- Parent **Analytics** page gains an "Onboarding" card: Completed / Skipped / Pending counts + per-member status.

## Verify
- 4 backend tests pass (`test_onboarding_analytics.py`); `astro check` 0 errors.
- End-to-end in the browser: skipping a tour makes that member show **⏭️ skipped** on `/parent/analytics` (confirmed "0 Completed · 1 Skipped · 3 Pending").

## Follow-up (noted, not in scope)
The `localStorage` tour guard (`ftm_tour_done`) is browser-global, so on a shared device the auto-tour shows once per browser rather than once per user (the per-user backend flag is authoritative, but the local fast-path short-circuits it). Replay from Profile is the escape hatch. A per-user guard key would close this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)