### PR TITLE
fix(guide): zoom-lightbox SVG was collapsing to a dot

### DIFF
--- a/frontend/src/components/GuideShell.astro
+++ b/frontend/src/components/GuideShell.astro
@@ -231,7 +231,23 @@ const {
                 lb.reset();
                 lb.stage.innerHTML = "";
                 const clone = svg.cloneNode(true) as SVGElement;
+                // Mermaid sizes its SVG via an inline `max-width` style and
+                // carries no width/height attrs; dropping the style in the
+                // flex stage would collapse it to ~0. Give the clone explicit
+                // intrinsic dimensions from its viewBox so CSS max-width/height
+                // can scale it to fit while preserving aspect ratio.
                 clone.removeAttribute("style");
+                const vb = (clone.getAttribute("viewBox") || "")
+                    .split(/[\s,]+/)
+                    .map(Number);
+                if (vb.length === 4 && vb[2] > 0 && vb[3] > 0) {
+                    clone.setAttribute("width", String(vb[2]));
+                    clone.setAttribute("height", String(vb[3]));
+                } else {
+                    const r = svg.getBoundingClientRect();
+                    clone.setAttribute("width", String(Math.round(r.width)));
+                    clone.setAttribute("height", String(Math.round(r.height)));
+                }
                 clone.classList.add("dl-svg");
                 lb.stage.appendChild(clone);
                 lb.overlay.hidden = false;


### PR DESCRIPTION
## Bug

Clicking a diagram opened the zoom overlay, but the diagram showed as a tiny white dot instead of an enlarged figure (reported on `/ayuda`, affects both guide pages).

**Cause:** the clone dropped mermaid's inline `max-width` style, and mermaid SVGs carry no `width`/`height` attributes — so inside the flex stage the clone had no intrinsic size and collapsed.

## Fix

Set explicit `width`/`height` on the clone from its `viewBox` (fallback: the source SVG's rendered box). CSS `max-width:92vw` / `max-height:86vh` then scale it to fit while preserving aspect ratio.

## Verification

Browser-driven on the standalone build (`/ayuda`): clone bounding box renders **1104×216** (clamped from intrinsic 1674 by `max-width:92vw` on a 1200px viewport), `visible:true`, aspect preserved — vs the ~30px collapsed dot before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)