### PR TITLE
fix(tour): per-user localStorage guard (shared devices)

### DIFF
--- a/frontend/src/components/TourReplayButton.astro
+++ b/frontend/src/components/TourReplayButton.astro
@@ -16,6 +16,8 @@ interface Props {
     class?: string;
     /** Wrapper display class — pass "block" to let the button stretch full-width. */
     wrapClass?: string;
+    /** User id — keeps the per-user tour guard consistent with the auto-tour. */
+    userKey?: string;
 }
 const {
     role,
@@ -23,8 +25,9 @@ const {
     label,
     class: cls = "",
     wrapClass = "inline-block",
+    userKey,
 } = Astro.props;
-const data = buildTour(role, lang);
+const data = buildTour(role, lang, userKey);
 const json = JSON.stringify(data).replace(/</g, "\\u003c");
 ---
 
@@ -55,7 +58,7 @@ const json = JSON.stringify(data).replace(/</g, "\\u003c");
                         return;
                     }
                     if (!data?.steps?.length) return;
-                    replayTour(data.steps, data.btn);
+                    replayTour(data.steps, data.btn, data.guardKey);
                 });
             });
     }

--- a/frontend/src/components/WelcomeTour.astro
+++ b/frontend/src/components/WelcomeTour.astro
@@ -14,9 +14,11 @@ import type { TourRole } from "../lib/tourSteps";
 interface Props {
     role: TourRole;
     lang?: "en" | "es";
+    /** User id — makes the localStorage guard per-user on shared devices. */
+    userKey?: string;
 }
-const { role, lang = "en" } = Astro.props;
-const data = buildTour(role, lang);
+const { role, lang = "en", userKey } = Astro.props;
+const data = buildTour(role, lang, userKey);
 const json = JSON.stringify(data).replace(/</g, "\\u003c");
 ---
 
@@ -27,7 +29,6 @@ const json = JSON.stringify(data).replace(/</g, "\\u003c");
 
     function maybeStartTour() {
         if ((window as any).__ftmTourStarted) return;
-        if (tourGuardSet()) return;
         const el = document.getElementById("ftm-tour-data");
         if (!el || !el.textContent) return;
         let data: any;
@@ -37,9 +38,13 @@ const json = JSON.stringify(data).replace(/</g, "\\u003c");
             return;
         }
         if (!data?.steps?.length) return;
+        if (tourGuardSet(data.guardKey)) return;
         (window as any).__ftmTourStarted = true;
         // Let the bottom nav + header finish painting before highlighting targets.
-        setTimeout(() => runTour(data.steps, data.btn), 450);
+        setTimeout(
+            () => runTour(data.steps, data.btn, "tour_started", data.guardKey),
+            450,
+        );
     }
 
     document.addEventListener("astro:page-load", maybeStartTour);

--- a/frontend/src/components/ui/PageLayout.astro
+++ b/frontend/src/components/ui/PageLayout.astro
@@ -49,6 +49,8 @@ interface Props {
    * Defaults to true (= "already done") so other pages never trigger it.
    */
   completedTour?: boolean;
+  /** User id — makes the welcome-tour localStorage guard per-user (shared devices). */
+  tourUserKey?: string;
 }
 
 const {
@@ -66,6 +68,7 @@ const {
   mainClass = "flex-1 px-4 py-6",
   containerClass = "w-full max-w-md md:max-w-4xl lg:max-w-6xl mx-auto bg-brand-cream-deep",
   completedTour = true,
+  tourUserKey,
 } = Astro.props;
 
 // Auto-start the welcome tour for first-time users on the home page that owns
@@ -94,7 +97,7 @@ const showWelcomeTour =
       </PageHeader>
     )}
     <slot name="banner" />
-    {showWelcomeTour && <WelcomeTour role={tourRole} lang={lang} />}
+    {showWelcomeTour && <WelcomeTour role={tourRole} lang={lang} userKey={tourUserKey} />}
     <main class={mainClass}>
       <slot />
     </main>

--- a/frontend/src/lib/tour.ts
+++ b/frontend/src/lib/tour.ts
@@ -37,9 +37,9 @@ const GUARD_KEY = "ftm_tour_done";
  * so the request survives the page navigation/unload that a fetch() would lose
  * (fetch falls back with keepalive when sendBeacon is unavailable).
  */
-function ackTour(): void {
+function ackTour(guardKey: string): void {
     try {
-        localStorage.setItem(GUARD_KEY, "1");
+        localStorage.setItem(guardKey, "1");
     } catch {
         /* private mode / storage disabled — backend flag still persists */
     }
@@ -90,6 +90,7 @@ export function runTour(
     steps: TourStep[],
     btn: TourButtons,
     startEvent = "tour_started",
+    guardKey: string = GUARD_KEY,
 ): void {
     // Keep element-less steps (centered modals); for targeted steps, require the
     // element to be present AND actually visible — a nav item collapsed at the
@@ -129,7 +130,7 @@ export function runTour(
             const idx = (d as any).getActiveIndex?.();
             const completed =
                 typeof idx === "number" && idx >= present.length - 1;
-            ackTour();
+            ackTour(guardKey);
             recordEvent(completed ? "tour_completed" : "tour_skipped", idx);
             d.destroy();
         },
@@ -138,19 +139,23 @@ export function runTour(
 }
 
 /** Clear the local guard so a replay starts fresh, then run. */
-export function replayTour(steps: TourStep[], btn: TourButtons): void {
+export function replayTour(
+    steps: TourStep[],
+    btn: TourButtons,
+    guardKey: string = GUARD_KEY,
+): void {
     try {
-        localStorage.removeItem(GUARD_KEY);
+        localStorage.removeItem(guardKey);
     } catch {
         /* ignore */
     }
-    runTour(steps, btn, "tour_replayed");
+    runTour(steps, btn, "tour_replayed", guardKey);
 }
 
 /** True if the tour was already finished/skipped on this device. */
-export function tourGuardSet(): boolean {
+export function tourGuardSet(guardKey: string = GUARD_KEY): boolean {
     try {
-        return localStorage.getItem(GUARD_KEY) === "1";
+        return localStorage.getItem(guardKey) === "1";
     } catch {
         return false;
     }

--- a/frontend/src/lib/tourSteps.ts
+++ b/frontend/src/lib/tourSteps.ts
@@ -13,9 +13,16 @@ export interface TourData {
     role: TourRole;
     steps: TourStep[];
     btn: TourButtons;
+    /** localStorage guard key — per-user so a second member on a shared device
+     *  still gets their own tour. */
+    guardKey: string;
 }
 
-export function buildTour(role: TourRole, lang: string): TourData {
+export function buildTour(
+    role: TourRole,
+    lang: string,
+    userId?: string,
+): TourData {
     const btn: TourButtons = {
         next: t(lang, "tour_next"),
         prev: t(lang, "tour_prev"),
@@ -117,5 +124,6 @@ export function buildTour(role: TourRole, lang: string): TourData {
         role,
         steps: role === "parent" ? parentSteps : kidSteps,
         btn,
+        guardKey: userId ? `ftm_tour_done_${userId}` : "ftm_tour_done",
     };
 }

--- a/frontend/src/pages/dashboard.astro
+++ b/frontend/src/pages/dashboard.astro
@@ -73,6 +73,7 @@ if (flashError) Astro.cookies.delete("flash_error", { path: "/" });
     active="tasks"
     lang={lang}
     completedTour={user.completed_welcome_tour ?? true}
+    tourUserKey={user.id}
 >
     <header slot="header" class="bg-brand-sky-deep text-white pt-12 pb-6 px-6 rounded-b-[var(--radius-tile)] shadow-[var(--shadow-card)]">
             <div class="flex justify-between items-center mb-6">

--- a/frontend/src/pages/parent/index.astro
+++ b/frontend/src/pages/parent/index.astro
@@ -63,6 +63,7 @@ const onbPct = Math.round((onbDone / onbTotal) * 100);
     active="parent"
     lang={lang}
     completedTour={user.completed_welcome_tour ?? true}
+    tourUserKey={user.id}
 >
     <header
         slot="header"
@@ -150,6 +151,7 @@ const onbPct = Math.round((onbDone / onbTotal) * 100);
                         <TourReplayButton
                             role="parent"
                             lang={lang}
+                            userKey={user.id}
                             label={`🧭 ${t(lang, "onboarding_take_tour")}`}
                             class="px-3 py-2 rounded-lg bg-brand-sky-deep text-white text-xs font-semibold hover:bg-brand-ink transition-colors cursor-pointer"
                         />

--- a/frontend/src/pages/profile.astro
+++ b/frontend/src/pages/profile.astro
@@ -209,6 +209,7 @@ const tourRole = String(user.role).toLowerCase() === "parent" ? "parent" : "kid"
                     <TourReplayButton
                         role={tourRole}
                         lang={lang}
+                        userKey={user.id}
                         label={`🧭 ${t(lang, "onboarding_replay_tour")}`}
                         wrapClass="block"
                         class="w-full text-center px-4 py-2.5 rounded-lg bg-brand-sky-deep text-white text-sm font-semibold hover:bg-brand-ink transition-colors cursor-pointer"


### PR DESCRIPTION
Keys the welcome-tour localStorage guard per user (`ftm_tour_done_<userId>`) instead of the browser-global key, so a second family member on a shared device gets their own auto-tour. Threaded `userId` through buildTour → WelcomeTour/TourReplayButton/PageLayout, set from `user.id` on dashboard/parent/profile. Functions default to the legacy global key when no id is passed.

Closes the follow-up noted in #64. astro check 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)