### PR TITLE
fix(budget): points converter uses runtime API base (fixes broken converter in prod)

### DIFF
--- a/frontend/src/components/PointsConverter.astro
+++ b/frontend/src/components/PointsConverter.astro
@@ -38,7 +38,7 @@ let error: string | null = null;
 if (token) {
     try {
         const response = await fetch(
-            `${import.meta.env.API_BASE_URL || import.meta.env.PUBLIC_API_BASE_URL || "http://localhost:8002"}/api/points-conversion/eligibility`,
+            `${process.env.API_BASE_URL || process.env.PUBLIC_API_BASE_URL || "http://backend:8000"}/api/points-conversion/eligibility`,
             {
                 headers: {
                     Authorization: `Bearer ${token}`,

--- a/frontend/src/pages/api/points/convert.ts
+++ b/frontend/src/pages/api/points/convert.ts
@@ -18,7 +18,10 @@ export const POST: APIRoute = async ({ request, cookies }) => {
     
     try {
         const body = await request.json();
-        const apiUrl = import.meta.env.API_BASE_URL || import.meta.env.PUBLIC_API_BASE_URL || 'http://localhost:8002';
+        // Runtime env (process.env) — import.meta.env is inlined at build and
+        // the Dockerfile doesn't bake API_BASE_URL, so it would resolve to the
+        // wrong localhost fallback inside the container.
+        const apiUrl = process.env.API_BASE_URL || process.env.PUBLIC_API_BASE_URL || 'http://backend:8000';
         
         const response = await fetch(`${apiUrl}/api/points-conversion/convert`, {
             method: 'POST',


### PR DESCRIPTION
## Bug (affects prod)
`PointsConverter`'s eligibility fetch and the `/api/points/convert` proxy resolved the backend via `import.meta.env.API_BASE_URL`, which Vite **inlines at build**. The frontend Dockerfile never declares `ARG API_BASE_URL`, so it resolved to `undefined` → fell back to `http://localhost:8002` (wrong inside the container) → the eligibility request failed and the green **"Convert Points to Money"** card never rendered for eligible kids — in every container build, including prod.

The other `import.meta.env.API_BASE_URL` usages happened to fall back to `backend:8000`, so only these two were broken.

## Fix
Both now use `process.env.API_BASE_URL` (resolved at runtime from the container env = `http://backend:8000`), matching the working pattern in `lib/api.ts`.

## How it surfaced
A clean image rebuild (not the cp-dist hack used during earlier testing): `kid-onboarding.spec.js` "eligible kid sees the points converter" failed on the real build, passes after the fix. All onboarding specs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)