### PR TITLE
Fix DB connection leak: SSE streams must not hold a pooled session

### DIFF
--- a/backend/app/api/routes/dm.py
+++ b/backend/app/api/routes/dm.py
@@ -106,11 +106,13 @@ async def stream(
     thread_id: UUID,
     after_ts: Optional[datetime] = Query(None),
     current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
 ):
-    """SSE poll-stream of new DM messages in this thread. Reconnect ~30s."""
+    """SSE poll-stream of new DM messages in this thread. Reconnect ~30s.
+
+    No Depends(get_db): the generator manages its own short-lived sessions so a
+    long-lived SSE connection never pins a pooled DB connection.
+    """
     gen = DMService.stream_messages(
-        db,
         thread_id,
         to_uuid_required(current_user.id),
         to_uuid_required(current_user.family_id),

--- a/backend/app/api/routes/family_chat.py
+++ b/backend/app/api/routes/family_chat.py
@@ -160,11 +160,13 @@ async def remove_reaction(
 async def stream(
     after_ts: Optional[datetime] = Query(None),
     current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
 ):
-    """SSE poll-stream of new chat messages. Reconnect every ~30s."""
+    """SSE poll-stream of new chat messages. Reconnect every ~30s.
+
+    No Depends(get_db): the generator manages its own short-lived sessions so a
+    long-lived SSE connection never pins a pooled DB connection.
+    """
     gen = FamilyChatService.stream_messages(
-        db,
         to_uuid_required(current_user.family_id),
         after_ts=after_ts,
     )

--- a/backend/app/api/routes/jarvis.py
+++ b/backend/app/api/routes/jarvis.py
@@ -74,12 +74,14 @@ async def chat(
 async def chat_stream(
     data: ChatRequest,
     current_user: User = Depends(require_parent_role),
-    db: AsyncSession = Depends(get_db),
 ):
-    """SSE stream of chat progress. Client consumes via fetch + ReadableStream."""
+    """SSE stream of chat progress. Client consumes via fetch + ReadableStream.
+
+    No Depends(get_db): the stream generator owns its own session so the
+    long-lived SSE response never pins a pooled DB connection.
+    """
     model = data.model if data.model in ALLOWED_MODELS else None
     gen = JarvisService.chat_stream(
-        db,
         family_id=to_uuid_required(current_user.family_id),
         user_id=to_uuid_required(current_user.id),
         message=data.message,

--- a/backend/app/services/dm_service.py
+++ b/backend/app/services/dm_service.py
@@ -89,30 +89,38 @@ class DMService:
 
     @staticmethod
     async def stream_messages(
-        db: AsyncSession,
         thread_id: UUID,
         user_id: UUID,
         family_id: UUID,
         after_ts: Optional[datetime] = None,
     ):
-        """SSE generator — same pattern as family chat. Verifies participant."""
-        await DMService._get_thread_for_user(db, thread_id, user_id, family_id)
+        """SSE generator — same pattern as family chat. Verifies participant.
+
+        Uses a FRESH short-lived session per poll (not a request-scoped
+        Depends(get_db) session) so a long-lived SSE connection never pins a
+        pooled DB connection idle-in-transaction (pool exhaustion → 502s).
+        """
+        from app.core.database import AsyncSessionLocal
+
+        async with AsyncSessionLocal() as s:
+            await DMService._get_thread_for_user(s, thread_id, user_id, family_id)
         cursor = after_ts or datetime.now(timezone.utc)
         elapsed = 0.0
         last_heartbeat = 0.0
         while elapsed < STREAM_WINDOW_SECONDS:
-            q = (
-                select(DMMessage)
-                .where(
-                    and_(
-                        DMMessage.thread_id == thread_id,
-                        DMMessage.created_at > cursor,
+            async with AsyncSessionLocal() as s:
+                q = (
+                    select(DMMessage)
+                    .where(
+                        and_(
+                            DMMessage.thread_id == thread_id,
+                            DMMessage.created_at > cursor,
+                        )
                     )
+                    .order_by(DMMessage.created_at.asc())
+                    .limit(50)
                 )
-                .order_by(DMMessage.created_at.asc())
-                .limit(50)
-            )
-            rows = list((await db.execute(q)).scalars().all())
+                rows = list((await s.execute(q)).scalars().all())
             for m in rows:
                 payload = {
                     "id": str(m.id),

--- a/backend/app/services/family_chat_service.py
+++ b/backend/app/services/family_chat_service.py
@@ -204,7 +204,6 @@ class FamilyChatService:
 
     @staticmethod
     async def stream_messages(
-        db: AsyncSession,
         family_id: UUID,
         after_ts: Optional[datetime] = None,
     ):
@@ -212,24 +211,33 @@ class FamilyChatService:
         appears after ``after_ts`` (default: now). Closes after
         ``STREAM_WINDOW_SECONDS`` so the client reconnects. Heartbeats
         every ~10s so proxies don't time out.
+
+        Uses a FRESH short-lived session per poll (not a request-scoped
+        Depends(get_db) session): the pooled connection must NOT be held across
+        the sleep window, or every open chat tab pins a connection
+        ``idle in transaction`` and the pool (size 30) exhausts → app-wide 502s.
         """
+        from app.core.database import AsyncSessionLocal
+
         cursor = after_ts or datetime.now(timezone.utc)
         elapsed = 0.0
         last_heartbeat = 0.0
 
         while elapsed < STREAM_WINDOW_SECONDS:
-            q = (
-                select(FamilyChatMessage)
-                .where(
-                    and_(
-                        FamilyChatMessage.family_id == family_id,
-                        FamilyChatMessage.created_at > cursor,
+            async with AsyncSessionLocal() as s:
+                q = (
+                    select(FamilyChatMessage)
+                    .where(
+                        and_(
+                            FamilyChatMessage.family_id == family_id,
+                            FamilyChatMessage.created_at > cursor,
+                        )
                     )
+                    .order_by(FamilyChatMessage.created_at.asc())
+                    .limit(50)
                 )
-                .order_by(FamilyChatMessage.created_at.asc())
-                .limit(50)
-            )
-            rows = list((await db.execute(q)).scalars().all())
+                rows = list((await s.execute(q)).scalars().all())
+            # session closed here — connection returned to the pool before we sleep
             for m in rows:
                 payload = {
                     "id": str(m.id),

--- a/backend/app/services/jarvis_service.py
+++ b/backend/app/services/jarvis_service.py
@@ -219,6 +219,26 @@ class JarvisService:
 
     @staticmethod
     async def chat_stream(
+        family_id: UUID,
+        user_id: UUID,
+        message: str,
+        model: str | None = None,
+        preferred_lang: str = "en",
+    ):
+        """Public SSE generator — owns a short-lived DB session that is closed on
+        completion AND on client disconnect (the async-with __aexit__ runs on
+        GeneratorExit), so an abandoned stream never leaks a pooled connection
+        ``idle in transaction``. Delegates to _chat_stream_inner.
+        """
+        from app.core.database import AsyncSessionLocal
+        async with AsyncSessionLocal() as db:
+            async for evt in JarvisService._chat_stream_inner(
+                db, family_id, user_id, message, model, preferred_lang
+            ):
+                yield evt
+
+    @staticmethod
+    async def _chat_stream_inner(
         db: AsyncSession,
         family_id: UUID,
         user_id: UUID,

--- a/backend/tests/test_jarvis_sse.py
+++ b/backend/tests/test_jarvis_sse.py
@@ -75,7 +75,7 @@ class TestSSEStream:
         )
 
         events = await _collect_events(
-            JarvisService.chat_stream(
+            JarvisService._chat_stream_inner(
                 db_session, test_family.id, test_parent_user.id, "what now?"
             )
         )
@@ -104,7 +104,7 @@ class TestSSEStream:
         )
 
         events = await _collect_events(
-            JarvisService.chat_stream(
+            JarvisService._chat_stream_inner(
                 db_session, test_family.id, test_parent_user.id, "status?"
             )
         )
@@ -121,7 +121,7 @@ class TestSSEStream:
         self, db_session, test_family, test_parent_user
     ):
         events = await _collect_events(
-            JarvisService.chat_stream(
+            JarvisService._chat_stream_inner(
                 db_session, test_family.id, test_parent_user.id, "   "
             )
         )
@@ -140,7 +140,7 @@ class TestSSEStream:
         )
 
         await _collect_events(
-            JarvisService.chat_stream(
+            JarvisService._chat_stream_inner(
                 db_session, test_family.id, test_parent_user.id, "ping"
             )
         )
@@ -184,7 +184,7 @@ class TestSSEStream:
         )
 
         events = await _collect_events(
-            JarvisService.chat_stream(
+            JarvisService._chat_stream_inner(
                 db_session, test_family.id, test_parent_user.id, "delete Doomed"
             )
         )

--- a/backend/tests/test_sse_no_pooled_session.py
+++ b/backend/tests/test_sse_no_pooled_session.py
@@ -1,0 +1,31 @@
+"""Guard against the SSE connection-leak regression.
+
+Long-lived SSE generators (family chat, DM, Jarvis stream) must NOT take a
+request-scoped Depends(get_db) session — that pins a pooled connection
+idle-in-transaction for the whole stream, exhausting the pool (size 30) and
+causing app-wide 502s. They must own short-lived sessions internally. This
+guard fails if a session param sneaks back as the first argument.
+"""
+import inspect
+
+from app.services.family_chat_service import FamilyChatService
+from app.services.dm_service import DMService
+from app.services.jarvis_service import JarvisService
+
+
+def _first_param(func) -> str:
+    params = list(inspect.signature(func).parameters)
+    return params[0] if params else ""
+
+
+def test_family_chat_stream_has_no_session_param():
+    assert _first_param(FamilyChatService.stream_messages) == "family_id"
+
+
+def test_dm_stream_has_no_session_param():
+    assert _first_param(DMService.stream_messages) == "thread_id"
+
+
+def test_jarvis_public_stream_has_no_session_param():
+    # Public chat_stream owns its own session; first arg must not be a db handle.
+    assert _first_param(JarvisService.chat_stream) == "family_id"


### PR DESCRIPTION
## Problem
Budget ops intermittently 502'd because the asyncpg pool (size 30) was exhausted by connections stuck `idle in transaction` — observed on `jarvis_messages` and `family_chat_messages` SELECTs aged up to 16 min.

## Root cause
The family-chat, DM, and Jarvis SSE endpoints injected `db = Depends(get_db)` and held that **request-scoped pooled connection for the entire long-lived stream**. The poll loops ran SELECTs with no commit between `sleep`s → the connection sat `idle in transaction`. Every open chat/jarvis tab pinned one of the 30 pool slots; under load the pool exhausted and unrelated requests 502'd.

## Fix
- `family_chat` / `dm` `stream_messages`: drop the request session; open a **fresh short-lived `AsyncSessionLocal` per poll** so the connection is released during the sleep window.
- `jarvis`: public `chat_stream` now **owns its session via `async with`** (closed on completion *and* client disconnect) and delegates to `_chat_stream_inner`; both SSE routes drop `Depends(get_db)`.
- Regression guard: SSE generators must not take a session as their first param.

## Verification
- 1227 backend tests pass.
- **Prod:** 6 concurrent SSE chat streams open → `idle in transaction = 0` (was ~5 stuck). Pool no longer leaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)