### PR TITLE
QA batch: budget 502 fix, i18n (register/jarvis/profile/banner), nav overflow, onboarding tour, modal close

### DIFF
--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -141,6 +141,7 @@ async def register_family(
         family_id=family.id,
         points=0,
         is_active=True,
+        preferred_lang=data.preferred_lang,
     )
     db.add(user)
     await db.flush()

--- a/backend/app/api/routes/budget/ai_settings.py
+++ b/backend/app/api/routes/budget/ai_settings.py
@@ -80,9 +80,20 @@ async def set_vision_model(
 async def get_ai_usage(
     current_user: User = Depends(require_parent_role),
 ):
-    """Proxy LiteLLM /key/info for the configured virtual key's spend data."""
+    """Proxy LiteLLM /key/info for the configured virtual key's spend data.
+
+    Degrades gracefully: spend data is an optional stats panel, and the FTM
+    virtual key may not be permitted to call /key/info (an admin endpoint). On
+    any upstream failure return ``available: false`` (HTTP 200) so the settings
+    page shows "unavailable" instead of a hard 502.
+    """
+    unavailable = {
+        "available": False, "spend": None, "max_budget": None,
+        "budget_duration": None, "budget_reset_at": None, "key_alias": None,
+        "models": [], "tpm_limit": None, "rpm_limit": None,
+    }
     if not settings.LITELLM_API_KEY or not settings.LITELLM_API_BASE:
-        raise HTTPException(status_code=503, detail="LiteLLM not configured")
+        return unavailable
 
     base = settings.LITELLM_API_BASE.rstrip("/")
     headers = {"Authorization": f"Bearer {settings.LITELLM_API_KEY}"}
@@ -92,16 +103,12 @@ async def get_ai_usage(
             resp = await client.get(f"{base}/key/info", headers=headers)
             resp.raise_for_status()
             data = resp.json()
-        except httpx.HTTPStatusError as exc:
-            raise HTTPException(
-                status_code=502,
-                detail=f"LiteLLM returned {exc.response.status_code}",
-            )
-        except httpx.RequestError as exc:
-            raise HTTPException(status_code=502, detail=f"LiteLLM unreachable: {exc}")
+        except (httpx.HTTPStatusError, httpx.RequestError):
+            return unavailable
 
     info = data.get("info", data)
     return {
+        "available": True,
         "spend": info.get("spend", 0),
         "max_budget": info.get("max_budget"),
         "budget_duration": info.get("budget_duration"),

--- a/backend/app/api/routes/jarvis.py
+++ b/backend/app/api/routes/jarvis.py
@@ -64,6 +64,7 @@ async def chat(
             user_id=to_uuid_required(current_user.id),
             message=data.message,
             model=model,
+            preferred_lang=(current_user.preferred_lang or "en"),
         )
     except ValidationError as exc:
         raise HTTPException(status_code=502, detail=str(exc))
@@ -83,6 +84,7 @@ async def chat_stream(
         user_id=to_uuid_required(current_user.id),
         message=data.message,
         model=model,
+        preferred_lang=(current_user.preferred_lang or "en"),
     )
     return StreamingResponse(
         gen,

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -118,6 +118,7 @@ class RegisterFamilyRequest(BaseModel):
     name: str = Field(..., min_length=1, max_length=100)
     email: EmailStr
     password: str = Field(..., min_length=8, max_length=100)
+    preferred_lang: str = Field("en", pattern=r"^(en|es)$")
 
 
 class RegisterFamilyResponse(BaseModel):

--- a/backend/app/services/jarvis_service.py
+++ b/backend/app/services/jarvis_service.py
@@ -49,6 +49,28 @@ SYSTEM_BASE = (
     "Avoid platitudes. If you don't know, say so."
 )
 
+LANG_NAMES = {"en": "English", "es": "Spanish"}
+
+# Localized fallback when the model returns nothing useful.
+_EMPTY_REPLY = {
+    "en": "I had nothing useful to say. Try rephrasing?",
+    "es": "No tengo nada útil que decir. ¿Puedes reformular?",
+}
+
+
+def _build_system(context_block: str, preferred_lang: str) -> str:
+    """System prompt with a hard language directive so Jarvis replies in the
+    user's app language from the first turn (not just after they switch)."""
+    lang_name = LANG_NAMES.get(preferred_lang, "English")
+    return (
+        SYSTEM_BASE
+        + f"\n\nIMPORTANT: Always respond in {lang_name}, regardless of the "
+        "language of the family-state data below or earlier turns."
+        + "\n\n"
+        + context_block
+    )
+
+
 MAX_HISTORY_TURNS = 12
 HISTORY_RETURN_LIMIT = 50
 MAX_TOOL_HOPS = 4
@@ -202,6 +224,7 @@ class JarvisService:
         user_id: UUID,
         message: str,
         model: str | None = None,
+        preferred_lang: str = "en",
     ):
         """Async generator yielding SSE event lines.
 
@@ -239,7 +262,7 @@ class JarvisService:
             )
             context_block = await JarvisService._build_context(db, family_id)
             msgs: list[dict[str, Any]] = [
-                {"role": "system", "content": SYSTEM_BASE + "\n\n" + context_block}
+                {"role": "system", "content": _build_system(context_block, preferred_lang)}
             ]
             for h in history:
                 if h.role in ("user", "assistant"):
@@ -348,7 +371,7 @@ class JarvisService:
                 break
 
             if not reply:
-                reply = "I had nothing useful to say. Try rephrasing?"
+                reply = _EMPTY_REPLY.get(preferred_lang, _EMPTY_REPLY["en"])
 
             user_row = JarvisMessage(
                 family_id=family_id, user_id=user_id, role="user", content=msg
@@ -391,6 +414,7 @@ class JarvisService:
         user_id: UUID,
         message: str,
         model: str | None = None,
+        preferred_lang: str = "en",
     ) -> dict:
         if not settings.LITELLM_API_KEY:
             raise ValidationError(
@@ -414,7 +438,7 @@ class JarvisService:
         context_block = await JarvisService._build_context(db, family_id)
 
         msgs: list[dict[str, Any]] = [
-            {"role": "system", "content": SYSTEM_BASE + "\n\n" + context_block}
+            {"role": "system", "content": _build_system(context_block, preferred_lang)}
         ]
         for h in history:
             if h.role in ("user", "assistant"):
@@ -507,7 +531,7 @@ class JarvisService:
             break
 
         if not reply:
-            reply = "I had nothing useful to say. Try rephrasing?"
+            reply = _EMPTY_REPLY.get(preferred_lang, _EMPTY_REPLY["en"])
 
         user_msg = JarvisMessage(
             family_id=family_id, user_id=user_id, role="user", content=message

--- a/backend/tests/test_i18n_backend.py
+++ b/backend/tests/test_i18n_backend.py
@@ -1,0 +1,49 @@
+"""Guards for backend i18n wiring (register language + Jarvis language)."""
+
+import pytest
+
+
+def test_register_family_request_carries_preferred_lang():
+    from app.schemas.user import RegisterFamilyRequest
+    r = RegisterFamilyRequest(family_name="F", name="N", email="a@b.com",
+                              password="password123", preferred_lang="es")
+    assert r.preferred_lang == "es"
+    # defaults to en
+    r2 = RegisterFamilyRequest(family_name="F", name="N", email="c@d.com",
+                               password="password123")
+    assert r2.preferred_lang == "en"
+
+
+def test_register_family_request_rejects_bad_lang():
+    from app.schemas.user import RegisterFamilyRequest
+    with pytest.raises(Exception):
+        RegisterFamilyRequest(family_name="F", name="N", email="a@b.com",
+                              password="password123", preferred_lang="fr")
+
+
+def test_jarvis_system_prompt_has_language_directive():
+    from app.services.jarvis_service import _build_system
+    es = _build_system("CTX", "es")
+    en = _build_system("CTX", "en")
+    assert "Spanish" in es and "CTX" in es
+    assert "English" in en
+    # unknown lang falls back to English, never crashes
+    assert "English" in _build_system("CTX", "zz")
+
+
+def test_jarvis_empty_reply_localized():
+    from app.services.jarvis_service import _EMPTY_REPLY
+    assert _EMPTY_REPLY["es"].startswith("No tengo")
+    assert _EMPTY_REPLY["en"]
+
+
+@pytest.mark.asyncio
+async def test_register_family_sets_spanish_user(client):
+    """End-to-end: registering with preferred_lang=es stores a Spanish user so
+    the welcome email + first login render in Spanish."""
+    r = await client.post("/api/auth/register-family", json={
+        "family_name": "Familia ES", "name": "Papa", "email": "papa-es@test.com",
+        "password": "password123", "preferred_lang": "es",
+    })
+    assert r.status_code in (200, 201), r.text
+    assert r.json()["user"]["preferred_lang"] == "es"

--- a/frontend/src/components/BottomNav.astro
+++ b/frontend/src/components/BottomNav.astro
@@ -24,7 +24,7 @@ if (token) {
     }
 }
 
-const itemBase = "flex flex-col items-center justify-center gap-0.5 px-2 py-1 rounded-full transition-all";
+const itemBase = "shrink-0 flex flex-col items-center justify-center gap-0.5 px-1 py-1 rounded-full transition-all";
 const itemIdle = "text-brand-ink-soft hover:text-brand-ink";
 const itemActive = "bg-brand-coral text-brand-ink border-2 border-brand-ink shadow-[2px_2px_0_var(--color-brand-ink)]";
 ---
@@ -34,13 +34,13 @@ const itemActive = "bg-brand-coral text-brand-ink border-2 border-brand-ink shad
 <nav
     class="fixed bottom-0 left-0 right-0 bg-brand-cream border-t-2 border-brand-ink safe-area-bottom z-50"
 >
-    <div class="max-w-md mx-auto flex justify-around items-center px-1 py-2">
+    <div class="nav-row mx-auto flex justify-around items-center px-1 py-2">
         <a href="/dashboard" data-nav-key="tasks" class={`${itemBase} ${active === "tasks" ? itemActive : itemIdle}`}>
             <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                     d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
             </svg>
-            <span class="text-[10px] font-extrabold font-sans tracking-wider uppercase">{t(lang, "nav_tasks")}</span>
+            <span class="nav-label text-[10px] font-extrabold font-sans tracking-wider uppercase">{t(lang, "nav_tasks")}</span>
         </a>
 
         {role !== "parent" && (
@@ -49,7 +49,7 @@ const itemActive = "bg-brand-coral text-brand-ink border-2 border-brand-ink shad
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                         d="M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
                 </svg>
-                <span class="text-[10px] font-extrabold font-sans tracking-wider uppercase">Gigs</span>
+                <span class="nav-label text-[10px] font-extrabold font-sans tracking-wider uppercase">Gigs</span>
             </a>
         )}
 
@@ -58,7 +58,7 @@ const itemActive = "bg-brand-coral text-brand-ink border-2 border-brand-ink shad
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                     d="M12 8v13m0-13V6a2 2 0 112 2h-2zm0 0V5.5A2.5 2.5 0 109.5 8H12zm-7 4h14M5 12a2 2 0 110-4h14a2 2 0 110 4M5 12v7a2 2 0 002 2h10a2 2 0 002-2v-7" />
             </svg>
-            <span class="text-[10px] font-extrabold font-sans tracking-wider uppercase">{t(lang, "nav_rewards")}</span>
+            <span class="nav-label text-[10px] font-extrabold font-sans tracking-wider uppercase">{t(lang, "nav_rewards")}</span>
         </a>
 
         <a href="/notifications" data-nav-key="notifications" class={`${itemBase} relative ${active === "notifications" ? itemActive : itemIdle}`}>
@@ -71,7 +71,7 @@ const itemActive = "bg-brand-coral text-brand-ink border-2 border-brand-ink shad
                     {unreadCount > 99 ? "99+" : unreadCount}
                 </span>
             )}
-            <span class="text-[10px] font-extrabold font-sans tracking-wider uppercase">
+            <span class="nav-label text-[10px] font-extrabold font-sans tracking-wider uppercase">
                 {lang === "es" ? "Avisos" : "Inbox"}
             </span>
         </a>
@@ -81,7 +81,7 @@ const itemActive = "bg-brand-coral text-brand-ink border-2 border-brand-ink shad
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                     d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
             </svg>
-            <span class="text-[10px] font-extrabold font-sans tracking-wider uppercase">
+            <span class="nav-label text-[10px] font-extrabold font-sans tracking-wider uppercase">
                 {lang === "es" ? "Chat" : "Chat"}
             </span>
         </a>
@@ -92,7 +92,7 @@ const itemActive = "bg-brand-coral text-brand-ink border-2 border-brand-ink shad
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                         d="M4.318 6.318a4.5 4.5 0 016.364 0L12 7.636l1.318-1.318a4.5 4.5 0 116.364 6.364L12 20.364l-7.682-7.682a4.5 4.5 0 010-6.364z" />
                 </svg>
-                <span class="text-[10px] font-extrabold font-sans tracking-wider uppercase">
+                <span class="nav-label text-[10px] font-extrabold font-sans tracking-wider uppercase">
                     {lang === "es" ? "Mascota" : "Pet"}
                 </span>
             </a>
@@ -103,7 +103,7 @@ const itemActive = "bg-brand-coral text-brand-ink border-2 border-brand-ink shad
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                     d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
             </svg>
-            <span class="text-[10px] font-extrabold font-sans tracking-wider uppercase">{t(lang, "nav_profile")}</span>
+            <span class="nav-label text-[10px] font-extrabold font-sans tracking-wider uppercase">{t(lang, "nav_profile")}</span>
         </a>
 
         {role === "parent" && (
@@ -112,7 +112,7 @@ const itemActive = "bg-brand-coral text-brand-ink border-2 border-brand-ink shad
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                         d="M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
                 </svg>
-                <span class="text-[10px] font-extrabold font-sans tracking-wider uppercase">Gigs</span>
+                <span class="nav-label text-[10px] font-extrabold font-sans tracking-wider uppercase">Gigs</span>
             </a>
         )}
 
@@ -122,7 +122,7 @@ const itemActive = "bg-brand-coral text-brand-ink border-2 border-brand-ink shad
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                         d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                 </svg>
-                <span class="text-[10px] font-extrabold font-sans tracking-wider uppercase">{t(lang, "nav_budget")}</span>
+                <span class="nav-label text-[10px] font-extrabold font-sans tracking-wider uppercase">{t(lang, "nav_budget")}</span>
             </a>
         )}
 
@@ -134,7 +134,7 @@ const itemActive = "bg-brand-coral text-brand-ink border-2 border-brand-ink shad
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                         d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
                 </svg>
-                <span class="text-[10px] font-extrabold font-sans tracking-wider uppercase">{t(lang, "nav_manage")}</span>
+                <span class="nav-label text-[10px] font-extrabold font-sans tracking-wider uppercase">{t(lang, "nav_manage")}</span>
             </a>
         )}
 
@@ -146,7 +146,7 @@ const itemActive = "bg-brand-coral text-brand-ink border-2 border-brand-ink shad
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                         d="M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 10.77 8.07 15.61 3 18.129" />
                 </svg>
-                <span class="text-[10px] font-extrabold font-sans tracking-wider uppercase">{langLabel}</span>
+                <span class="nav-label text-[10px] font-extrabold font-sans tracking-wider uppercase">{langLabel}</span>
             </button>
         </form>
 
@@ -157,7 +157,7 @@ const itemActive = "bg-brand-coral text-brand-ink border-2 border-brand-ink shad
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                         d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
                 </svg>
-                <span class="text-[10px] font-extrabold font-sans tracking-wider uppercase">{t(lang, "nav_logout")}</span>
+                <span class="nav-label text-[10px] font-extrabold font-sans tracking-wider uppercase">{t(lang, "nav_logout")}</span>
             </button>
         </form>
     </div>
@@ -197,6 +197,31 @@ const itemActive = "bg-brand-coral text-brand-ink border-2 border-brand-ink shad
 <style>
     .safe-area-bottom {
         padding-bottom: env(safe-area-inset-bottom, 0px);
+    }
+    /* Keep the bar centered + capped on wide screens, but never clip items:
+       allow horizontal scroll as a safety net for the longest translations. */
+    .nav-row {
+        max-width: 28rem;
+        overflow-x: auto;
+        scrollbar-width: none;
+    }
+    .nav-row::-webkit-scrollbar { display: none; }
+    /* On narrow phones the full label set overflows (9-10 items), so go
+       icon-only — labels become screen-reader-only (still accessible, zero
+       width) so every destination fits and stays reachable. */
+    @media (max-width: 430px) {
+        .nav-row { max-width: 100%; }
+        .nav-label {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            white-space: nowrap;
+            border: 0;
+        }
     }
     .bottom-nav-spacer {
         display: block;

--- a/frontend/src/components/TourReplayButton.astro
+++ b/frontend/src/components/TourReplayButton.astro
@@ -64,4 +64,8 @@ const json = JSON.stringify(data).replace(/</g, "\\u003c");
     }
 
     document.addEventListener("astro:page-load", bindReplay);
+    // Self-trigger if the DOM is already ready — the one-shot astro:page-load
+    // may have fired before this module executed (the per-button __ftmBound
+    // guard keeps this idempotent), otherwise the replay button never binds.
+    if (document.readyState !== "loading") bindReplay();
 </script>

--- a/frontend/src/components/WelcomeTour.astro
+++ b/frontend/src/components/WelcomeTour.astro
@@ -48,4 +48,8 @@ const json = JSON.stringify(data).replace(/</g, "\\u003c");
     }
 
     document.addEventListener("astro:page-load", maybeStartTour);
+    // The one-shot astro:page-load fires on DOMContentLoaded; a module that
+    // executes after that would miss it. Self-trigger if the DOM is already
+    // ready (the __ftmTourStarted guard keeps this idempotent).
+    if (document.readyState !== "loading") maybeStartTour();
 </script>

--- a/frontend/src/components/ui/PageLayout.astro
+++ b/frontend/src/components/ui/PageLayout.astro
@@ -80,9 +80,12 @@ const {
 const _tourPath = Astro.url.pathname.replace(/\/+$/, "") || "/";
 const _isParent = String(role).toLowerCase() === "parent";
 const tourRole: TourRole = _isParent ? "parent" : "kid";
+// New parents land on /dashboard (not /parent), so allow the parent tour on
+// both — the tour's present-filter drops the /parent-only checklist step when
+// it's absent, so the welcome + nav + help steps still run on /dashboard.
 const showWelcomeTour =
   completedTour === false &&
-  ((_isParent && _tourPath === "/parent") ||
+  ((_isParent && (_tourPath === "/parent" || _tourPath === "/dashboard")) ||
     (!_isParent && _tourPath === "/dashboard"));
 ---
 

--- a/frontend/src/lib/i18n.ts
+++ b/frontend/src/lib/i18n.ts
@@ -436,8 +436,8 @@ export const translations = {
         fab_auto_rule: "rule ✓",
 
         // Gigs intro banner (one-time after scope change)
-        intro_banner_title: "What changed",
-        intro_banner_body: "Daily mandatory tasks now award 0 points — they're expected. Gigs (bonus tasks) are the only way to earn points, stay locked until every mandatory task (today and any overdue) is finished, and a parent reviews your proof before points are credited.",
+        intro_banner_title: "How points & cash work",
+        intro_banner_body: "Two ways to earn. Finish your chores to earn points — spend them on rewards and privileges like screen time, movie night, or picking dinner. Take on gigs from the gig board to earn real cash ($MXN), paid out by a parent after they review your proof. Gigs stay locked until every required chore (today and any overdue) is done. Points and cash are separate — points never turn into cash.",
         intro_banner_dismiss: "Got it",
 
         // Welcome tour (driver.js) — shared button labels
@@ -635,7 +635,7 @@ export const translations = {
         pt_allowed_roles: "Quien puede hacer esta tarea",
         pt_role_parent: "Padre/Madre",
         pt_role_teen: "Adolescente",
-        pt_role_child: "Nino",
+        pt_role_child: "Niño",
         pt_allowed_roles_hint: "Auto solo elige miembros con el rol marcado. Deja todo en blanco para permitir a todos.",
 
         // Shuffle
@@ -941,8 +941,8 @@ export const translations = {
         fab_auto_rule: "regla ✓",
 
         // Gigs intro banner (one-time after scope change)
-        intro_banner_title: "Qué cambió",
-        intro_banner_body: "Las tareas obligatorias diarias ahora dan 0 puntos — son lo esperado. Los gigs (tareas bonus) son la única forma de ganar puntos, quedan bloqueados hasta terminar todas las obligatorias (de hoy y atrasadas), y un padre revisa tu evidencia antes de acreditarlos.",
+        intro_banner_title: "Cómo funcionan los puntos y el dinero",
+        intro_banner_body: "Dos formas de ganar. Termina tus tareas para ganar puntos — cámbialos por premios y privilegios como tiempo de pantalla, noche de película o elegir la cena. Toma gigs del tablero de gigs para ganar dinero real ($MXN), que un padre te paga después de revisar tu evidencia. Los gigs quedan bloqueados hasta terminar todas las tareas obligatorias (de hoy y atrasadas). Los puntos y el dinero son separados — los puntos nunca se vuelven dinero.",
         intro_banner_dismiss: "Entendido",
 
         // Recorrido de bienvenida (driver.js) — botones

--- a/frontend/src/pages/api/analytics/[...path].ts
+++ b/frontend/src/pages/api/analytics/[...path].ts
@@ -6,7 +6,7 @@ const BACKEND_URL = process.env.API_BASE_URL || process.env.PUBLIC_API_BASE_URL 
 async function proxy({ request, params }: { request: Request; params: Record<string, string | undefined> }): Promise<Response> {
     const path = params.path ?? "";
     const url = new URL(request.url);
-    const backendUrl = `${BACKEND_URL}/api/analytics/${path}${url.search}`;
+    const backendUrl = `${BACKEND_URL}${url.pathname}${url.search}`;
 
     const forwardHeaders = new Headers();
     for (const [key, value] of request.headers.entries()) {

--- a/frontend/src/pages/api/auth/login.ts
+++ b/frontend/src/pages/api/auth/login.ts
@@ -77,6 +77,7 @@ export const POST: APIRoute = async ({ request }) => {
             // Stash role for UI theming (W4.2). Non-httpOnly so the
             // Astro server-side Layout can read it on subsequent renders.
             let uiRoleCookie = "";
+            let langCookie = "";
             try {
                 const meResp = await fetch(`${apiUrl}/api/auth/me`, {
                     headers: { Authorization: `Bearer ${result.access_token}` },
@@ -92,6 +93,17 @@ export const POST: APIRoute = async ({ request }) => {
                             secure: !import.meta.env.DEV,
                         });
                     }
+                    // Sync UI language to the account's stored preference so the
+                    // app renders in the user's language on any device.
+                    const pl = String(me?.preferred_lang || "").toLowerCase();
+                    if (pl === "en" || pl === "es") {
+                        langCookie = buildCookie("lang", pl, {
+                            path: "/",
+                            sameSite: "Lax",
+                            maxAge: 60 * 60 * 24 * 365,
+                            secure: !import.meta.env.DEV,
+                        });
+                    }
                 }
             } catch {
                 // Non-critical — fallback to kid theme.
@@ -102,6 +114,7 @@ export const POST: APIRoute = async ({ request }) => {
                 const headers = new Headers({ "Content-Type": "application/json" });
                 for (const c of cookies) headers.append("Set-Cookie", c);
                 if (uiRoleCookie) headers.append("Set-Cookie", uiRoleCookie);
+                if (langCookie) headers.append("Set-Cookie", langCookie);
                 return new Response(
                     JSON.stringify({ success: true, redirect: "/dashboard" }),
                     { status: 200, headers }
@@ -112,6 +125,7 @@ export const POST: APIRoute = async ({ request }) => {
             const headers = new Headers({ Location: "/dashboard" });
             for (const c of cookies) headers.append("Set-Cookie", c);
             if (uiRoleCookie) headers.append("Set-Cookie", uiRoleCookie);
+            if (langCookie) headers.append("Set-Cookie", langCookie);
             return new Response(null, { status: 302, headers });
         } else {
             let errorMessage = "Invalid email or password";

--- a/frontend/src/pages/api/auth/register.ts
+++ b/frontend/src/pages/api/auth/register.ts
@@ -6,10 +6,15 @@ import { authCookies } from "../../../lib/auth-cookies";
  * POST /api/auth/register
  * Creates a new family + founding PARENT user, sets httpOnly cookie, and returns JSON.
  */
-export const POST: APIRoute = async ({ request }) => {
+export const POST: APIRoute = async ({ request, cookies }) => {
     try {
         const body = await request.json();
-        const { family_name, family_code, name, email, password } = body;
+        const { family_name, family_code, name, email, password, preferred_lang } = body;
+        // Carry the UI language into the account so the welcome email + first
+        // login render in the user's language. Fall back to the lang cookie.
+        const lang = preferred_lang === "es" || preferred_lang === "en"
+            ? preferred_lang
+            : (cookies.get("lang")?.value === "es" ? "es" : "en");
 
         // Validate required fields
         if (!name || !email || !password) {
@@ -28,8 +33,8 @@ export const POST: APIRoute = async ({ request }) => {
         }
 
         const apiUrl = process.env.API_BASE_URL || "http://localhost:8002";
-        const registerBody: Record<string, string> = { name, email, password };
-        
+        const registerBody: Record<string, string> = { name, email, password, preferred_lang: lang };
+
         if (family_code) {
             registerBody.family_code = family_code;
         } else {
@@ -46,9 +51,11 @@ export const POST: APIRoute = async ({ request }) => {
 
         if (response.ok) {
             const result = data as LoginResponse;
-            const cookies = authCookies(result.access_token, result.refresh_token, !import.meta.env.DEV);
+            const authCks = authCookies(result.access_token, result.refresh_token, !import.meta.env.DEV);
             const headers = new Headers({ "Content-Type": "application/json" });
-            for (const c of cookies) headers.append("Set-Cookie", c);
+            for (const c of authCks) headers.append("Set-Cookie", c);
+            // Seed the UI language cookie so the dashboard renders in the chosen language.
+            cookies.set("lang", lang, { path: "/", sameSite: "lax", maxAge: 60 * 60 * 24 * 365 });
             return new Response(
                 JSON.stringify({ success: true, redirect: "/dashboard" }),
                 { status: 200, headers }

--- a/frontend/src/pages/api/budget/[...path].ts
+++ b/frontend/src/pages/api/budget/[...path].ts
@@ -18,7 +18,7 @@ const BACKEND_URL = process.env.API_BASE_URL || process.env.PUBLIC_API_BASE_URL 
 async function proxy({ request, params }: { request: Request; params: Record<string, string | undefined> }): Promise<Response> {
     const path = params.path ?? "";
     const url = new URL(request.url);
-    const backendUrl = `${BACKEND_URL}/api/budget/${path}${url.search}`;
+    const backendUrl = `${BACKEND_URL}${url.pathname}${url.search}`;
 
     // Forward all headers except Host (which must point to the backend)
     const forwardHeaders = new Headers();

--- a/frontend/src/pages/api/calendar/[...path].ts
+++ b/frontend/src/pages/api/calendar/[...path].ts
@@ -6,7 +6,7 @@ const BACKEND_URL = process.env.API_BASE_URL || process.env.PUBLIC_API_BASE_URL 
 async function proxy({ request, params }: { request: Request; params: Record<string, string | undefined> }): Promise<Response> {
     const path = params.path ?? "";
     const url = new URL(request.url);
-    const backendUrl = `${BACKEND_URL}/api/calendar/${path}${url.search}`;
+    const backendUrl = `${BACKEND_URL}${url.pathname}${url.search}`;
 
     const forwardHeaders = new Headers();
     for (const [key, value] of request.headers.entries()) {

--- a/frontend/src/pages/api/cash/[...path].ts
+++ b/frontend/src/pages/api/cash/[...path].ts
@@ -15,7 +15,7 @@ const BACKEND_URL = process.env.API_BASE_URL || process.env.PUBLIC_API_BASE_URL 
 async function proxy({ request, params }: { request: Request; params: Record<string, string | undefined> }): Promise<Response> {
     const path = params.path ?? "";
     const url = new URL(request.url);
-    const backendUrl = `${BACKEND_URL}/api/cash/${path}${url.search}`;
+    const backendUrl = `${BACKEND_URL}${url.pathname}${url.search}`;
 
     const forwardHeaders = new Headers();
     for (const [key, value] of request.headers.entries()) {

--- a/frontend/src/pages/api/chat/[...path].ts
+++ b/frontend/src/pages/api/chat/[...path].ts
@@ -6,7 +6,7 @@ const BACKEND_URL = process.env.API_BASE_URL || process.env.PUBLIC_API_BASE_URL 
 async function proxy({ request, params }: { request: Request; params: Record<string, string | undefined> }): Promise<Response> {
     const path = params.path ?? "";
     const url = new URL(request.url);
-    const backendUrl = `${BACKEND_URL}/api/chat/${path}${url.search}`;
+    const backendUrl = `${BACKEND_URL}${url.pathname}${url.search}`;
 
     const forwardHeaders = new Headers();
     for (const [key, value] of request.headers.entries()) {

--- a/frontend/src/pages/api/dm/[...path].ts
+++ b/frontend/src/pages/api/dm/[...path].ts
@@ -6,7 +6,7 @@ const BACKEND_URL = process.env.API_BASE_URL || process.env.PUBLIC_API_BASE_URL 
 async function proxy({ request, params }: { request: Request; params: Record<string, string | undefined> }): Promise<Response> {
     const path = params.path ?? "";
     const url = new URL(request.url);
-    const backendUrl = `${BACKEND_URL}/api/dm/${path}${url.search}`;
+    const backendUrl = `${BACKEND_URL}${url.pathname}${url.search}`;
 
     const forwardHeaders = new Headers();
     for (const [key, value] of request.headers.entries()) {

--- a/frontend/src/pages/api/gigs/[...path].ts
+++ b/frontend/src/pages/api/gigs/[...path].ts
@@ -21,7 +21,7 @@ const BACKEND_URL = process.env.API_BASE_URL || process.env.PUBLIC_API_BASE_URL 
 async function proxy({ request, params }: { request: Request; params: Record<string, string | undefined> }): Promise<Response> {
     const path = params.path ?? "";
     const url = new URL(request.url);
-    const backendUrl = `${BACKEND_URL}/api/gigs/${path}${url.search}`;
+    const backendUrl = `${BACKEND_URL}${url.pathname}${url.search}`;
 
     // Forward all headers except Host (which must point to the backend)
     const forwardHeaders = new Headers();

--- a/frontend/src/pages/api/jarvis/[...path].ts
+++ b/frontend/src/pages/api/jarvis/[...path].ts
@@ -6,7 +6,7 @@ const BACKEND_URL = process.env.API_BASE_URL || process.env.PUBLIC_API_BASE_URL 
 async function proxy({ request, params }: { request: Request; params: Record<string, string | undefined> }): Promise<Response> {
     const path = params.path ?? "";
     const url = new URL(request.url);
-    const backendUrl = `${BACKEND_URL}/api/jarvis/${path}${url.search}`;
+    const backendUrl = `${BACKEND_URL}${url.pathname}${url.search}`;
 
     const forwardHeaders = new Headers();
     for (const [key, value] of request.headers.entries()) {

--- a/frontend/src/pages/api/kiosk/[...path].ts
+++ b/frontend/src/pages/api/kiosk/[...path].ts
@@ -6,7 +6,7 @@ const BACKEND_URL = process.env.API_BASE_URL || process.env.PUBLIC_API_BASE_URL 
 async function proxy({ request, params }: { request: Request; params: Record<string, string | undefined> }): Promise<Response> {
     const path = params.path ?? "";
     const url = new URL(request.url);
-    const backendUrl = `${BACKEND_URL}/api/kiosk/${path}${url.search}`;
+    const backendUrl = `${BACKEND_URL}${url.pathname}${url.search}`;
 
     const forwardHeaders = new Headers();
     for (const [key, value] of request.headers.entries()) {

--- a/frontend/src/pages/api/meals/[...path].ts
+++ b/frontend/src/pages/api/meals/[...path].ts
@@ -6,7 +6,7 @@ const BACKEND_URL = process.env.API_BASE_URL || process.env.PUBLIC_API_BASE_URL 
 async function proxy({ request, params }: { request: Request; params: Record<string, string | undefined> }): Promise<Response> {
     const path = params.path ?? "";
     const url = new URL(request.url);
-    const backendUrl = `${BACKEND_URL}/api/meals/${path}${url.search}`;
+    const backendUrl = `${BACKEND_URL}${url.pathname}${url.search}`;
 
     const forwardHeaders = new Headers();
     for (const [key, value] of request.headers.entries()) {

--- a/frontend/src/pages/api/subscriptions/[...path].ts
+++ b/frontend/src/pages/api/subscriptions/[...path].ts
@@ -6,7 +6,7 @@ const BACKEND_URL = process.env.API_BASE_URL || process.env.PUBLIC_API_BASE_URL 
 async function proxy({ request, params }: { request: Request; params: Record<string, string | undefined> }): Promise<Response> {
     const path = params.path ?? "";
     const url = new URL(request.url);
-    const backendUrl = `${BACKEND_URL}/api/subscriptions/${path}${url.search}`;
+    const backendUrl = `${BACKEND_URL}${url.pathname}${url.search}`;
 
     const forwardHeaders = new Headers();
     for (const [key, value] of request.headers.entries()) {

--- a/frontend/src/pages/api/task-templates/[...path].ts
+++ b/frontend/src/pages/api/task-templates/[...path].ts
@@ -18,7 +18,7 @@ const BACKEND_URL = process.env.API_BASE_URL || process.env.PUBLIC_API_BASE_URL 
 async function proxy({ request, params }: { request: Request; params: Record<string, string | undefined> }): Promise<Response> {
     const path = params.path ?? "";
     const url = new URL(request.url);
-    const backendUrl = `${BACKEND_URL}/api/task-templates/${path}${url.search}`;
+    const backendUrl = `${BACKEND_URL}${url.pathname}${url.search}`;
 
     // Forward all headers except Host (which must point to the backend)
     const forwardHeaders = new Headers();

--- a/frontend/src/pages/budget/settings.astro
+++ b/frontend/src/pages/budget/settings.astro
@@ -515,6 +515,12 @@ function closeConfirm() {
     document.getElementById("confirm-overlay")?.classList.add("hidden");
 }
 
+// The modal's X / Cancel buttons use inline onclick="closeSettingsModal()",
+// which only resolves if the function is on window. Expose it explicitly so the
+// close/cancel buttons work regardless of how Astro scopes this script.
+window.closeSettingsModal = closeSettingsModal;
+window.closeConfirm = closeConfirm;
+
 function openConfirm(msg, onConfirm) {
     document.getElementById("confirm-msg").textContent = msg;
     document.getElementById("confirm-overlay")?.classList.remove("hidden");

--- a/frontend/src/pages/profile.astro
+++ b/frontend/src/pages/profile.astro
@@ -79,7 +79,7 @@ const tourRole = String(user.role).toLowerCase() === "parent" ? "parent" : "kid"
                     <p class="text-brand-coral-deep text-sm">{user.email}</p>
                     <span
                         class="inline-block mt-1 px-2.5 py-0.5 text-xs font-semibold rounded-full bg-brand-cream/20 border border-white/30"
-                        >{user.role}</span
+                        >{t(lang, `pt_role_${String(user.role).toLowerCase()}`)}</span
                     >
                 </div>
             </div>
@@ -187,6 +187,7 @@ const tourRole = String(user.role).toLowerCase() === "parent" ? "parent" : "kid"
                     </select>
                     <button
                         type="submit"
+                        formnovalidate
                         class="px-5 py-2.5 bg-brand-sky-deep hover:bg-brand-ink text-white text-sm font-semibold rounded-lg transition-colors shadow-[var(--shadow-card)]"
                     >
                         {t(lang, "pt_save")}

--- a/frontend/src/pages/register.astro
+++ b/frontend/src/pages/register.astro
@@ -283,6 +283,7 @@ const lang = Astro.cookies.get("lang")?.value ?? "es";
                     name,
                     email,
                     password,
+                    preferred_lang: lang,
                 };
 
                 if (family_code) {


### PR DESCRIPTION
Fixes from the 2026-06-30 investor QA pass. All deployed to prod and verified.

## Critical — budget ops returned 502
`POST /api/budget/accounts` and `/payees` (and other budget writes) 502'd. Root cause: Astro `[...path]` strips the trailing slash, so collection requests hit FastAPI's 307 trailing-slash redirect, and the proxy's redirect-follow re-fetched on a **reused keep-alive connection that uvicorn had closed** → `fetch failed` → 502. All 12 `[...path]` proxies now build the backend URL from `url.pathname` (preserves the slash) → no 307. Verified: budget GET 200, POST 201 on prod.

## i18n
- **Register**: thread the UI `lang` → `preferred_lang` on the account → welcome email + first login render in the chosen language; `login.ts` syncs the `lang` cookie from `preferred_lang`.
- **Jarvis**: inject a language directive into the system prompt (was English-only) + localized empty-reply fallback.
- **Profile**: role badge localized (`pt_role_*`; fixed `Niño` tilde).
- **"What changed" banner**: rewritten for the two-currency model (chores→points, gig board→cash $MXN), EN + ES.

## UX
- **Bottom nav** overflowed on narrow phones (9–10 items, no wrap/scroll, `max-w-md` clip). Now icon-only (sr-only labels, still accessible) + horizontal-scroll safety net → all items reachable.
- **Onboarding tour** never started for parents (gate only fired on `/parent`, but they land on `/dashboard`) and the one-shot `astro:page-load` was missed by late modules. Fixed: allow parent tour on `/dashboard` + consumers self-trigger if the DOM is already ready.
- **Budget settings modal** close/Cancel exposed on `window` so the inline `onclick` resolves.
- **ai-settings/usage**: degrades gracefully (`available:false`, HTTP 200) instead of 502 when the FTM key can't reach LiteLLM `/key/info`.

## Tests
`test_i18n_backend.py` (register preferred_lang end-to-end, Jarvis language directive + fallback). Frontend build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)