### PR TITLE
fix(deps): reconcile pydantic pins with mcp==1.12.4 (unblocks prod build)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -23,8 +23,10 @@ alembic==1.13.1
 PyJWT==2.10.1
 passlib[bcrypt]==1.7.4
 bcrypt==4.1.2
-pydantic[email]==2.5.3
-pydantic-settings==2.1.0
+# bumped from 2.5.3/2.1.0: mcp==1.12.4 requires pydantic-settings>=2.5.2 (pulls pydantic>=2.7).
+# These are the versions the suite is validated against; the old pins make a clean image build unresolvable.
+pydantic[email]==2.13.4
+pydantic-settings==2.14.2
 authlib==1.3.0
 itsdangerous==2.1.2
 


### PR DESCRIPTION
PR #72's `mcp==1.12.4` needs pydantic-settings>=2.5.2 (pydantic>=2.7), but requirements.txt still pinned pydantic==2.5.3 / pydantic-settings==2.1.0. A clean image build (deploy-gcp) fails with `ResolutionImpossible`; the dev container masked it because mcp was live-installed post-build. Bumped to 2.13.4 / 2.14.2 — the set the 1197-test suite already validates against. Verified a clean from-scratch resolution in python:3.12-slim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)