### PR TITLE
Align seeds + approvals label with two-currency economy

### DIFF
--- a/backend/seed_data.py
+++ b/backend/seed_data.py
@@ -152,23 +152,21 @@ async def create_e2e_account(session: AsyncSession):
 
 
 async def create_task_templates(session: AsyncSession, family, parent):
-    """Create task templates — regular + bonus
+    """Create task templates — regular chores + bonus tasks (both award POINTS).
 
-    DB constraint chk_mandatory_zero_points (migration 2026_05_22) enforces
-    `is_bonus = true OR points = 0`: mandatory/regular chores award no points,
-    only bonus chores earn them. The tuples below are the single source of
-    truth — every regular (is_bonus=False) row therefore carries 0 points, and
-    only bonus rows carry a positive value. Keep it that way or the seed will
-    fail the constraint.
+    Two-currency economy: all task templates award privilege POINTS on completion
+    (mandatory chores and bonus tasks); only the /gigs board pays cash. (The old
+    chk_mandatory_zero_points constraint that forced regular chores to 0 points
+    was dropped in the two-currency-economy migration.)
     """
     print("\nCreating task templates...")
     templates_data = [
-        ("Make Your Bed", "Hacer la Cama", "Make your bed neatly", "Haz tu cama ordenadamente", 0, 1, False),
-        ("Complete Homework", "Terminar la Tarea", "Finish homework before dinner", "Termina la tarea antes de cenar", 0, 1, False),
-        ("Brush Teeth", "Cepillar Dientes", "Brush morning and night", "Cepíllate mañana y noche", 0, 1, False),
-        ("Feed the Pet", "Alimentar Mascota", "Give food and water to the pet", "Dale comida y agua a la mascota", 0, 1, False),
-        ("Take Out Trash", "Sacar la Basura", "Empty trash cans", "Vacía los botes de basura", 0, 3, False),
-        ("Clean Your Room", "Limpiar Cuarto", "Pick up toys and organize", "Recoge juguetes y organiza", 0, 7, False),
+        ("Make Your Bed", "Hacer la Cama", "Make your bed neatly", "Haz tu cama ordenadamente", 10, 1, False),
+        ("Complete Homework", "Terminar la Tarea", "Finish homework before dinner", "Termina la tarea antes de cenar", 15, 1, False),
+        ("Brush Teeth", "Cepillar Dientes", "Brush morning and night", "Cepíllate mañana y noche", 10, 1, False),
+        ("Feed the Pet", "Alimentar Mascota", "Give food and water to the pet", "Dale comida y agua a la mascota", 10, 1, False),
+        ("Take Out Trash", "Sacar la Basura", "Empty trash cans", "Vacía los botes de basura", 15, 3, False),
+        ("Clean Your Room", "Limpiar Cuarto", "Pick up toys and organize", "Recoge juguetes y organiza", 20, 7, False),
         ("Help With Dishes", "Ayudar con Platos", "Wash or dry dishes after dinner", "Lava o seca los platos", 40, 1, True),
         ("Vacuum Living Room", "Aspirar la Sala", "Vacuum living room and hallway", "Aspira sala y pasillo", 75, 7, True),
         ("Help With Laundry", "Ayudar con Ropa", "Fold and put away clothes", "Dobla y guarda la ropa", 60, 7, True),

--- a/backend/seed_demo_family.py
+++ b/backend/seed_demo_family.py
@@ -210,18 +210,19 @@ async def create_members(session: AsyncSession, family: Family):
 
 
 async def create_tasks(session: AsyncSession, family, parent, members):
-    """Templates (regular=0pts / bonus>0) + a week of assignments.
+    """Templates (chores + bonus tasks award POINTS) + a week of assignments.
 
-    chk_mandatory_zero_points: regular (is_bonus=False) rows MUST be 0 points.
+    Two-currency economy: all task templates award privilege POINTS on completion
+    (mandatory chores and bonus tasks alike); only the /gigs board pays cash.
     Returns (templates, assignments, completed_bonus_by_user).
     """
     print("\nCreating task templates + assignments...")
     templates_data = [
         # title, title_es, desc, desc_es, points, interval_days, is_bonus
-        ("Make Your Bed", "Hacer la Cama", "Make your bed neatly", "Haz tu cama ordenadamente", 0, 1, False),
-        ("Brush Teeth", "Cepillar Dientes", "Brush morning and night", "Cepíllate mañana y noche", 0, 1, False),
-        ("Complete Homework", "Terminar la Tarea", "Finish homework before dinner", "Termina la tarea antes de cenar", 0, 1, False),
-        ("Clean Your Room", "Limpiar Cuarto", "Pick up and organize", "Recoge y organiza", 0, 7, False),
+        ("Make Your Bed", "Hacer la Cama", "Make your bed neatly", "Haz tu cama ordenadamente", 10, 1, False),
+        ("Brush Teeth", "Cepillar Dientes", "Brush morning and night", "Cepíllate mañana y noche", 10, 1, False),
+        ("Complete Homework", "Terminar la Tarea", "Finish homework before dinner", "Termina la tarea antes de cenar", 15, 1, False),
+        ("Clean Your Room", "Limpiar Cuarto", "Pick up and organize", "Recoge y organiza", 20, 7, False),
         ("Help With Dishes", "Ayudar con Platos", "Wash or dry after dinner", "Lava o seca después de cenar", 40, 1, True),
         ("Vacuum Living Room", "Aspirar la Sala", "Vacuum living room and hallway", "Aspira sala y pasillo", 75, 7, True),
         ("Help With Laundry", "Ayudar con Ropa", "Fold and put away clothes", "Dobla y guarda la ropa", 60, 7, True),
@@ -288,7 +289,7 @@ async def create_tasks(session: AsyncSession, family, parent, members):
 
 
 async def create_gigs(session: AsyncSession, family, parent, members):
-    """Offerings + claims across the full lifecycle. Approved claims pay points."""
+    """Offerings + claims across the full lifecycle. Approved claims pay CASH ($MXN)."""
     print("\nCreating gig board...")
     teen = next(m for m in members if m.role == UserRole.TEEN)
     child = next(m for m in members if m.role == UserRole.CHILD)
@@ -344,10 +345,18 @@ async def create_gigs(session: AsyncSession, family, parent, members):
         session.add(c)
     await session.commit()
 
-    # Pay out approved claims (points + transaction), advance trust streak.
+    # Pay out approved claims in CASH (the gig board pays $MXN, 1 pt = 100 cents),
+    # advance trust streak.
+    from app.models.cash_transaction import CashTransaction, CashTransactionType
     for c, kid, pts in approved_claims:
-        _earn(session, kid, lambda bal, _c=c, _p=pts: PointTransaction.create_gig_claim_approval(
-            user_id=_c.claimed_by, gig_claim_id=_c.id, points=_p, balance_before=bal,
+        cents = pts * 100
+        before = kid.cash_cents or 0
+        kid.cash_cents = before + cents
+        session.add(CashTransaction(
+            user_id=kid.id, family_id=family.id,
+            type=CashTransactionType.GIG_EARNED, amount_cents=cents,
+            balance_before=before, balance_after=before + cents,
+            gig_claim_id=c.id, description="Gig (demo seed)",
         ))
         kid.gig_trust_streak = (kid.gig_trust_streak or 0) + 1
     await session.commit()

--- a/frontend/src/pages/parent/approvals.astro
+++ b/frontend/src/pages/parent/approvals.astro
@@ -150,7 +150,7 @@ const fmtDate = (d: string) =>
                                             {claim.gig_points != null && (
                                                 <>
                                                     <span class="mx-1">·</span>
-                                                    <span class="text-brand-sun-deep font-semibold">+{claim.gig_points} pts</span>
+                                                    <span class="text-emerald-600 font-semibold">+${claim.gig_points} MXN</span>
                                                 </>
                                             )}
                                         </p>


### PR DESCRIPTION
Cosmetic / dev-only follow-ups from the QA pass (no functional prod-runtime changes).

- **seed_data.py / seed_demo_family.py**: regular chores now award POINTS (were 0 under the dropped `chk_mandatory_zero_points`); demo gig-board payouts credit CASH (`cash_cents` + `CashTransaction`) instead of points; stale constraint/points-converter docstrings updated. `seed_data.py` verified end-to-end locally (chores seeded 10–20 pts, no errors).
- **Parent approvals**: gig-board claim value shown as `$N MXN` (was `N pts`). Task/bonus proofs keep `pts` (they award points).

Deployed + verified (budget 200, frontend 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)